### PR TITLE
small correction in Portuguese translation

### DIFF
--- a/CareKit/Localization/pt.lproj/CareKit.strings
+++ b/CareKit/Localization/pt.lproj/CareKit.strings
@@ -41,7 +41,7 @@
 "SYMPTOM_TRACKER_HEADER_TITLE" = "Progresso da Atividade";
 
 /* Connect Master View */
-"CARE_TEAM_SECTION_TITLE" = "Equipe do Tratamento";
+"CARE_TEAM_SECTION_TITLE" = "Equipe de Tratamento";
 "PERSONAL_SECTION_TITLE" = "Amigos e Família";
 "CONNECT_NO_CONTACTS_TITLE" = "Nenhum contato";
 


### PR DESCRIPTION
Care Team is better translated as _"Equipe de Tratamento"_,  _"do"_ in this case would be **one** specific treatment.

Other option would be _ "Equipe de Cuidados"_ 