### PR TITLE
Fix connect cell monogram truncation

### DIFF
--- a/CareKit/Connect/OCKConnectTableViewCell.m
+++ b/CareKit/Connect/OCKConnectTableViewCell.m
@@ -103,7 +103,12 @@ static const CGFloat ImageViewSize = 40.0;
     } else {
         _imageView.image = nil;
         _imageView.backgroundColor = OCKSystemGrayColor();
-        _monogramLabel.text = self.contact.monogram;
+        
+        NSString *monogram = self.contact.monogram;
+        NSRange stringRange = {0, MIN([monogram length], 2)};
+        stringRange = [monogram rangeOfComposedCharacterSequencesForRange:stringRange];
+        NSString *clippedMonogram = [monogram substringWithRange:stringRange];
+        _monogramLabel.text = clippedMonogram;
     }
     
     _nameLabel.text = self.contact.name;

--- a/CareKit/Connect/OCKConnectTableViewCell.m
+++ b/CareKit/Connect/OCKConnectTableViewCell.m
@@ -85,6 +85,7 @@ static const CGFloat ImageViewSize = 40.0;
         _monogramLabel.textColor = [UIColor whiteColor];
         _monogramLabel.textAlignment = NSTextAlignmentCenter;
         _monogramLabel.font = [UIFont boldSystemFontOfSize:16.0];
+        _monogramLabel.adjustsFontSizeToFitWidth = YES;
         [self addSubview:_monogramLabel];
     }
     

--- a/CareKit/Connect/OCKConnectTableViewHeader.m
+++ b/CareKit/Connect/OCKConnectTableViewHeader.m
@@ -96,6 +96,7 @@ static const CGFloat ImageViewSize = 135.0;
         _monogramLabel.textColor = [UIColor whiteColor];
         _monogramLabel.textAlignment = NSTextAlignmentCenter;
         _monogramLabel.font = [UIFont boldSystemFontOfSize:56.0];
+        _monogramLabel.adjustsFontSizeToFitWidth = YES;
         [self addSubview:_monogramLabel];
     }
     

--- a/CareKit/Connect/OCKContact.h
+++ b/CareKit/Connect/OCKContact.h
@@ -137,8 +137,7 @@ OCK_CLASS_AVAILABLE
 /**
  A string indicating the monogram for a contact.
  
- If a monogram is not provided, the image will be used for the contact.
- If a monogram is available, it will be clipped to two glyphs.
+ The monogram will be clipped to two glyphs.
  */
 @property (nonatomic, readonly) NSString *monogram;
 

--- a/CareKit/Connect/OCKContact.h
+++ b/CareKit/Connect/OCKContact.h
@@ -138,6 +138,7 @@ OCK_CLASS_AVAILABLE
  A string indicating the monogram for a contact.
  
  If a monogram is not provided, the image will be used for the contact.
+ If a monogram is available, it will be clipped to two glyphs.
  */
 @property (nonatomic, readonly) NSString *monogram;
 

--- a/CareKit/Connect/OCKContact.m
+++ b/CareKit/Connect/OCKContact.m
@@ -60,7 +60,7 @@
         _phoneNumber = [phoneNumber copy];
         _messageNumber = [messageNumber copy];
         _emailAddress = [emailAddress copy];
-        _monogram = [monogram copy];
+        _monogram = [self clippedMonogramForString:monogram];
         _image = image;
     }
     return self;
@@ -80,6 +80,15 @@
             OCKEqualObjects(self.emailAddress, castObject.emailAddress) &&
             OCKEqualObjects(self.monogram, castObject.monogram) &&
             OCKEqualObjects(self.image, castObject.image));
+}
+
+
+#pragma mark - Helpers
+
+- (NSString *)clippedMonogramForString:(NSString *)string {
+    NSRange stringRange = {0, MIN([string length], 2)};
+    stringRange = [string rangeOfComposedCharacterSequencesForRange:stringRange];
+    return [string substringWithRange:stringRange];
 }
 
 


### PR DESCRIPTION
When an emoji is used in monogram label in the connect TVC sometimes the monogram becomes truncated. Turning on adjustsFontSizeToFitWidth is a quick fix but other fixes may be desired. I believe the phone and contacts apps on iOS display a default avatar image when an emoji is the first character in a contact's first or last name. An emoji might be a silly example but other unicode glyphs could become truncated as well. See the before and after images.

![truncated-monogram](https://cloud.githubusercontent.com/assets/89981/14907081/cdc67312-0d91-11e6-9692-39116c54efce.png)

![fixed-monogram](https://cloud.githubusercontent.com/assets/89981/14907084/d3d8a5c2-0d91-11e6-9a47-82ac9299ac66.png)
