### PR TITLE
Unify code blocks.

### DIFF
--- a/docs/AccessingCarePlanData/AccessingCarePlanData-template.md
+++ b/docs/AccessingCarePlanData/AccessingCarePlanData-template.md
@@ -3,7 +3,7 @@
 
 # Accessing Care Plan Data
 
-CareKit stores your treatment plan in a database. This database is located at the URL you provided when you instantiated your app's `OCKCarePlanStore` object. CareKit automatically creates the database the first time you instantiate your care plan store. For more information on instantiating your care plan store, see  [Creating the Care Card > Instantiating the Care Plan Store](../CreatingTheCareCard/CreatingTheCareCard.html#InstantiatingTheCarePlanStore). 
+CareKit stores your treatment plan in a database. This database is located at the URL you provided when you instantiated your app's `OCKCarePlanStore` object. CareKit automatically creates the database the first time you instantiate your care plan store. For more information on instantiating your care plan store, see  [Creating the Care Card > Instantiating the Care Plan Store](../CreatingTheCareCard/CreatingTheCareCard.html#InstantiatingTheCarePlanStore).
 
 CareKit's database is encrypted using standard file system encryption. Specifically, the database uses `NSFileProtectionComplete` encryption, which means the database is stored in an encrypted format on disk and cannot be read from or written to while the device is locked or booting.
 
@@ -14,7 +14,7 @@ Additionally, when working with CareKit data, you don't access this database dir
 * Read activities or events
 * Update events
 
-The Care Plan Store must be created on the main thread, but its methods can be called from any thread. All of the methods are asynchronous. They dispatch the actual work to a FIFO background queue. As soon as the work is complete, the method's completion handler is called on an anonymous background queue. You often need to dispatch these results back to the main queue before updating your app. 
+The Care Plan Store must be created on the main thread, but its methods can be called from any thread. All of the methods are asynchronous. They dispatch the actual work to a FIFO background queue. As soon as the work is complete, the method's completion handler is called on an anonymous background queue. You often need to dispatch these results back to the main queue before updating your app.
 
 For more information on working with asynchronous APIs, see [Concurrency Programming Guide](https://developer.apple.com/library/ios/documentation/General/Conceptual/ConcurrencyProgrammingGuide/Introduction/Introduction.html).
 
@@ -22,12 +22,12 @@ For more information on working with asynchronous APIs, see [Concurrency Program
 
 The Care Plan Store manages two basic data types:
 
-* `OCKCarePlanActivity` objects 
-* `OCKCarePlanEvent` objects 
+* `OCKCarePlanActivity` objects
+* `OCKCarePlanEvent` objects
 
-The activities represent the user's care plan, while the events represent the individual tasks that the user must perform to complete the plan. When you add an activity to the store, CareKit automatically generates the event objects associated with that activity. For example, if the activity indicates taking three doses of medication a day, CareKit generates three events for each day. 
+The activities represent the user's care plan, while the events represent the individual tasks that the user must perform to complete the plan. When you add an activity to the store, CareKit automatically generates the event objects associated with that activity. For example, if the activity indicates taking three doses of medication a day, CareKit generates three events for each day.
 
-Each activity is uniquely identified by its `identifier` property. These identifiers are strings that you provide when you create the activity. You can use any string you wish, but every activity in the Care Plan Store must have a unique string. 
+Each activity is uniquely identified by its `identifier` property. These identifiers are strings that you provide when you create the activity. You can use any string you wish, but every activity in the Care Plan Store must have a unique string.
 
 If an activity already exists in the Care Plan Store, any attempt to add a second activity with the same identifier fails. The store returns an error object with an `OCKErrorDomain` domain and a `OCKErrorInvalidObject` error code.
 
@@ -47,24 +47,25 @@ Use a delegate object to monitor changes to your app's Care Plan Store. This del
 
 As an example, if you want to update your Insights scene whenever the store data changes, implement the `carePlanStore(didReceiveUpdateOfEvent:)` method, and have it call a method that reads new data from the store and updates the Insight items, as shown below:
 
-    func carePlanStore(store: OCKCarePlanStore, didReceiveUpdateOfEvent event: OCKCarePlanEvent) {
-        updateInsights()
-    }
-    
+```swift
+func carePlanStore(store: OCKCarePlanStore, didReceiveUpdateOfEvent event: OCKCarePlanEvent) {
+  updateInsights()
+}
+```    
 
 ## Reading Data from the Store
 
-The Care Plan Store provides methods for reading both activities and events. For activities, you can read the activity for a given identifier, all the activities for a group identifier, or even batch read all the activities in the entire treatment plan. 
+The Care Plan Store provides methods for reading both activities and events. For activities, you can read the activity for a given identifier, all the activities for a group identifier, or even batch read all the activities in the entire treatment plan.
 
 For example, the following sample code reads all the intervention activities currently saved in the store:
 
-```
+```swift
 store.activitiesWithType(.Intervention) { (success, activities, errorOrNil) in
     guard success else {
         // perform proper error handling here
         fatalError(errorOrNil!.localizedDescription)
     }
-    
+
     // now do something with the activities.
 }
 ```
@@ -72,19 +73,19 @@ CareKit is somewhat more restrictive when it comes to reading events. In general
 
 For example, the following sample code reads all of today's events for the ibuprofen activity.
 
-```
+```swift
 guard let calendar = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian) else {
     fatalError("This should never fail.")
 }
 
 let today = calendar.components([.Day, .Month, .Year], fromDate: NSDate())
 store.eventsForActivity(ibuprofen, date: today) { (events, errorOrNil) in
-    
+
     if let error = errorOrNil {
         // Perform proper error handling here
         fatalError(error.localizedDescription)
     }
-    
+
     // do something with the events.
 }
 ```
@@ -97,15 +98,15 @@ To help gather data from a range of dates, the Care Plan Store provides two high
 
 The `dailyCompletionStatusWithType(startDate:, endDate:, handler:, completion:)` method calls its handler once for each date in the provided range of dates. However, instead of providing information about specific events, it provides a count of the number of events that the user has completed, and the total number of events for each date.
 
-The `enumerateEventsOfActivity(startDate:, endDate:, handler:, completion:)` method calls its handler once for each event generated by the provided activity during the provided range of dates. 
+The `enumerateEventsOfActivity(startDate:, endDate:, handler:, completion:)` method calls its handler once for each event generated by the provided activity during the provided range of dates.
 
 In both cases, the higher order method calls its completion block once all the events have been handled.
 
-The following sample code demonstrates using these methods to collect data over a range of dates, and then combine that data. 
+The following sample code demonstrates using these methods to collect data over a range of dates, and then combine that data.
 
-```
+```swift
 // These variables will store the data generated by the Care Plan Store.
-var completionData =  [(dateComponent: NSDateComponents, value: Double)]()
+var completionData = [(dateComponent: NSDateComponents, value: Double)]()
 var stressAssessmentData = [NSDateComponents: Double]()
 
 dispatch_group_enter(gatherDataGroup)
@@ -117,7 +118,7 @@ store.dailyCompletionStatusWithType(
         // This block is called once for each date.
         let percentComplete = Double(completed) / Double(total)
         completionData.append((dateComponents, percentComplete))
-        
+
     },
     completion: { (success, errorOrNil) in
         // This block is called after the last date's handler returns.
@@ -125,7 +126,7 @@ store.dailyCompletionStatusWithType(
             // Add proper error handling here...
             fatalError(errorOrNil!.localizedDescription)
         }
-        
+
         dispatch_group_leave(gatherDataGroup)
 })
 
@@ -139,11 +140,11 @@ store.enumerateEventsOfActivity(
         if let event = eventOrNil,
             result = event.result,
             value = Double(result.valueString) {
-            
+
             stressAssessmentData[event.date] = value
-            
+
         }
-        
+
     },
     completion: { (success, errorOrNil) in
         // This block is called after the last event's handler returns.
@@ -151,7 +152,7 @@ store.enumerateEventsOfActivity(
             // Add proper error handling here...
             fatalError(errorOrNil!.localizedDescription)
         }
-        
+
         dispatch_group_leave(gatherDataGroup)
 })
 
@@ -173,26 +174,26 @@ Alternatively, you can create a function that deletes all the activities from th
 
 The sample code below demonstrates a straightforward synchronous method that deletes everything from the store.
 
-```
+```swift
 private func _clearStore() {
     print("*** CLEANING STORE DEBUG ONLY ****")
-    
+
     let deleteGroup = dispatch_group_create()
     let store = self.store
 
     dispatch_group_enter(deleteGroup)
     store.activitiesWithCompletion { (success, activities, errorOrNil) in
-        
+
         guard success else {
             // Perform proper error handling here...
             fatalError(errorOrNil!.localizedDescription)
         }
-        
+
         for activity in activities {
-            
+
             dispatch_group_enter(deleteGroup)
             store.removeActivity(activity) { (success, error) -> Void in
-                
+
                 print("Removing \(activity)")
                 guard success else {
                     fatalError("*** An error occurred: \(error!.localizedDescription)")
@@ -201,10 +202,10 @@ private func _clearStore() {
                 dispatch_group_leave(deleteGroup)
             }
         }
-        
+
         dispatch_group_leave(deleteGroup)
     }
-    
+
     // Wait until all the asynchronous calls are done.
     dispatch_group_wait(deleteGroup, DISPATCH_TIME_FOREVER)
 }
@@ -216,33 +217,34 @@ This sample reads all the activities from the store, and then iterates over the 
 ## Sharing Data with HealthKit
 Because CareKit and HealthKit both focus on health information, you may find it useful to share data between the two stores. Here's a code example that illustrates how this can be achieved:
 
-	- (void)symptomTrackerViewController:(OCKSymptomTrackerViewController *)viewController didSelectRowWithAssessmentEvent:(OCKCarePlanEvent *)assessmentEvent {
-		NSString *identifier = assessmentEvent.activity.identifier;
-    
-	    if ([identifier isEqualToString:TemperatureAssessment]) {
-			//1. Present a survey to ask for temperature
-			// ...
-    
-			//2. Save the collected temperature into health kit 
-			HKHealthStore *hkstore = [HKHealthStore new];
-			HKQuantityType *type = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBodyTemperature];
-			
-			[hkstore requestAuthorizationToShareTypes:[NSSet setWithObject:type] readTypes:[NSSet setWithObject:type] completion:^(BOOL success, NSError * _Nullable error) {
-			HKQuantitySample *sample = [HKQuantitySample quantitySampleWithType:type quantity:[HKQuantity quantityWithUnit:[HKUnit degreeFahrenheitUnit] doubleValue:99.1] startDate:[NSDate date] endDate:[NSDate date]];
-			                                           
-			[hkstore saveObject:sample withCompletion:^(BOOL success, NSError * _Nullable error) {
-				// 3. When the collected temperature has been saved into health kit  
-				// Use the saved HKSample object to create a result object and save it to CarePlanStore.
-				// Then each time, CarePlanStore will load the temperature data from HealthKit.
-				OCKCarePlanEventResult *result = [[OCKCarePlanEventResult alloc] initWithQuantitySample:sample quantityStringFormatter:nil unitStringKeys:@{[HKUnit degreeFahrenheitUnit]: @"\u00B0F", [HKUnit degreeCelsiusUnit]: @"\u00B0C",} userInfo:nil];
+```objective-c
+- (void)symptomTrackerViewController:(OCKSymptomTrackerViewController *)viewController didSelectRowWithAssessmentEvent:(OCKCarePlanEvent *)assessmentEvent {
+	NSString *identifier = assessmentEvent.activity.identifier;
 
-				[_store updateEvent:assessmentEvent withResult:result state:OCKCarePlanEventStateCompleted completion:^(BOOL success, OCKCarePlanEvent * _Nonnull event, NSError * _Nonnull error) {
-					NSAssert(success, error.localizedDescription);
-					}];
-				}];                                        
-			}];
-		}
-	}             
-	
+    if ([identifier isEqualToString:TemperatureAssessment]) {
+		//1. Present a survey to ask for temperature
+		// ...
+
+		//2. Save the collected temperature into health kit
+		HKHealthStore *hkstore = [HKHealthStore new];
+		HKQuantityType *type = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBodyTemperature];
+
+		[hkstore requestAuthorizationToShareTypes:[NSSet setWithObject:type] readTypes:[NSSet setWithObject:type] completion:^(BOOL success, NSError * _Nullable error) {
+		HKQuantitySample *sample = [HKQuantitySample quantitySampleWithType:type quantity:[HKQuantity quantityWithUnit:[HKUnit degreeFahrenheitUnit] doubleValue:99.1] startDate:[NSDate date] endDate:[NSDate date]];
+
+		[hkstore saveObject:sample withCompletion:^(BOOL success, NSError * _Nullable error) {
+			// 3. When the collected temperature has been saved into health kit  
+			// Use the saved HKSample object to create a result object and save it to CarePlanStore.
+			// Then each time, CarePlanStore will load the temperature data from HealthKit.
+			OCKCarePlanEventResult *result = [[OCKCarePlanEventResult alloc] initWithQuantitySample:sample quantityStringFormatter:nil unitStringKeys:@{[HKUnit degreeFahrenheitUnit]: @"\u00B0F", [HKUnit degreeCelsiusUnit]: @"\u00B0C",} userInfo:nil];
+
+			[_store updateEvent:assessmentEvent withResult:result state:OCKCarePlanEventStateCompleted completion:^(BOOL success, OCKCarePlanEvent * _Nonnull event, NSError * _Nonnull error) {
+				NSAssert(success, error.localizedDescription);
+				}];
+			}];                                        
+		}];
+	}
+}             
+```
+
 In this example, a body temperature value is saved to a HealthKit store after being acquired from CareKit.
-                            

--- a/docs/ConnectingWithCareTeamsAndPersonalContacts/ConnectingWithCareTeamsAndPersonalContacts-template.md
+++ b/docs/ConnectingWithCareTeamsAndPersonalContacts/ConnectingWithCareTeamsAndPersonalContacts-template.md
@@ -12,7 +12,7 @@ CareKit defines two types of contacts: Care team contacts and personal contacts.
 
 The following code demonstrates how to create a new care team contact:
 
-```
+```swift
 let newContact = OCKContact(contactType: .CareTeam,
     name: "Bill James",
     relation: "Nurse",
@@ -27,10 +27,10 @@ let newContact = OCKContact(contactType: .CareTeam,
 ## Presenting the Contact View Controller
 The contact view controller displays both care team and personal contacts. When creating the view controller, you must pass an array of `OCKContact` objects:
 
-```
+```swift
 let viewController = OCKConnectViewController(contacts: sampleData.contacts)
 viewController.delegate = self
-        
+
 // Setup the controller's title and tab bar item
 viewController.title = NSLocalizedString("Connect", comment: "")
 viewController.tabBarItem = UITabBarItem(title: viewController.title, image: UIImage(named:"connect"), selectedImage: UIImage(named: "connect-filled"))
@@ -38,12 +38,12 @@ viewController.tabBarItem = UITabBarItem(title: viewController.title, image: UII
 
 Upon creation and display of the contact view controller, the following view appears:
 
-<center><img src="ConnectingWithCareTeamsAndPersonalContactsImages/ContactsView.png" style="border: solid #e0e0e0 1px;" width="310px" alt="Contacts View"/> 
+<center><img src="ConnectingWithCareTeamsAndPersonalContactsImages/ContactsView.png" style="border: solid #e0e0e0 1px;" width="310px" alt="Contacts View"/>
 <figcaption>Figure 1: The Contact View</figcaption></center>.
 
 Users can tap on a contact to view the detailed contact information. From this view, the user tap on the appropriate icon to call, text, or email the contact, as well as send reports. Attachments such as photos or documents can be attached to the email as well.
 
-<center><img src="ConnectingWithCareTeamsAndPersonalContactsImages/ContactDetails.png" style="border: solid #e0e0e0 1px;" width="310px" alt="Contacts View"/> 
+<center><img src="ConnectingWithCareTeamsAndPersonalContactsImages/ContactDetails.png" style="border: solid #e0e0e0 1px;" width="310px" alt="Contacts View"/>
 <figcaption>Figure 2: The Details for a Contact</figcaption></center>.
 
 
@@ -51,7 +51,7 @@ Users can tap on a contact to view the detailed contact information. From this v
 
 When using the Connect View Controller, you must implement one required delegate.
 
-```
+```swift
 func connectViewController(connectViewController: OCKConnectViewController, didSelectShareButtonForContact contact: OCKContact)
 ```
 
@@ -59,8 +59,8 @@ This delegate method is called when the user touches the Share button for a give
 
 One common operation is to generate a report or other data, then send it to one of the many sharing services available in the `UIActivityViewController`:
 
-```
+```swift
 let document = someObject.generateSomeDocument()
 let activityViewController = UIActivityViewController(activityItems: [document], applicationActivities: nil)     
-	presentViewController(activityViewController, animated: true, completion: nil)
+presentViewController(activityViewController, animated: true, completion: nil)
 ```

--- a/docs/CreatingTheCareCard/CreatingTheCareCard-template.md
+++ b/docs/CreatingTheCareCard/CreatingTheCareCard-template.md
@@ -4,43 +4,43 @@
 # Creating the Care Card
 
 The care card manages the tasks that the user must perform as part of their treatment plan. To create a care card, you must instantiate the app's care plan store and add the desired intervention activities to the store. Then, you simply instantiate and present the care card view controller.
- 
+
 <center><img src="CreatingTheCareCardImages/CareCard.png" style="border: solid #e0e0e0 1px;" width="310" alt="Care Card Screenshot"/>
 <figcaption>Figure 1: The care card.</figcaption></center>.
 
 CareKit automatically displays the intervention activity events for each day and automatically tracks the user's progress as they perform these tasks. The user can also tap on the activity to get more details or instructions.
- 
+
 <center><img src="CreatingTheCareCardImages/CareCardDetails.png" style="border: solid #e0e0e0 1px;" width="310" alt="Care Card Details Screenshot"/><figcaption>Figure 2: Activity details.</figcaption></center>.
 
 
 ## Instantiate the Care Plan Store
 
-Your app's care plan store is represented using the `OCKCarePlanStore` class. To instantiate a store object, you pass the constructor a URL for your store's data. This URL must point to a directory, and it indicates the location where the system loads and saves your store's files. 
+Your app's care plan store is represented using the `OCKCarePlanStore` class. To instantiate a store object, you pass the constructor a URL for your store's data. This URL must point to a directory, and it indicates the location where the system loads and saves your store's files.
 
 
 1. Generate a URL to a directory inside your app's documents directory.
 
-	```
+	```swift
 	let fileManager = NSFileManager.defaultManager()
 
-	guard let documentDirectory = 	fileManager.URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask).last else {
+	guard let documentDirectory = fileManager.URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask).last else {
 		fatalError("*** Error: Unable to get the document directory! ***")
 	}
 
 	let storeURL = documentDirectory.URLByAppendingPathComponent("MyCareKitStore")
 	```
-	
+
 2. Verify that the directory exists. If it does not exists, create it.
 
-	```
+	```swift
 	if !fileManager.fileExistsAtPath(storeURL.path!) {
-	try! fileManager.createDirectoryAtURL(storeURL, 	withIntermediateDirectories: true, attributes: nil)
+	   try! fileManager.createDirectoryAtURL(storeURL, withIntermediateDirectories: true, attributes: nil)
 	}
 	```
 
 3. Instantiate the care plan store, and assign it to an instance variable for later use. You can also assign the store's delegate. This lets you respond to any changes to the store.
 
-	```
+	```swift
 	store = OCKCarePlanStore(persistenceDirectoryURL: storeURL)
 	store.delegate = self
 	```
@@ -57,37 +57,37 @@ For more information on working with URLs and the iOS file system, see [File Sys
 
 1. Before adding an activity to the care plan store, you should check to see if that activity already exists.
 
-	```
+	```swift
 	store.activityForIdentifier(MyMedicationIdentifier) { (success, activityOrNil, errorOrNil) -> Void in
 	    guard success else {
 	        // perform real error handling here.
 	        fatalError("*** An error occurred \(errorOrNil?.localizedDescription) ***")
 	    }
-	    
+
 	    if let activity = activityOrNil {
-	        
+
 	        // the activity already exists.
-	        
+
 	    } else {
-	        
+
 	        // ADD THE ACTIVITY HERE...
-	        
+
 	    }
 	}
 	```
 	Each activity has a unique identifier. If an identifier is already used in the store, any attempt to add another activity with the same identifier has no effect on the store.
-	
+
 2. Create the activity's schedule.
 
-	```
+	```swift
 	// take medication twice a day, every day starting March 15, 2016
 	let startDay = NSDateComponents(year: 2016, month: 3, day: 15)
 	let twiceADay = OCKCareSchedule.dailyScheduleWithStartDate(startDay, occurrencesPerDay: 2)
 	```
-	
+
 3. Instantiate the intervention activity.
 
-	```
+	```swift
 	let medication = OCKCarePlanActivity(
 	    identifier: MyMedicationIdentifier,
 	    groupIdentifier: nil,
@@ -102,31 +102,31 @@ For more information on working with URLs and the iOS file system, see [File Sys
 	    userInfo: nil)
 	```
 	Activity objects are immutable, which means that you cannot change their properties after they are created.
-	
-	To appear on the care card, the activity must use the `OCKCarePlanActivityType.Intervention` activity type. Intervention activities also require valid `schedule`, `title`, `text`, and `detailedText` parameters. The schedule sets the number of circles to be filled on each day. CareKit displays the title and text on the care card. It displays the detail text on the activity's detail scene. Other parameters are optional, and can further modify how the activity behaves, or how it appears. 
-	
+
+	To appear on the care card, the activity must use the `OCKCarePlanActivityType.Intervention` activity type. Intervention activities also require valid `schedule`, `title`, `text`, and `detailedText` parameters. The schedule sets the number of circles to be filled on each day. CareKit displays the title and text on the care card. It displays the detail text on the activity's detail scene. Other parameters are optional, and can further modify how the activity behaves, or how it appears.
+
 	**Note:** the `resultsResettable` only applies to assessment activities. It has no effect in this example.
-	
+
 4. Add the activity to the store
 
-	```
+	```swift
 	store.addActivity(medication, completion: { (bool, error) in
       // your completion block  
 	})
 	```
-The activity will appear in the Care Card.	
+The activity will appear in the Care Card.
 
 ## Create and Present the Care Card View Controller
 
 To initialize your care card view controller, pass your care plan store to the constructor.
 
-```
+```swift
 let careCardViewController = OCKCareCardViewController(carePlanStore: store)
 ```
 
 You can now present the care card by pushing it onto a navagation controller.
 
-```
+```swift
 // presenting the view controller modally
 self.navigationController?.pushViewController(careCardViewController, animated: true)
 ```

--- a/docs/CreatingTheSymptomAndMeasurementTracker/CreatingTheSymptomAndMeasurementTracker-template.md
+++ b/docs/CreatingTheSymptomAndMeasurementTracker/CreatingTheSymptomAndMeasurementTracker-template.md
@@ -4,22 +4,22 @@
 # Creating the Symptom and Measurement Tracker
 
 The Symptom and Measurement Tracker manages assessment actions and events to measure the effectiveness of the user's care plan.
- 
+
  <center><img src="CreatingTheSymptomAndMeasurementTrackerImages/SymptomTracker.png" style="border: solid #e0e0e0 1px;" width="310" alt="Symptom and Measurement Tracker Screenshot"/>
 <figcaption>Figure 1: The Symptom and Measurement Tracker.</figcaption></center>.
 
 The procedure for creating the Symptom and Measurement Tracker is similar to creating a Care Card, but involves an extra delegate object.
- 
+
 1. Instantiate the app's Care Plan Store.
 2. Add the desired assessment activities to the store.
 3. Create the Symptom and Measurement Tracker delegate.
 4. Instantiate and present the Symptom and Measurement Tracker view controller.
- 
+
 The Symptom and Measurement Tracker automatically displays the assessment activity events for each day and automatically tracks the user's progress as they complete these events.
 
  <center><img src="CreatingTheSymptomAndMeasurementTrackerImages/Evaluations.png" style="border: solid #e0e0e0 1px;" width="310" alt="Evaulation Screenshot"/>
 <figcaption>Figure 2: An example evaluation.</figcaption></center>.
- 
+
 ## Instantiate the Care Plan Store
 
 If you haven't already instantiated the Care Plan Store, follow the instructions listed in [Creating the Care Card](../CreatingTheCareCard/CreatingTheCareCard.html).  
@@ -31,38 +31,38 @@ Remember: You need only a single care plan store per app. The stores are long-li
 
 1. Before adding an activity to the care plan store, you should check to see if that activity already exists.
 
-	```
+	```swift
 	store.activityForIdentifier(MyEmotionalSurveyIdentifier) { (success, activityOrNil, errorOrNil) -> Void in
 	    guard success else {
 	        // perform real error handling here.
 	        fatalError("*** An error occurred \(errorOrNil?.localizedDescription) ***")
 	    }
-	    
+
 	    if let activity = activityOrNil {
-	        
+
 	        // the activity already exists.
-	        
+
 	    } else {
-	        
+
 	        // ADD THE ACTIVITY HERE...
-	        
+
 	    }
 	}
 	```
 	Each activity has a unique identifier. If an identifier is already used in the store, any attempt to add another activity with the same identifier has no effect on the store.
 
-	
+
 2. Create the activity's schedule.
 
-	```
+	```swift
 	// take the emotional survey once a day, every day starting March 15, 2016
 	let startDay = NSDateComponents(year: 2016, month: 3, day: 15)
 	let onceADay = OCKCareSchedule.dailyScheduleWithStartDate(startDay, occurrencesPerDay: 1)
 	```
-	
+
 3. Instantiate the assessment activity.
 
-	```
+	```swift
 	let emotionalSurvey = OCKCarePlanActivity(
 	    identifier: MyEmotionalSurveyIdentifier,
 	    groupIdentifier: nil,
@@ -77,51 +77,51 @@ Remember: You need only a single care plan store per app. The stores are long-li
 	    userInfo: nil)
 	```
 	Activity objects are immutable, which means that you cannot change their properties after they are created.
-	
+
 	To appear on the Symptom and Measurement Tracker, the activity must use the `OCKCarePlanActivityType.Assessment` activity type. Assessment activities also require valid `schedule`, `title`, and  `text` parameters. The schedule sets the number of circles to be filled on each day. CareKit displays the title and text on the Symptom and Measurement Tracker.
-	
+
 	Other parameters can further modify how the activity behaves, or how it appears. In particular, the `resultResettable` parameter determines whether the user can retry the event after they have completed it. In this example, the user can take the survey only once each day, and they cannot edit their results.
-	
+
 
 <!--
 ## Creating the Symptom And Measurement Tracker Delegate
 
 Before you can instantiate the Symptom And Measurement Tracker, you need to create a Symptom And Measurement Tracker delegate. One of your classes must adopt the `OCKEvaluationTableViewDelegate` protocol. This protocol declares a single, required method: the `tableViewDidSelectRowWithEvaluationEvent(evaluationEvent:)` method. The system calls this method whenever the user selects an activity in the Symptom And Measurement Tracker, passing in the current event for that activity.
 
-	```
+```swift
 	func tableViewDidSelectRowWithEvaluationEvent(evaluationEvent: OCKCarePlanEvent) {
 		let identifier = evaluationEvent.activity.identifier
 		switch(identifier) {
 			case MyEmotionalSurveyIdentifier:
 				performSegueWithIdentifier("EmotionalSurveyScene", sender: self)
-            
+
 			default:
 				fatalError("*** Unknown Identifier: \(identifier) ***")
 		}
 }
 ```
 
-	The example implementation starts by extracting the associated activity's identifier from the selected event. Next, it checks to see if the identifier matches any of the expected identifiers. If a match is found, it presents the event view controller for that match--in this case, the example code triggers the `EmotionalSurveyScene` segue from the app's storyboard. 
+	The example implementation starts by extracting the associated activity's identifier from the selected event. Next, it checks to see if the identifier matches any of the expected identifiers. If a match is found, it presents the event view controller for that match--in this case, the example code triggers the `EmotionalSurveyScene` segue from the app's storyboard.
 
 If no match is found, a fatal error is thrown. This will only occur if you add a new assessment action, but forget to add a switch case for its identifier. This is an error you want to find and fix during development and testing.
 
 ### Recording the Result
 
-The event view controller walks the user through the steps necessary to complete the event. When the user completes the event, the controller lets them save or cancel the event. 
+The event view controller walks the user through the steps necessary to complete the event. When the user completes the event, the controller lets them save or cancel the event.
 
 If the user cancels the event, you simply dismiss the event view controller. The action remains unchanged, and the user can select it again to restart the event.
 
 If the user saves the event, you need to instantiate an event result object, and then update the event in the store.
 
-```
+```swift
 let result = OCKCarePlanEventResult(valueString: happinessRating, unitString: nil, userInfo: nil)
-        
+
 store.updateEvent(event, withResult: result, state: .Completed) { (success, updatedEvent, error) -> Void in
-            
+
     guard success else {
         fatalError(error!.localizedDescription)
     }
-            
+
     print("Emotional Survey Event Updated")
 }
 ```
@@ -144,12 +144,12 @@ If the app cannot get the data passively (for example, there are no matching rec
 
 To initialize your Symptom and Measurement Tracker view controller, pass your Care Plan Store and your delegate to the constructor.
 
-```
- let symptomTrackerController = OCKSymptomTrackerViewController(carePlanStore: store, delegate: self)
+```swift
+let symptomTrackerController = OCKSymptomTrackerViewController(carePlanStore: store, delegate: self)
 ```
 Next, present the Symptom and Measurement Tracker just like you would present any other view controller. You can add it to a tab bar controller, push it onto a navigation controller, or present it modally.
 
-```
+```swift
 // presenting the view controller modally
 presentViewController(symptomTrackerController, animated: true, completion: nil)
 ```

--- a/docs/PresentingInsights/PresentingInsights-template.md
+++ b/docs/PresentingInsights/PresentingInsights-template.md
@@ -19,7 +19,7 @@ You can display simple text messages using the `OCKMessageItem` class. This clas
 
 The following sample code creates the message shown in Figure 1.
 
-```
+```swift
 // Calculate the percentage of completed events.
 let medicationAdherence = Float(completedEventCount) / Float(totalEventCount)
 
@@ -55,7 +55,7 @@ For more information on reading data from the Care Plan Store, see [Accessing Ca
 
 ### Generating Your Labels
 
-You need to create a number of labels for your charts. The chart may have a title, text, axis labels, and axis sublabels; however, all of these labels are optional. 
+You need to create a number of labels for your charts. The chart may have a title, text, axis labels, and axis sublabels; however, all of these labels are optional.
 
 The title and text appear in the upper left corner, above the chart. In Figure 1, the title is "Back Pain," and the chart does not have a text label.
 
@@ -77,28 +77,28 @@ Because the chart's scale and origin are based on the data across all your serie
 
 ### Creating Your Series
 
-You need to instantiate one or more `OCKBarSeries` objects for your chart. Each distinct piece of data should have its own series. The following sample code demonstrates creating the series for the chart in Figure 1. 
+You need to instantiate one or more `OCKBarSeries` objects for your chart. Each distinct piece of data should have its own series. The following sample code demonstrates creating the series for the chart in Figure 1.
 
-```
+```swift
 // Create a `OCKBarSeries` for each set of data.
 let painBarSeries = OCKBarSeries(
     title: "Pain",
     values: painValues,
     valueLabels: painLabels,
     tintColor: Colors.Blue.color)
-        
+
 let medicationBarSeries = OCKBarSeries(
     title: "Medication Adherence",
     values: medicationValues,
     valueLabels: medicationLabels,
-    tintColor: Colors.LightBlue.color) 
+    tintColor: Colors.LightBlue.color)
 ```
 
 ### Creating Your Chart
 
 Once you have your series, you can create the chart. The following sample code demonstrates creating the chart from Figure 1.
 
-```
+```swift
 // Add the series to a chart.
 let chart = OCKBarChart(
     title: "Back Pain",
@@ -115,7 +115,7 @@ To create your Insights scene, instantiate and present an `OCKInsightsViewContro
 
 The following sample code creates an Insights view controller like the one shown in Figure 1.
 
-```
+```swift
 let insightsViewController = OCKInsightsViewController(
     insightItems: [message, chart],
     headerTitle: "Weekly Charts",
@@ -126,7 +126,7 @@ let insightsViewController = OCKInsightsViewController(
 
 CareKit's messages and charts are immutable objects, which means that you cannot change them after they are created. However, you can update your Insights scene by assigning a new array of insight items to the Insights view controller's `items` property, as shown below:
 
-```
+```swift
 insightsViewController.items = [message, chart]
 ```
 
@@ -137,65 +137,65 @@ CareKit automatically populates the scene with the new charts and messages.
 The following sample code shows a complete run through of all the steps needed to update an Insights View Controller, using the data gathered from the sample code in [Accessing Care Plan Data](../AccessingCarePlanData/AccessingCarePlanData.html).
 
 
-```
+```swift
 // Wait until all the data is gathered, then process the results.
 dispatch_group_notify(gatherDataGroup, mainQueue) {
-    
+
     // Generate the labels and data
     let dateStrings = completionData.map({(entry) -> String in
-        
+
         guard let date = calendar.dateFromComponents(entry.dateComponent) else {
             fatalError("Unable to create date")
         }
-        
+
         return NSDateFormatter.localizedStringFromDate(date, dateStyle: .ShortStyle, timeStyle: .NoStyle)
     })
-    
+
     let completionValues = completionData.map({ (entry) -> Double in
         return entry.value
     })
-    
+
     let completionValueLabels = completionValues.map({ (value) -> String in
         return NSNumberFormatter.localizedStringFromNumber(value, numberStyle: .PercentStyle)
     })
-    
+
     let rawStressValues = completionData.map({ (entry) -> Double? in
         return stressAssessmentData[entry.dateComponent]
     })
-    
+
     let stressValues = rawStressValues.map({ (valueOrNil) -> Double in
         guard let value = valueOrNil else {
             return 0.0
         }
-        
+
         // Scale to match the completion values
         return value / 10.0
     })
-    
+
     let stressValueLabels = rawStressValues.map({ (valueOrNil) -> String in
         guard let value = valueOrNil else {
             return ""
         }
-        
+
         return NSNumberFormatter.localizedStringFromNumber(value, numberStyle: .DecimalStyle)
     })
-    
+
     // Create the series
-    
+
     let completionSeries = OCKBarSeries(
         title: "Treatment Plan Completed",
         values: completionValues,
         valueLabels: completionValueLabels,
         tintColor: UIColor.blueColor())
-    
+
     let stressAssessmentSeries = OCKBarSeries(
         title: "Stress Assessment",
         values: stressValues,
         valueLabels: stressValueLabels,
         tintColor: UIColor.redColor())
-    
+
     // Create the chart
-    
+
     let chart = OCKBarChart(
         title: "Treatment Plan",
         text: "Compliance and Stress",
@@ -203,19 +203,19 @@ dispatch_group_notify(gatherDataGroup, mainQueue) {
         axisTitles: dateStrings,
         axisSubtitles: nil,
         dataSeries: [completionSeries, stressAssessmentSeries])
-    
+
     // Create the message
-    
+
     let averageCompliance = completionValues.reduce(0.0, combine: +) / Double(completionValues.count)
-    
+
     let messageString = "Over the last week, you completed an average of \(NSNumberFormatter.localizedStringFromNumber(averageCompliance, numberStyle: .PercentStyle)) of your treatment plan per day."
-    
+
     let message = OCKMessageItem(
         title: "Compliance Rate",
         text: messageString,
         tintColor: UIColor.blackColor(),
         messageType: .Alert)
-    
+
     // Update the view controller.
     insightViewControler.items = [chart, message]
 }
@@ -244,13 +244,12 @@ To create a document:
 
 The following sample code creates a subtitle element, a chart element, and a paragraph element.
 
-```
+```swift
 let subheadElement = OCKDocumentElementSubtitle(subtitle: "Weekly Summary")
 
 let chartElement = OCKDocumentElementChart(chart: chart)
 
 let paragraphElement = OCKDocumentElementParagraph(content: "Lorem ipsum dolor sit amet, vim primis noster sententiae ne, et albucius apeirian accusata mea, vim at dicunt laoreet. Eu probo omnes inimicus ius, duo at veritus alienum. Nostrud facilisi id pro. Putant oporteat id eos. Admodum antiopam mel in, at per everti quaeque. Lorem ipsum dolor sit amet, vim primis noster sententiae ne, et albucius apeirian accusata mea, vim at dicunt laoreet. Eu probo omnes inimicus ius, duo at veritus alienum. Nostrud facilisi id pro. Putant oporteat id eos. Admodum antiopam mel in, at per everti quaeque. Lorem ipsum dolor sit amet, vim primis noster sententiae ne, et albucius apeirian accusata mea, vim at dicunt laoreet. Eu probo omnes inimicus ius, duo at veritus alienum. Nostrud facilisi id pro. Putant oporteat id eos. Admodum antiopam mel in, at per everti quaeque.")
-
 ```
 
 **Note:** The `OCKDocumentElementChart` class lets you use CareKit charts in your documents, which means that you can use the same chart in both your reports and your Insights scene.
@@ -259,7 +258,7 @@ let paragraphElement = OCKDocumentElementParagraph(content: "Lorem ipsum dolor s
 
 With the document elements in hand, you can create the document and set its page headers, as shown below:
 
-```
+```swift
 let document = OCKDocument(title: "Weekly Update", elements: [subheadElement, chartElement, paragraphElement])
 
 document.pageHeader = "\(dateString) update for \(userName)"
@@ -269,13 +268,13 @@ document.pageHeader = "\(dateString) update for \(userName)"
 
 After you have created a valid document object, you can access the HTML or PDF data from the document. The code sample below demonstrates creating a PDF version of the document.
 
-```
+```swift
 document.createPDFDataWithCompletion { (PDFData, errorOrNil) in
     if let error = errorOrNil {
         // perform proper error checking here...
         fatalError(error.localizedDescription)
     }
-    
+
     // Do something with the PDF data here...
 }
 ```


### PR DESCRIPTION
Unify code blocks of documents.

Summary:
1. replace tab-based code blocks with backtick ones (fenced code blocks)
2. add syntax highlighting for Swift and Objective-C
3. unify whitespace and indentions in code blocks
4. remove trailing whitespace