### PR TITLE
[Dcumentation] Fix misplaced unicode chars "\u{0B0C}" and "\u{0B0F}"

### DIFF
--- a/docs/AccessingCarePlanData/AccessingCarePlanData-template.md
+++ b/docs/AccessingCarePlanData/AccessingCarePlanData-template.md
@@ -250,8 +250,8 @@ func symptomTrackerViewController(viewController: OCKSymptomTrackerViewControlle
                             quantitySample: sample,
                             quantityStringFormatter: nil,
                             unitStringKeys: [
-                                HKUnit.degreeFahrenheitUnit() : "\u{00B0F}",
-                                HKUnit.degreeCelsiusUnit()    : "\u{00B0C}"
+                                HKUnit.degreeFahrenheitUnit() : "\u{00B0}F", // °F
+                                HKUnit.degreeCelsiusUnit()    : "\u{00B0}C"  // °C
                             ],
                             userInfo: nil
                         )


### PR DESCRIPTION
Hi all,

I converted some example code to Swift in #14.
However, some characters is not displaying correctly due to a bug made by me 😭 

We'd like to display `°F` and `°C` on the screen, but I put the `C` and `F` into the hexadecimal block the the text was rendered as  `ଏ` (0B0F) and `ଌ` (0B0C).

I've fixed this. Really sorry about the bug :bow:
 
It would be appreciated if you could take some time reviewing the changes.