### PR TITLE
Increased tap target size in week view control.

### DIFF
--- a/CareKit/CareCard/OCKCareCardWeekView.m
+++ b/CareKit/CareCard/OCKCareCardWeekView.m
@@ -42,7 +42,6 @@ static const CGFloat HeartButtonSize = 20.0;
 static const CGFloat TopMargin = 15.0;
 static const CGFloat LeadingMargin = 15.0;
 static const CGFloat TrailingMargin = 15.0;
-static const CGFloat BottomMargin = 5.0;
 
 @implementation OCKCareCardWeekView {
     OCKWeekLabelsView *_weekView;

--- a/CareKit/CareCard/OCKCareCardWeekView.m
+++ b/CareKit/CareCard/OCKCareCardWeekView.m
@@ -144,8 +144,8 @@ static const CGFloat BottomMargin = 5.0;
                                         [NSLayoutConstraint constraintWithItem:_stackView
                                                                      attribute:NSLayoutAttributeTop
                                                                      relatedBy:NSLayoutRelationEqual
-                                                                        toItem:_weekView
-                                                                     attribute:NSLayoutAttributeBottom
+                                                                        toItem:self
+                                                                     attribute:NSLayoutAttributeTop
                                                                     multiplier:1.0
                                                                       constant:0.0],
                                         [NSLayoutConstraint constraintWithItem:_stackView
@@ -154,7 +154,7 @@ static const CGFloat BottomMargin = 5.0;
                                                                         toItem:self
                                                                      attribute:NSLayoutAttributeBottom
                                                                     multiplier:1.0
-                                                                      constant:-BottomMargin]
+                                                                      constant:0.0]
                                         ]];
     
     [NSLayoutConstraint activateConstraints:_constraints];

--- a/CareKit/CareCard/OCKHeartButton.m
+++ b/CareKit/CareCard/OCKHeartButton.m
@@ -67,7 +67,7 @@ static const CGFloat HeartViewSize = 30.0;
                                                                         toItem:self
                                                                      attribute:NSLayoutAttributeCenterY
                                                                     multiplier:1.0
-                                                                      constant:0.0],
+                                                                      constant:8.0],
                                         [NSLayoutConstraint constraintWithItem:self.heartView
                                                                      attribute:NSLayoutAttributeWidth
                                                                      relatedBy:NSLayoutRelationEqual

--- a/CareKit/SymptomTracker/OCKSymptomTrackerWeekView.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerWeekView.m
@@ -42,7 +42,6 @@ static const CGFloat RingButtonSize = 20.0;
 static const CGFloat TopMargin = 15.0;
 static const CGFloat LeadingMargin = 15.0;
 static const CGFloat TrailingMargin = 15.0;
-static const CGFloat BottomMargin = 5.0;
 
 @implementation OCKSymptomTrackerWeekView {
     OCKWeekLabelsView *_weekView;

--- a/CareKit/SymptomTracker/OCKSymptomTrackerWeekView.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerWeekView.m
@@ -71,7 +71,7 @@ static const CGFloat BottomMargin = 5.0;
         for (int i = 0; i < 7; i++) {
             OCKRingButton *ringButton = [[OCKRingButton alloc] initWithFrame:CGRectMake(0, 0, RingButtonSize, RingButtonSize)];
             
-            OCKRingView *ringView = [[OCKRingView alloc] initWithFrame:CGRectMake(0, 0, RingButtonSize + 10, RingButtonSize + 10)];
+            OCKRingView *ringView = [[OCKRingView alloc] initWithFrame:CGRectMake(0, 25, RingButtonSize + 10, RingButtonSize + 10)];
             ringView.userInteractionEnabled = NO;
             ringView.disableAnimation = YES;
             ringView.hideLabel = YES;
@@ -143,17 +143,17 @@ static const CGFloat BottomMargin = 5.0;
                                         [NSLayoutConstraint constraintWithItem:_stackView
                                                                      attribute:NSLayoutAttributeTop
                                                                      relatedBy:NSLayoutRelationEqual
-                                                                        toItem:_weekView
-                                                                     attribute:NSLayoutAttributeBottom
+                                                                        toItem:self
+                                                                     attribute:NSLayoutAttributeTop
                                                                     multiplier:1.0
-                                                                      constant:2*RingButtonSize],
+                                                                      constant:0.0],
                                         [NSLayoutConstraint constraintWithItem:_stackView
                                                                      attribute:NSLayoutAttributeBottom
                                                                      relatedBy:NSLayoutRelationEqual
                                                                         toItem:self
                                                                      attribute:NSLayoutAttributeBottom
                                                                     multiplier:1.0
-                                                                      constant:-BottomMargin]
+                                                                      constant:0.0]
                                         ]];
     
     [NSLayoutConstraint activateConstraints:_constraints];


### PR DESCRIPTION
I increased the size of the buttons for the week view in the Care Card and Symptom Tracker so that you can tap on the day of the week label to change the day as well as by tapping the circle or heart underneath. This doesn't change anything visually.