### PR TITLE
Refactor Task Result Completion in the Sample App

### DIFF
--- a/Sample/OCKSample/RootViewController.swift
+++ b/Sample/OCKSample/RootViewController.swift
@@ -176,7 +176,6 @@ extension RootViewController: ORKTaskViewControllerDelegate {
 
         // Check assessment can be associated with a HealthKit sample.
         guard let healthSampleBuilder = sampleAssessment as? HealthSampleBuilder else {
-            print("Not Health Kit")
             completion(carePlanResult: carePlanResult, savedToHealthKit: false)
             return
         }
@@ -188,33 +187,33 @@ extension RootViewController: ORKTaskViewControllerDelegate {
         // Requst authorization to store the HealthKit sample.
         let healthStore = HKHealthStore()
         healthStore.requestAuthorizationToShareTypes(sampleTypes, readTypes: sampleTypes) { success, _ in
-            // Check if authorization was granted.
-            if !success {
-                 // Fall back to the simple `OCKCarePlanEventResult`
+            guard success else {
+                 // Check if authorization was grante and fall back to the simple `OCKCarePlanEventResult`
                 completion(carePlanResult: carePlanResult, savedToHealthKit: false)
                 return
             }
 
             // Save the HealthKit sample in the HealthKit store.
             healthStore.saveObject(sample) { success, _ in
-                if success {
-                    /*
-                     The sample was saved to the HealthKit store. Use it
-                     to create an `OCKCarePlanEventResult`
-                     */
-                    let healthKitAssociatedResult = OCKCarePlanEventResult(
-                        quantitySample: sample,
-                        quantityStringFormatter: nil,
-                        displayUnit: healthSampleBuilder.unit,
-                        displayUnitStringKey: healthSampleBuilder.localizedUnitForSample(sample),
-                        userInfo: nil
-                    )
-                    completion(carePlanResult: healthKitAssociatedResult, savedToHealthKit: true)
-                }
-                else {
-                     // Fall back to the simple `OCKCarePlanEventResult`
+                guard success else {
+                    // Fall back to the simple `OCKCarePlanEventResult`
                     completion(carePlanResult: carePlanResult, savedToHealthKit: false)
+                    return
                 }
+
+                /*
+                 The sample was saved to the HealthKit store. Use it
+                 to create an `OCKCarePlanEventResult`
+                 */
+                let healthKitAssociatedResult = OCKCarePlanEventResult(
+                    quantitySample: sample,
+                    quantityStringFormatter: nil,
+                    displayUnit: healthSampleBuilder.unit,
+                    displayUnitStringKey: healthSampleBuilder.localizedUnitForSample(sample),
+                    userInfo: nil
+                )
+
+                completion(carePlanResult: healthKitAssociatedResult, savedToHealthKit: true)
             }
         }
     }

--- a/Sample/OCKSample/RootViewController.swift
+++ b/Sample/OCKSample/RootViewController.swift
@@ -155,70 +155,70 @@ extension RootViewController: ORKTaskViewControllerDelegate {
         // Make sure the reason the task controller finished is that it was completed.
         guard reason == .Completed else { return }
         
-        // Determine the event that was completed and the `SampleAssessment` it represents.
-        guard let event = symptomTrackerViewController.lastSelectedAssessmentEvent,
-            activityType = ActivityType(rawValue: event.activity.identifier),
-            sampleAssessment = sampleData.activityWithType(activityType) as? Assessment else { return }
-        
-        // Build an `OCKCarePlanEventResult` that can be saved into the `OCKCarePlanStore`.
-        let carePlanResult = sampleAssessment.buildResultForCarePlanEvent(event, taskResult: taskViewController.result)
-        
-        // Check assessment can be associated with a HealthKit sample.
-        if let healthSampleBuilder = sampleAssessment as? HealthSampleBuilder {
-            // Build the sample to save in the HealthKit store.
-            let sample = healthSampleBuilder.buildSampleWithTaskResult(taskViewController.result)
-            let sampleTypes: Set<HKSampleType> = [sample.sampleType]
-            
-            // Requst authorization to store the HealthKit sample.
-            let healthStore = HKHealthStore()
-            healthStore.requestAuthorizationToShareTypes(sampleTypes, readTypes: sampleTypes, completion: { success, _ in
-                // Check if authorization was granted.
-                if !success {
-                    /*
-                        Fall back to saving the simple `OCKCarePlanEventResult`
-                        in the `OCKCarePlanStore`.
-                    */
-                    self.completeEvent(event, inStore: self.storeManager.store, withResult: carePlanResult)
-                    return
-                }
-                
-                // Save the HealthKit sample in the HealthKit store.
-                healthStore.saveObject(sample, withCompletion: { success, _ in
-                    if success {
-                        /*
-                            The sample was saved to the HealthKit store. Use it
-                            to create an `OCKCarePlanEventResult` and save that
-                            to the `OCKCarePlanStore`.
-                         */
-                        let healthKitAssociatedResult = OCKCarePlanEventResult(
-                                quantitySample: sample,
-                                quantityStringFormatter: nil,
-                                displayUnit: healthSampleBuilder.unit,
-                                displayUnitStringKey: healthSampleBuilder.localizedUnitForSample(sample),
-                                userInfo: nil
-                        )
-                        
-                        self.completeEvent(event, inStore: self.storeManager.store, withResult: healthKitAssociatedResult)
-                    }
-                    else {
-                        /*
-                            Fall back to saving the simple `OCKCarePlanEventResult`
-                            in the `OCKCarePlanStore`.
-                        */
-                        self.completeEvent(event, inStore: self.storeManager.store, withResult: carePlanResult)
-                    }
-                    
-                })
-            })
-        }
-        else {
-            // Update the event with the result.
-            completeEvent(event, inStore: storeManager.store, withResult: carePlanResult)
+        // Determine the event that was completed
+        guard let event = symptomTrackerViewController.lastSelectedAssessmentEvent else { return }
+
+        carePlanResultWith(event: event, taskResult: taskViewController.result) { carePlanResult, _ in
+            self.completeEvent(event, inStore: self.storeManager.store, withResult: carePlanResult)
         }
     }
     
     // MARK: Convenience
-    
+
+    // Generate an `OCKCarePlanEventResult` with given event and task result, saving it to HealthKit if appropriate
+    private func carePlanResultWith(event event: OCKCarePlanEvent, taskResult:ORKTaskResult, completion: (carePlanResult: OCKCarePlanEventResult, savedToHealthKit: Bool) -> ()) {
+        // The `SampleAssessment` this event represents.
+        guard let activityType = ActivityType(rawValue: event.activity.identifier),
+            sampleAssessment = sampleData.activityWithType(activityType) as? Assessment else { return }
+
+        // Build an `OCKCarePlanEventResult` that can be saved into the `OCKCarePlanStore`.
+        let carePlanResult = sampleAssessment.buildResultForCarePlanEvent(event, taskResult: taskResult)
+
+        // Check assessment can be associated with a HealthKit sample.
+        guard let healthSampleBuilder = sampleAssessment as? HealthSampleBuilder else {
+            print("Not Health Kit")
+            completion(carePlanResult: carePlanResult, savedToHealthKit: false)
+            return
+        }
+
+        // Build the sample to save in the HealthKit store.
+        let sample = healthSampleBuilder.buildSampleWithTaskResult(taskResult)
+        let sampleTypes: Set<HKSampleType> = [sample.sampleType]
+
+        // Requst authorization to store the HealthKit sample.
+        let healthStore = HKHealthStore()
+        healthStore.requestAuthorizationToShareTypes(sampleTypes, readTypes: sampleTypes) { success, _ in
+            // Check if authorization was granted.
+            if !success {
+                 // Fall back to the simple `OCKCarePlanEventResult`
+                completion(carePlanResult: carePlanResult, savedToHealthKit: false)
+                return
+            }
+
+            // Save the HealthKit sample in the HealthKit store.
+            healthStore.saveObject(sample) { success, _ in
+                if success {
+                    /*
+                     The sample was saved to the HealthKit store. Use it
+                     to create an `OCKCarePlanEventResult`
+                     */
+                    let healthKitAssociatedResult = OCKCarePlanEventResult(
+                        quantitySample: sample,
+                        quantityStringFormatter: nil,
+                        displayUnit: healthSampleBuilder.unit,
+                        displayUnitStringKey: healthSampleBuilder.localizedUnitForSample(sample),
+                        userInfo: nil
+                    )
+                    completion(carePlanResult: healthKitAssociatedResult, savedToHealthKit: true)
+                }
+                else {
+                     // Fall back to the simple `OCKCarePlanEventResult`
+                    completion(carePlanResult: carePlanResult, savedToHealthKit: false)
+                }
+            }
+        }
+    }
+
     private func completeEvent(event: OCKCarePlanEvent, inStore store: OCKCarePlanStore, withResult result: OCKCarePlanEventResult) {
         store.updateEvent(event, withResult: result, state: .Completed) { success, _, error in
             if !success {


### PR DESCRIPTION
In reviewing the sample app, I found the implementation of the `ORKTaskViewControllerDelegate` slightly dense and difficult to read. This pull request aims to make this section of the sample app more readable, as well as a bit DRYer and more Swifty. The intent of the `taskViewController:didFinishWithReason:error:` method is now clearer: generate a care plan result and use it to complete the event.
