### PR TITLE
Add a (read only) property encapsulating whetner an `OCKCarePlanEvent` is available

### DIFF
--- a/CareKit/CarePlan/OCKCarePlanEvent.h
+++ b/CareKit/CarePlan/OCKCarePlanEvent.h
@@ -96,6 +96,12 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, readonly) OCKCarePlanEventState state;
 
 /**
+ The availability of this event, based on its `state`
+ and its activity's `resultResettable` property.
+ */
+@property (nonatomic, readonly) BOOL isAvailable;
+
+/**
  A result object can be attached to event by using the OCKCarePlanStore API.
  */
 @property (nonatomic, readonly, nullable) OCKCarePlanEventResult *result;

--- a/CareKit/CarePlan/OCKCarePlanEvent.m
+++ b/CareKit/CarePlan/OCKCarePlanEvent.m
@@ -69,6 +69,12 @@
     return [self.activity.schedule.startDate dateCompByAddingDays:self.numberOfDaysSinceStart];
 }
 
+- (BOOL)isAvailable {
+    return _state == OCKCarePlanEventStateInitial ||
+            _state == OCKCarePlanEventStateNotCompleted ||
+            (_state == OCKCarePlanEventStateCompleted && _activity.resultResettable);
+}
+
 - (instancetype)copyWithZone:(NSZone *)zone {
     OCKCarePlanEvent* event = [[[self class] allocWithZone:zone] init];
     event->_occurrenceIndexOfDay = _occurrenceIndexOfDay;

--- a/Sample/OCKSample/RootViewController.swift
+++ b/Sample/OCKSample/RootViewController.swift
@@ -126,13 +126,8 @@ extension RootViewController: OCKSymptomTrackerViewControllerDelegate {
         guard let activityType = ActivityType(rawValue: assessmentEvent.activity.identifier) else { return }
         guard let sampleAssessment = sampleData.activityWithType(activityType) as? Assessment else { return }
         
-        /*
-            Check if we should show a task for the selected assessment event
-            based on its state.
-        */
-        guard assessmentEvent.state == .Initial ||
-            assessmentEvent.state == .NotCompleted ||
-            (assessmentEvent.state == .Completed && assessmentEvent.activity.resultResettable) else { return }
+        // Check if the task is currently available to the participant
+        guard assessmentEvent.isAvailable else { return }
         
         // Show an `ORKTaskViewController` for the assessment's task.
         let taskViewController = ORKTaskViewController(task: sampleAssessment.task(), taskRunUUID: nil)


### PR DESCRIPTION
This adds a read only property that uses the `OCKCarePlanEvent`'s state, and the `resultResettable` property of its activity to expose whether the event is available to the user. It seems useful to provide this definition internally; I'd imagine most every CareKit app would have to perform this check.