### PR TITLE
OCKSymptomTrackerViewController doesn't update contents when activity list is changed

### DIFF
--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -355,7 +355,7 @@
     }
 }
 
-- (void)carePlanStoreEvaluationListDidChange:(OCKCarePlanStore *)store {
+- (void)carePlanStoreActivityListDidChange:(OCKCarePlanStore *)store {
     [self fetchEvents];
 }
 


### PR DESCRIPTION
Hi there,
I noticed that ``OCKSymptomTrackerViewController`` doesn't update its contents when activity list is changed. According to ``handleActivityListChange`` in ``OCKCarePlanStore``,
I guess ``carePlanStoreActivityListDidChange`` should be correct method name
by original intention.

Cheers,