### PR TITLE
Fix store callback when an activity with an existing identifier is added

### DIFF
--- a/CareKit/CarePlan/OCKCarePlanStore.m
+++ b/CareKit/CarePlan/OCKCarePlanStore.m
@@ -124,7 +124,7 @@ static NSString * const OCKAttributeNameDayIndex = @"numberOfDaysSinceStart";
     NSParameterAssert(sourceItem);
 
     NSManagedObjectContext *context = _managedObjectContext;
-    if (context == nil) {
+    if (nil == context) {
         return NO;
     }
     
@@ -134,28 +134,34 @@ static NSString * const OCKAttributeNameDayIndex = @"numberOfDaysSinceStart";
                                                          identifier:sourceItem.identifier
                                                               class:[OCKCarePlanActivity class]
                                                               error:&errorOut];
-    
-    if (item) {
-        if (error) {
+    if (nil != errorOut) {
+        if (nil != error) {
+            *error = errorOut;
+        }
+        return NO;
+    }
+
+    if (nil != item) {
+        if (nil != error) {
             NSString *reasonString = [NSString stringWithFormat:@"An activity with the identifier %@ already exists.", sourceItem.identifier];
             *error = [NSError errorWithDomain:OCKErrorDomain code:OCKErrorInvalidObject userInfo:@{@"reason":reasonString}];
         }
-    } else {
+        return NO;
+    }
     
-        NSManagedObject *cdObject;
-        cdObject = [[coreDataClass alloc] initWithEntity:[NSEntityDescription entityForName:entityName
-                                                                     inManagedObjectContext:context]
-                          insertIntoManagedObjectContext:context
-                                                    item:sourceItem];
-        
-        if (![context save:&errorOut]) {
-            if (error) {
-                *error = errorOut;
-            }
-        }
+    NSManagedObject *cdObject;
+    cdObject = [[coreDataClass alloc] initWithEntity:[NSEntityDescription entityForName:entityName
+                                                                 inManagedObjectContext:context]
+                      insertIntoManagedObjectContext:context
+                                                item:sourceItem];
+
+    BOOL savedSuccessfully = [context save:&errorOut];
+
+    if (nil != error) {
+        *error = errorOut;
     }
 
-    return errorOut ? NO : YES;
+    return savedSuccessfully;
 }
 
 - (BOOL)block_alterItemWithEntityName:(NSString *)name


### PR DESCRIPTION
Previously, the callback would contain `YES` and an error. Now, it properly returns `NO` and an error. I also tried to clarify the semantics to avoid future confusion, at the expense of a bit of verbosity.

As a side note, the naming here makes it very easy to get confused, which it seems is what happened to both the original implementer and to me when I reported #37. I might prefer calling the `error` parameter `errorPtr` or similar, but didn't make that change here as the same convention is used throughout the class.