### PR TITLE
Add 3D Touch to Care Card and Connect

### DIFF
--- a/CareKit/CareCard/OCKCareCardTableViewHeader.h
+++ b/CareKit/CareCard/OCKCareCardTableViewHeader.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class OCKHeartView;
 
-@interface OCKCareCardTableViewHeader : UIView
+@interface OCKCareCardTableViewHeader : UITableViewHeaderFooterView
 
 @property (nonatomic) double value;
 

--- a/CareKit/CareCard/OCKCareCardTableViewHeader.m
+++ b/CareKit/CareCard/OCKCareCardTableViewHeader.m
@@ -57,15 +57,15 @@ static const CGFloat HeartViewSize = 110.0;
     self = [super initWithFrame:frame];
     if (self) {
         if (!UIAccessibilityIsReduceTransparencyEnabled()) {
-            self.backgroundColor = [UIColor clearColor];
+            self.contentView.backgroundColor = [UIColor clearColor];
             
             UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
             UIVisualEffectView *blurEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
             blurEffectView.frame = self.bounds;
             blurEffectView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-            [self addSubview:blurEffectView];
+            self.backgroundView = blurEffectView;
         } else {
-            self.backgroundColor = [UIColor whiteColor];
+            self.contentView.backgroundColor = [UIColor whiteColor];
         }
         
         [self prepareView];

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -46,7 +46,7 @@
 
 #define RedColor() OCKColorFromRGB(0xEF445B);
 
-@interface OCKCareCardViewController() <OCKWeekViewDelegate, OCKCarePlanStoreDelegate, OCKCareCardCellDelegate, UITableViewDelegate, UITableViewDataSource, UIPageViewControllerDelegate, UIPageViewControllerDataSource>
+@interface OCKCareCardViewController() <OCKWeekViewDelegate, OCKCarePlanStoreDelegate, OCKCareCardCellDelegate, UITableViewDelegate, UITableViewDataSource, UIPageViewControllerDelegate, UIPageViewControllerDataSource, UIViewControllerPreviewingDelegate>
 
 @property (nonatomic) NSDateComponents *selectedDate;
 
@@ -106,6 +106,10 @@
     _tableView.rowHeight = UITableViewAutomaticDimension;
     _tableView.estimatedSectionHeaderHeight = 100.0;
     _tableView.sectionHeaderHeight = UITableViewAutomaticDimension;
+    
+    if ([self respondsToSelector:@selector(registerForPreviewingWithDelegate:sourceView:)]) {
+        [self registerForPreviewingWithDelegate:self sourceView:_tableView];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -343,6 +347,20 @@
     return [NSDateComponents ock_componentsWithDate:[NSDate date] calendar:_calendar];
 }
 
+- (UIViewController *)detailViewControllerForActivity:(OCKCarePlanActivity *)activity {
+    OCKCareCardDetailViewController *detailViewController = [[OCKCareCardDetailViewController alloc] initWithIntervention:activity];
+    detailViewController.showEdgeIndicator = self.showEdgeIndicators;
+    return detailViewController;
+}
+
+- (OCKCarePlanActivity *)activityForIndexPath:(NSIndexPath *)indexPath {
+    return _events[indexPath.row].firstObject.activity;
+}
+
+- (BOOL)delegateCustomizesRowSelection {
+    return self.delegate && [self.delegate respondsToSelector:@selector(careCardViewController:didSelectRowWithInterventionActivity:)];
+}
+
 
 #pragma mark - OCKWeekViewDelegate
 
@@ -459,15 +477,12 @@
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    OCKCarePlanActivity *selectedActivity = _events[indexPath.row].firstObject.activity;
+    OCKCarePlanActivity *selectedActivity = [self activityForIndexPath:indexPath];
     
-    if (self.delegate &&
-        [self.delegate respondsToSelector:@selector(careCardViewController:didSelectRowWithInterventionActivity:)]) {
+    if ([self delegateCustomizesRowSelection]) {
         [self.delegate careCardViewController:self didSelectRowWithInterventionActivity:selectedActivity];
     } else {
-        OCKCareCardDetailViewController *detailViewController = [[OCKCareCardDetailViewController alloc] initWithIntervention:selectedActivity];
-        detailViewController.showEdgeIndicator = self.showEdgeIndicators;
-        [self.navigationController pushViewController:detailViewController animated:YES];
+        [self.navigationController pushViewController:[self detailViewControllerForActivity:selectedActivity] animated:YES];
     }
     
     [tableView deselectRowAtIndexPath:indexPath animated:NO];
@@ -491,6 +506,28 @@
     cell.delegate = self;
     cell.showEdgeIndicator = self.showEdgeIndicators;
     return cell;
+}
+
+#pragma mark - UIViewControllerPreviewingDelegate
+
+- (nullable UIViewController *)previewingContext:(id <UIViewControllerPreviewing>)previewingContext viewControllerForLocation:(CGPoint)location {
+    NSIndexPath *indexPath = [_tableView indexPathForRowAtPoint:location];
+    CGRect headerFrame = [_tableView headerViewForSection:0].frame;
+    
+    if (indexPath &&
+        !CGRectContainsPoint(headerFrame, location) &&
+        ![self delegateCustomizesRowSelection]) {
+        CGRect cellFrame = [_tableView cellForRowAtIndexPath:indexPath].frame;
+        previewingContext.sourceRect = cellFrame;
+        return [self detailViewControllerForActivity:[self activityForIndexPath:indexPath]];
+    }
+    
+    return nil;
+}
+
+- (void)previewingContext:(id <UIViewControllerPreviewing>)previewingContext commitViewController:(UIViewController *)viewControllerToCommit {
+    NSIndexPath *indexPath = [_tableView indexPathForRowAtPoint:previewingContext.sourceRect.origin];
+    [self.navigationController pushViewController:[self detailViewControllerForActivity:[self activityForIndexPath:indexPath]] animated:YES];
 }
 
 @end

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -509,6 +509,7 @@
     cell.interventionEvents = _events[indexPath.row];
     cell.delegate = self;
     cell.showEdgeIndicator = self.showEdgeIndicators;
+    
     return cell;
 }
 

--- a/CareKit/Connect/OCKConnectDetailViewController.m
+++ b/CareKit/Connect/OCKConnectDetailViewController.m
@@ -154,7 +154,7 @@ static const CGFloat HeaderViewHeight = 225.0;
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:stringURL]];
 }
 
-- (void)sendMessageToNumber:(NSString *)number withDelegate:(id<MFMessageComposeViewControllerDelegate>)messageDelegate usingPresentingViewController:(UIViewController *)presentingViewController {
+- (void)sendMessageToNumber:(NSString *)number delegate:(id<MFMessageComposeViewControllerDelegate>)messageDelegate presentingViewController:(UIViewController *)presentingViewController {
     MFMessageComposeViewController *messageViewController = [MFMessageComposeViewController new];
     if ([MFMessageComposeViewController canSendText]) {
         messageViewController.messageComposeDelegate = messageDelegate;
@@ -163,7 +163,7 @@ static const CGFloat HeaderViewHeight = 225.0;
     }
 }
 
-- (void)sendEmailToAddress:(NSString *)address withDelegate:(id<MFMailComposeViewControllerDelegate>)emailDelegate usingPresentingViewController:(UIViewController *)presentingViewController {
+- (void)sendEmailToAddress:(NSString *)address delegate:(id<MFMailComposeViewControllerDelegate>)emailDelegate presentingViewController:(UIViewController *)presentingViewController {
     MFMailComposeViewController *emailViewController = [MFMailComposeViewController new];
     if ([MFMailComposeViewController canSendMail]) {
         emailViewController.mailComposeDelegate = emailDelegate;
@@ -182,11 +182,11 @@ static const CGFloat HeaderViewHeight = 225.0;
             break;
             
         case OCKConnectTypeMessage:
-            [self sendMessageToNumber:cell.contact.messageNumber.stringValue withDelegate:self usingPresentingViewController:self];
+            [self sendMessageToNumber:cell.contact.messageNumber.stringValue delegate:self presentingViewController:self];
             break;
             
         case OCKConnectTypeEmail:
-            [self sendEmailToAddress:cell.contact.emailAddress withDelegate:self usingPresentingViewController:self];
+            [self sendEmailToAddress:cell.contact.emailAddress delegate:self presentingViewController:self];
             break;
     }
 }
@@ -302,20 +302,26 @@ static const CGFloat HeaderViewHeight = 225.0;
     if (self.contact.messageNumber) {
         NSString *messageTitle = [OCKLocalizedString(@"CONTACT_INFO_MESSAGE_TITLE", nil) capitalizedStringWithLocale:[NSLocale currentLocale]];
         UIPreviewAction *messageAction = [UIPreviewAction actionWithTitle:messageTitle style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
-            [self sendMessageToNumber:self.contact.messageNumber.stringValue withDelegate:(id<MFMessageComposeViewControllerDelegate>)self.masterViewController usingPresentingViewController:self.masterViewController];
+            [self sendMessageToNumber:self.contact.messageNumber.stringValue delegate:(id<MFMessageComposeViewControllerDelegate>)self.masterViewController presentingViewController:self.masterViewController];
         }];
         [actions addObject:messageAction];
     }
     if (self.contact.emailAddress) {
         NSString *emailTitle = [OCKLocalizedString(@"CONTACT_INFO_EMAIL_TITLE", nil) capitalizedStringWithLocale:[NSLocale currentLocale]];
         UIPreviewAction *emailAction = [UIPreviewAction actionWithTitle:emailTitle style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
-            [self sendEmailToAddress:self.contact.emailAddress withDelegate:(id<MFMailComposeViewControllerDelegate>)self.masterViewController usingPresentingViewController:self.masterViewController];
+            [self sendEmailToAddress:self.contact.emailAddress delegate:(id<MFMailComposeViewControllerDelegate>)self.masterViewController presentingViewController:self.masterViewController];
         }];
         [actions addObject:emailAction];
     }
     if (self.delegate) {
-        NSString *shareTitle = [self.delegate connectViewController:self.masterViewController titleForSharingCellForContact:self.contact];
-        UIPreviewAction *shareAction = [UIPreviewAction actionWithTitle:((shareTitle) ? shareTitle : OCKLocalizedString(@"SHARING_CELL_TITLE", nil)) style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+        NSString *sharingTitle = OCKLocalizedString(@"SHARING_CELL_TITLE", nil);
+        if ([self.delegate respondsToSelector:@selector(connectViewController:titleForSharingCellForContact:)]) {
+            NSString *delegateTitle = [self.delegate connectViewController:self.masterViewController titleForSharingCellForContact:self.contact];
+            if (delegateTitle.length > 0) {
+                sharingTitle = delegateTitle;
+            }
+        }
+        UIPreviewAction *shareAction = [UIPreviewAction actionWithTitle:sharingTitle style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
             [self.delegate connectViewController:self.masterViewController didSelectShareButtonForContact:self.contact presentationSourceView:nil];
         }];
         [actions addObject:shareAction];

--- a/CareKit/Connect/OCKConnectDetailViewController.m
+++ b/CareKit/Connect/OCKConnectDetailViewController.m
@@ -293,22 +293,32 @@ static const CGFloat HeaderViewHeight = 225.0;
 - (NSArray<id<UIPreviewActionItem>> *)previewActionItems {
     NSMutableArray<id<UIPreviewActionItem>> *actions = [[NSMutableArray alloc] init];
     if (self.contact.phoneNumber) {
-        UIPreviewAction *phoneAction = [UIPreviewAction actionWithTitle:OCKLocalizedString(@"CONTACT_INFO_PHONE_TITLE", nil) style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+        NSString *phoneTitle = [OCKLocalizedString(@"CONTACT_INFO_PHONE_TITLE", nil) capitalizedStringWithLocale:[NSLocale currentLocale]];
+        UIPreviewAction *phoneAction = [UIPreviewAction actionWithTitle:phoneTitle style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
             [self makeCallToNumber:self.contact.phoneNumber.stringValue];
         }];
         [actions addObject:phoneAction];
     }
     if (self.contact.messageNumber) {
-        UIPreviewAction *messageAction = [UIPreviewAction actionWithTitle:OCKLocalizedString(@"CONTACT_INFO_MESSAGE_TITLE", nil) style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+        NSString *messageTitle = [OCKLocalizedString(@"CONTACT_INFO_MESSAGE_TITLE", nil) capitalizedStringWithLocale:[NSLocale currentLocale]];
+        UIPreviewAction *messageAction = [UIPreviewAction actionWithTitle:messageTitle style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
             [self sendMessageToNumber:self.contact.messageNumber.stringValue withDelegate:(id<MFMessageComposeViewControllerDelegate>)self.masterViewController usingPresentingViewController:self.masterViewController];
         }];
         [actions addObject:messageAction];
     }
     if (self.contact.emailAddress) {
-        UIPreviewAction *emailAction = [UIPreviewAction actionWithTitle:OCKLocalizedString(@"CONTACT_INFO_EMAIL_TITLE", nil) style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+        NSString *emailTitle = [OCKLocalizedString(@"CONTACT_INFO_EMAIL_TITLE", nil) capitalizedStringWithLocale:[NSLocale currentLocale]];
+        UIPreviewAction *emailAction = [UIPreviewAction actionWithTitle:emailTitle style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
             [self sendEmailToAddress:self.contact.emailAddress withDelegate:(id<MFMailComposeViewControllerDelegate>)self.masterViewController usingPresentingViewController:self.masterViewController];
         }];
         [actions addObject:emailAction];
+    }
+    if (self.delegate) {
+        NSString *shareTitle = [self.delegate connectViewController:self.masterViewController titleForSharingCellForContact:self.contact];
+        UIPreviewAction *shareAction = [UIPreviewAction actionWithTitle:((shareTitle) ? shareTitle : OCKLocalizedString(@"SHARING_CELL_TITLE", nil)) style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+            [self.delegate connectViewController:self.masterViewController didSelectShareButtonForContact:self.contact presentationSourceView:nil];
+        }];
+        [actions addObject:shareAction];
     }
     return actions;
 }

--- a/CareKit/Connect/OCKConnectDetailViewController.m
+++ b/CareKit/Connect/OCKConnectDetailViewController.m
@@ -186,7 +186,7 @@ static const CGFloat HeaderViewHeight = 225.0;
             break;
             
         case OCKConnectTypeEmail:
-            [self sendMessageToNumber:cell.contact.emailAddress withDelegate:self usingPresentingViewController:self];
+            [self sendEmailToAddress:cell.contact.emailAddress withDelegate:self usingPresentingViewController:self];
             break;
     }
 }

--- a/CareKit/Connect/OCKConnectViewController.h
+++ b/CareKit/Connect/OCKConnectViewController.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param contact                     The contact that is currently displayed.
  @param sourceView                  Source view can be used to present a popover on iPad.
  */
-- (void)connectViewController:(OCKConnectViewController *)connectViewController didSelectShareButtonForContact:(OCKContact *)contact presentationSourceView:(UIView *)sourceView;
+- (void)connectViewController:(OCKConnectViewController *)connectViewController didSelectShareButtonForContact:(OCKContact *)contact presentationSourceView:(nullable UIView *)sourceView;
 
 @optional
 /**

--- a/CareKit/Connect/OCKConnectViewController.m
+++ b/CareKit/Connect/OCKConnectViewController.m
@@ -213,6 +213,7 @@
 
 - (void)setShowEdgeIndicators:(BOOL)showEdgeIndicators {
     _showEdgeIndicators = showEdgeIndicators;
+    
     [_tableView reloadData];
 }
 
@@ -265,6 +266,7 @@
     }
     cell.contact = _sectionedContacts[indexPath.section][indexPath.row];
     cell.showEdgeIndicator = self.showEdgeIndicators;
+    
     return cell;
 }
 

--- a/CareKit/Connect/OCKConnectViewController.m
+++ b/CareKit/Connect/OCKConnectViewController.m
@@ -37,7 +37,7 @@
 #import "OCKLabel.h"
 
 
-@interface OCKConnectViewController() <UITableViewDelegate, UITableViewDataSource, UIViewControllerPreviewingDelegate>
+@interface OCKConnectViewController() <UITableViewDelegate, UITableViewDataSource, UIViewControllerPreviewingDelegate, MFMessageComposeViewControllerDelegate, MFMailComposeViewControllerDelegate>
 
 @end
 
@@ -266,6 +266,30 @@
     cell.contact = _sectionedContacts[indexPath.section][indexPath.row];
     cell.showEdgeIndicator = self.showEdgeIndicators;
     return cell;
+}
+
+#pragma mark - MFMessageComposeViewControllerDelegate
+
+- (void)messageComposeViewController:(MFMessageComposeViewController *)controller didFinishWithResult:(MessageComposeResult)result {
+    [self dismissViewControllerAnimated:YES completion:nil];
+    if (result == MessageComposeResultFailed) {
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:OCKLocalizedString(@"ERROR_TITLE", nil)
+                                                                                 message:OCKLocalizedString(@"MESSAGE_SEND_ERROR", nil)
+                                                                          preferredStyle:UIAlertControllerStyleAlert];
+        [self presentViewController:alertController animated:YES completion:nil];
+    }
+}
+
+#pragma mark - MFMailComposeViewControllerDelegate
+
+- (void)mailComposeController:(MFMailComposeViewController *)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError *)error {
+    [self dismissViewControllerAnimated:YES completion:nil];
+    if (result == MFMailComposeResultFailed) {
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:OCKLocalizedString(@"ERROR_TITLE", nil)
+                                                                                 message:OCKLocalizedString(@"EMAIL_SEND_ERROR", nil)
+                                                                          preferredStyle:UIAlertControllerStyleAlert];
+        [self presentViewController:alertController animated:YES completion:nil];
+    }
 }
 
 #pragma mark - UIViewControllerPreviewingDelegate

--- a/Sample/OCKSample/RootViewController.swift
+++ b/Sample/OCKSample/RootViewController.swift
@@ -233,7 +233,7 @@ extension RootViewController: ORKTaskViewControllerDelegate {
 extension RootViewController: OCKConnectViewControllerDelegate {
     
     /// Called when the user taps a contact in the `OCKConnectViewController`.
-    func connectViewController(connectViewController: OCKConnectViewController, didSelectShareButtonForContact contact: OCKContact, presentationSourceView sourceView: UIView) {
+    func connectViewController(connectViewController: OCKConnectViewController, didSelectShareButtonForContact contact: OCKContact, presentationSourceView sourceView: UIView?) {
         let document = sampleData.generateSampleDocument()
         let activityViewController = UIActivityViewController(activityItems: [document], applicationActivities: nil)
         activityViewController.popoverPresentationController?.sourceView = sourceView

--- a/testing/OCKTest/OCKTest/ConnectTableViewController.swift
+++ b/testing/OCKTest/OCKTest/ConnectTableViewController.swift
@@ -131,7 +131,7 @@ class ConnectTableViewController: UITableViewController, OCKConnectViewControlle
         return nil
     }
     
-    func connectViewController(connectViewController: OCKConnectViewController, didSelectShareButtonForContact contact: OCKContact, presentationSourceView sourceView: UIView) {
+    func connectViewController(connectViewController: OCKConnectViewController, didSelectShareButtonForContact contact: OCKContact, presentationSourceView sourceView: UIView?) {
         
         let bar1 = OCKBarSeries.init(title: "Title 1", values: [6, 5], valueLabels: ["6", "5"], tintColor: UIColor.brownColor())
         let bar2 = OCKBarSeries.init(title: "Title 2", values: [5, 10], valueLabels: ["5", "10"], tintColor: UIColor.blackColor())


### PR DESCRIPTION
This adds peek and pop functionality to `OCKCareCardViewController` and `OCKConnectViewController`. When applying pressure to the table view cells, the peek view will show the respective detail view controller.

`OCKConnectDetailViewController` now leverages preview action items. When peeking into an `OCKConnectDetailViewController` from an `OCKConnectViewController`, swiping up will provide options to call, text, email, or send reports to the contact. Only the available options will be shown.

In order to do this, I added `UIViewControllerPreviewingDelegate` to `OCKCareCardViewController` and `OCKConnectViewController`. I implemented the `previewActionItems` method on `OCKConnectDetailViewController` to show the peek options.

To prevent a weird animation from occurring when applying pressure to the header in the Care Card, I changed `OCKCareCardTableViewHeader`'s superclass to be `UITableViewHeaderFooterView` and made slight modifications to preserve the blurring effect.

I also changed some helper methods to allow presentation of message and mail view controllers from both `OCKConnectViewController` and `OCKConnectDetailViewController`.