### PR TITLE
Fix constraints for 7/day schedule in CareCardCell

### DIFF
--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -250,7 +250,7 @@ static const CGFloat ButtonViewSize = 40.0;
                                             ]];
     }
     
-    int index = (_frequencyButtons.count < 7) ? 0 : 7;
+    int index = (_frequencyButtons.count <= 7) ? 0 : 7;
     for (int i = index; i <_frequencyButtons.count; i++) {
         [_constraints addObjectsFromArray:@[
                                             [NSLayoutConstraint constraintWithItem:_frequencyButtons[i]


### PR DESCRIPTION
If an intervention activity had 7 events scheduled for a single day, the bottom constraints for the event circles weren't being constructed.