### PR TITLE
Public access to table view properties

### DIFF
--- a/CareKit.xcodeproj/project.pbxproj
+++ b/CareKit.xcodeproj/project.pbxproj
@@ -816,11 +816,11 @@
 				TargetAttributes = {
 					8605A5B91C4F04EC00DD65FF = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0810;
 					};
 					8605A5C31C4F04EC00DD65FF = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0810;
 					};
 					86189D081CC06A75006C74F0 = {
 						CreatedOnToolsVersion = 7.3;

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -144,6 +144,11 @@ OCK_CLASS_AVAILABLE
  */
 @property (nonatomic, readonly, nullable) OCKCarePlanEvent *lastSelectedInterventionEvent;
 
+/** 
+ A reference to the `UITableView` contained in the view controller
+ */
+@property (nonatomic, nonnull) UITableView *tableView;
+
 /**
  The image that will be used to mask the fill shape in the header view.
  

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -148,7 +148,7 @@ OCK_CLASS_AVAILABLE
 /** 
  A reference to the `UITableView` contained in the view controller
  */
-@property (nonatomic, nonnull) UITableView *tableView;
+@property (nonatomic, readonly, nonnull) UITableView *tableView;
 
 /**
  The image that will be used to mask the fill shape in the header view.

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
  Copyright (c) 2016, Troy Tsubota. All rights reserved.
+ Copyright (c) 2016, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -55,7 +55,6 @@
 
 
 @implementation OCKCareCardViewController {
-    UITableView *_tableView;
     NSMutableArray<NSMutableArray<OCKCarePlanEvent *> *> *_events;
     NSMutableArray *_weekValues;
     OCKCareCardTableViewHeader *_headerView;

--- a/CareKit/Connect/OCKConnectViewController.h
+++ b/CareKit/Connect/OCKConnectViewController.h
@@ -111,6 +111,11 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, weak, nullable) id<OCKConnectViewControllerDelegate> delegate;
 
 /**
+ A reference to the `UITableView` contained in the view controller
+ */
+@property (nonatomic, nonnull) UITableView *tableView;
+
+/**
  A boolean to show the edge indicators.
  
  The default value is NO.

--- a/CareKit/Connect/OCKConnectViewController.h
+++ b/CareKit/Connect/OCKConnectViewController.h
@@ -114,7 +114,7 @@ OCK_CLASS_AVAILABLE
 /**
  A reference to the `UITableView` contained in the view controller
  */
-@property (nonatomic, nonnull) UITableView *tableView;
+@property (nonatomic, readonly, nonnull) UITableView *tableView;
 
 /**
  A boolean to show the edge indicators.

--- a/CareKit/Connect/OCKConnectViewController.h
+++ b/CareKit/Connect/OCKConnectViewController.h
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
  Copyright (c) 2016, WWT Asynchrony Labs. All rights reserved.
+ Copyright (c) 2016, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/Connect/OCKConnectViewController.m
+++ b/CareKit/Connect/OCKConnectViewController.m
@@ -44,7 +44,6 @@
 
 
 @implementation OCKConnectViewController {
-    UITableView *_tableView;
     NSMutableArray *_constraints;
     NSMutableArray<NSArray<OCKContact *>*> *_sectionedContacts;
     NSMutableArray<NSString *> *_sectionTitles;

--- a/CareKit/Connect/OCKConnectViewController.m
+++ b/CareKit/Connect/OCKConnectViewController.m
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
  Copyright (c) 2016, Troy Tsubota. All rights reserved.
+ Copyright (c) 2016, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -113,6 +113,11 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, readonly, nullable) OCKCarePlanEvent *lastSelectedAssessmentEvent;
 
 /**
+ A reference to the `UITableView` contained in the view controller
+ */
+@property (nonatomic, nonnull) UITableView *tableView;
+
+/**
  The tint color that will be used to fill the ring view.
  
  If the value is not specified, the app's tint color is used.

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -116,7 +116,7 @@ OCK_CLASS_AVAILABLE
 /**
  A reference to the `UITableView` contained in the view controller
  */
-@property (nonatomic, nonnull) UITableView *tableView;
+@property (nonatomic, readonly, nonnull) UITableView *tableView;
 
 /**
  The tint color that will be used to fill the ring view.

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -50,7 +50,6 @@
 
 
 @implementation OCKSymptomTrackerViewController {
-    UITableView *_tableView;
     NSMutableArray<OCKCarePlanEvent *> *_events;
     NSMutableArray *_weekValues;
     OCKSymptomTrackerTableViewHeader *_headerView;

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:


### PR DESCRIPTION
I'm working on a project in which I'd like to add a custom `tableViewHeader` to some of the table views in CareKit, but there is no public accessors currently.

The workaround I'm currently using is to filter subviews for a `UITableView`, but this is not really an ideal solution, so I decided to create a pull request to make the tableView property on `OCKCareCardViewController`, `OCKConnectViewController`, and `OCKSymptomTrackerViewController` available publicly. 