### PR TITLE
Allow custom header title in Care Card and Symptom Tracker

### DIFF
--- a/CareKit/CareCard/OCKCareCardTableViewHeader.h
+++ b/CareKit/CareCard/OCKCareCardTableViewHeader.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) OCKHeartView *heartView;
 
+@property (nonatomic, copy) NSString *title;
+
 @property (nonatomic, copy) NSString *date;
 
 @end

--- a/CareKit/CareCard/OCKCareCardTableViewHeader.m
+++ b/CareKit/CareCard/OCKCareCardTableViewHeader.m
@@ -82,7 +82,6 @@ static const CGFloat HeartViewSize = 110.0;
     if (!_titleLabel) {
         _titleLabel = [OCKLabel new];
         _titleLabel.textStyle = UIFontTextStyleHeadline;
-        _titleLabel.text = OCKLocalizedString(@"CARE_CARD_HEADER_TITLE", nil);
         _titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
         _titleLabel.numberOfLines = 0;
         [self addSubview:_titleLabel];
@@ -120,6 +119,7 @@ static const CGFloat HeartViewSize = 110.0;
 }
 
 - (void)updateView {
+    _titleLabel.text = self.title;
     _dateLabel.text = self.date;
     self.heartView.value = self.value;
     self.heartView.tintColor = self.tintColor;

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -178,7 +178,7 @@ OCK_CLASS_AVAILABLE
  
  If the value is not specified, CareKit's default string ("Care Completion") is used.
  */
-@property (nonatomic, nonnull) NSString *headerTitle;
+@property (nonatomic, null_resettable) NSString *headerTitle;
 
 /**
  A boolean to show the edge indicators.

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -174,6 +174,13 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, null_resettable) UIColor *maskImageTintColor;
 
 /**
+ The string that will be used as the Care Card header title.
+ 
+ If the value is not specified, CareKit's default string ("Care Completion") is used.
+ */
+@property (nonatomic, nonnull) NSString *headerTitle;
+
+/**
  A boolean to show the edge indicators.
  
  The default value is NO.

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -130,6 +130,10 @@
     if (!_headerView) {
         _headerView = [[OCKCareCardTableViewHeader alloc] initWithFrame:CGRectZero];
     }
+    if ([_headerTitle length] == 0) {
+        _headerTitle = OCKLocalizedString(@"CARE_CARD_HEADER_TITLE", nil);
+    }
+    _headerView.title = _headerTitle;
     _headerView.heartView.maskImage = self.maskImage;
     _headerView.tintColor = self.maskImageTintColor;
     
@@ -245,6 +249,15 @@
     _weekViewController.careCardWeekView.tintColor = _maskImageTintColor;
     _headerView.tintColor = _maskImageTintColor;
     self.navigationItem.rightBarButtonItem.tintColor = _maskImageTintColor;
+}
+
+- (void)setHeaderTitle:(NSString *)headerTitle {
+    _headerTitle = headerTitle;
+    if ([_headerTitle length] == 0) {
+        _headerView.title = OCKLocalizedString(@"CARE_CARD_HEADER_TITLE", nil);
+    } else {
+        _headerView.title = _headerTitle;
+    }
 }
 
 - (void)setShowEdgeIndicators:(BOOL)showEdgeIndicators {

--- a/CareKit/SymptomTracker/OCKSymptomTrackerTableViewHeader.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerTableViewHeader.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) OCKRingView *ringView;
 
+@property (nonatomic, copy) NSString *title;
+
 @property (nonatomic, copy) NSString *date;
 
 @end

--- a/CareKit/SymptomTracker/OCKSymptomTrackerTableViewHeader.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerTableViewHeader.m
@@ -80,7 +80,6 @@ static const CGFloat RingViewSize = 110.0;
     if (!_titleLabel) {
         _titleLabel = [OCKLabel new];
         _titleLabel.textStyle = UIFontTextStyleHeadline;
-        _titleLabel.text = OCKLocalizedString(@"SYMPTOM_TRACKER_HEADER_TITLE", nil);
         _titleLabel.numberOfLines = 2;
         [self addSubview:_titleLabel];
     }
@@ -112,6 +111,7 @@ static const CGFloat RingViewSize = 110.0;
 - (void)updateView {
     self.ringView.tintColor = self.tintColor;
     self.ringView.value = self.value;
+    _titleLabel.text = self.title;
     _dateLabel.text = self.date;
 }
 

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -124,7 +124,7 @@ OCK_CLASS_AVAILABLE
  
  If the value is not specified, CareKit's default string ("Activity Completion") is used.
  */
-@property (nonatomic, nonnull) NSString *headerTitle;
+@property (nonatomic, null_resettable) NSString *headerTitle;
 
 /**
  A boolean to show the edge indicators.

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -120,6 +120,13 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, null_resettable) UIColor *progressRingTintColor;
 
 /**
+ The string that will be used as the Symptom Tracker header title.
+ 
+ If the value is not specified, CareKit's default string ("Activity Completion") is used.
+ */
+@property (nonatomic, nonnull) NSString *headerTitle;
+
+/**
  A boolean to show the edge indicators.
  
  The default value is NO.

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -117,6 +117,10 @@
     if (!_headerView) {
         _headerView = [[OCKSymptomTrackerTableViewHeader alloc] initWithFrame:CGRectZero];
     }
+    if ([_headerTitle length] == 0) {
+        _headerTitle = OCKLocalizedString(@"SYMPTOM_TRACKER_HEADER_TITLE", nil);
+    }
+    _headerView.title = _headerTitle;
     _headerView.tintColor = self.progressRingTintColor;
     
     if (!_pageViewController) {
@@ -214,6 +218,15 @@
     _weekViewController.symptomTrackerWeekView.tintColor = _progressRingTintColor;
     _headerView.tintColor = _progressRingTintColor;
     self.navigationItem.rightBarButtonItem.tintColor = _progressRingTintColor;
+}
+
+- (void)setHeaderTitle:(NSString *)headerTitle {
+    _headerTitle = headerTitle;
+    if ([_headerTitle length] == 0) {
+        _headerView.title = OCKLocalizedString(@"SYMPTOM_TRACKER_HEADER_TITLE", nil);
+    } else {
+        _headerView.title = _headerTitle;
+    }
 }
 
 - (void)setShowEdgeIndicators:(BOOL)showEdgeIndicators {


### PR DESCRIPTION
There are use cases that the default header titles for Care Card and Symptom Tracker, i.e. "Care Completion" and "Activity Completion," respectively, cannot provide clear instructions to users. This PR allows customizing the header title by setting the ```headerTitle``` of the corresponding ```OCKCareCardViewController``` or ```OCKSymptomTrackerViewController``` instance.
