### PR TITLE
Avoid calling self.view if view has not been loaded

### DIFF
--- a/CareKit/Connect/OCKConnectViewController.m
+++ b/CareKit/Connect/OCKConnectViewController.m
@@ -194,6 +194,9 @@
 }
 
 - (void)prepareHeaderView {
+    if (![self isViewLoaded]) {
+        return;
+    }
     if (self.contacts.count == 0) {
         if (!_noContactsLabel) {
             _noContactsLabel = [OCKLabel new];


### PR DESCRIPTION
This fixes #34 . Similar issue seems to persist in `OCKWeekViewController`.