### PR TITLE
Custom connect detail view handling

### DIFF
--- a/CareKit.xcodeproj/project.pbxproj
+++ b/CareKit.xcodeproj/project.pbxproj
@@ -60,7 +60,7 @@
 		244A92481CA210F7007B42D6 /* OCKWeekLabelsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 244A92421CA210F7007B42D6 /* OCKWeekLabelsView.m */; };
 		244A92491CA210F7007B42D6 /* OCKWeekViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 244A92431CA210F7007B42D6 /* OCKWeekViewController.h */; };
 		244A924A1CA210F7007B42D6 /* OCKWeekViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 244A92441CA210F7007B42D6 /* OCKWeekViewController.m */; };
-		248929751C90E70100EBBE1F /* OCKConnectDetailViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 248929641C90E70100EBBE1F /* OCKConnectDetailViewController.h */; };
+		248929751C90E70100EBBE1F /* OCKConnectDetailViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 248929641C90E70100EBBE1F /* OCKConnectDetailViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		248929761C90E70100EBBE1F /* OCKConnectDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 248929651C90E70100EBBE1F /* OCKConnectDetailViewController.m */; };
 		248929771C90E70100EBBE1F /* OCKConnectTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 248929661C90E70100EBBE1F /* OCKConnectTableViewCell.h */; };
 		248929781C90E70100EBBE1F /* OCKConnectTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 248929671C90E70100EBBE1F /* OCKConnectTableViewCell.m */; };
@@ -725,6 +725,7 @@
 				241707D51C9A3AB7005D7123 /* OCKInsightsMessageTableViewCell.h in Headers */,
 				242DBA9C1C9F7F8700529386 /* OCKRingView.h in Headers */,
 				5A9D2C931D5E432B00D0F13B /* OCKContactInfo.h in Headers */,
+				248929751C90E70100EBBE1F /* OCKConnectDetailViewController.h in Headers */,
 				24EA9FB81C9A3D420036028E /* OCKCareCardDetailViewController.h in Headers */,
 				8677EE1A1C9775EB00588CD6 /* OCKCarePlanStore_Internal.h in Headers */,
 				2489297D1C90E70100EBBE1F /* OCKConnectViewController.h in Headers */,
@@ -733,7 +734,6 @@
 				24EA9FC21C9A3D420036028E /* OCKCareCardViewController.h in Headers */,
 				8677EE0E1C9775EB00588CD6 /* OCKCarePlanActivity.h in Headers */,
 				248929771C90E70100EBBE1F /* OCKConnectTableViewCell.h in Headers */,
-				248929751C90E70100EBBE1F /* OCKConnectDetailViewController.h in Headers */,
 				242DBA901C9F7F8700529386 /* OCKSymptomTrackerTableViewCell.h in Headers */,
 				24EA9FC71C9A3D420036028E /* OCKHeartButton.h in Headers */,
 				248929801C90E70100EBBE1F /* OCKContact.h in Headers */,

--- a/CareKit/CareKit.h
+++ b/CareKit/CareKit.h
@@ -60,6 +60,7 @@
 #import <CareKit/OCKContactInfo.h>
 #import <CareKit/OCKContact.h>
 #import <CareKit/OCKConnectViewController.h>
+#import <CareKit/OCKConnectDetailViewController.h>
 
 // PDF
 #import <CareKit/OCKDocument.h>

--- a/CareKit/CareKit.h
+++ b/CareKit/CareKit.h
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/Common/OCKTableViewCell.h
+++ b/CareKit/Common/OCKTableViewCell.h
@@ -31,7 +31,6 @@
 
 #import <CareKit/CareKit.h>
 
-
 @interface OCKTableViewCell : UITableViewCell
 
 - (void)prepareView;

--- a/CareKit/Connect/OCKConnectDetailViewController.h
+++ b/CareKit/Connect/OCKConnectDetailViewController.h
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
  Copyright (c) 2016, WWT Asynchrony Labs. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -37,16 +38,45 @@ NS_ASSUME_NONNULL_BEGIN
 @class OCKConnectViewController;
 @protocol OCKConnectViewControllerDelegate, OCKContactInfoTableViewCellDelegate, OCKContactSharingTableViewCellDelegate;
 
+/** 
+ The `OCKConnectDetailViewController` class is a view controller that
+ displays the contact information for a single `OCKContact`. It is typically
+ embedded in a navigation controller as the detail view of a master detail pair.
+ */
+OCK_CLASS_AVAILABLE
 @interface OCKConnectDetailViewController : UITableViewController
 
+/** 
+ Returns an initialized connect detail view controller using the specified contact.
+ 
+ @param contact     An `OCKContact` object.
+ 
+ @return An initialized view controller
+ */
 - (instancetype)initWithContact:(OCKContact *)contact;
 
+/** 
+ The contact whose information will be displayed in the table view.
+ */
 @property (nonatomic) OCKContact *contact;
 
+/** 
+ The delegate is used for the sharing section
+ 
+ See the `OCKConnectViewControllerDelegate` protocol
+ */
 @property (nonatomic, weak, nullable) id<OCKConnectViewControllerDelegate> delegate;
 
+/** 
+ A reference to the master view controller
+ */
 @property (nonatomic, weak) OCKConnectViewController *masterViewController;
 
+/** 
+ A boolean to show the edge indicators.
+ 
+ The default value is NO.
+ */
 @property (nonatomic) BOOL showEdgeIndicator;
 
 @end

--- a/CareKit/Connect/OCKConnectDetailViewController.h
+++ b/CareKit/Connect/OCKConnectDetailViewController.h
@@ -32,15 +32,12 @@
 
 #import <CareKit/CareKit.h>
 #import <MessageUI/MessageUI.h>
-#import "OCKContactInfoTableViewCell.h"
-#import "OCKContactSharingTableViewCell.h"
-
 
 NS_ASSUME_NONNULL_BEGIN
+@class OCKConnectViewController;
+@protocol OCKConnectViewControllerDelegate, OCKContactInfoTableViewCellDelegate, OCKContactSharingTableViewCellDelegate;
 
-@protocol OCKConnectViewControllerDelegate;
-
-@interface OCKConnectDetailViewController : UITableViewController <MFMessageComposeViewControllerDelegate, MFMailComposeViewControllerDelegate, OCKContactInfoTableViewCellDelegate, OCKContactSharingTableViewCellDelegate>
+@interface OCKConnectDetailViewController : UITableViewController
 
 - (instancetype)initWithContact:(OCKContact *)contact;
 

--- a/CareKit/Connect/OCKConnectDetailViewController.m
+++ b/CareKit/Connect/OCKConnectDetailViewController.m
@@ -2,6 +2,7 @@
  Copyright (c) 2016, Apple Inc. All rights reserved.
  Copyright (c) 2016, Troy Tsubota. All rights reserved.
  Copyright (c) 2016, WWT Asynchrony Labs. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/Connect/OCKConnectDetailViewController.m
+++ b/CareKit/Connect/OCKConnectDetailViewController.m
@@ -35,7 +35,11 @@
 #import "OCKConnectTableViewHeader.h"
 #import "OCKDefines_Private.h"
 #import "OCKHelpers.h"
+#import "OCKContactSharingTableViewCell.h"
+#import "OCKContactInfoTableViewCell.h"
 
+@interface OCKConnectDetailViewController () <MFMessageComposeViewControllerDelegate, MFMailComposeViewControllerDelegate, OCKContactInfoTableViewCellDelegate, OCKContactSharingTableViewCellDelegate>
+@end
 
 static const CGFloat HeaderViewHeight = 225.0;
 

--- a/CareKit/Connect/OCKConnectTableViewCell.h
+++ b/CareKit/Connect/OCKConnectTableViewCell.h
@@ -32,7 +32,6 @@
 #import <CareKit/CareKit.h>
 #import "OCKTableViewCell.h"
 
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OCKConnectTableViewCell : OCKTableViewCell

--- a/CareKit/Connect/OCKConnectViewController.h
+++ b/CareKit/Connect/OCKConnectViewController.h
@@ -1,7 +1,7 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
  Copyright (c) 2016, WWT Asynchrony Labs. All rights reserved.
- Copyright (c) 2016, Erik Hornberger. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -80,6 +80,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)connectViewController:(OCKConnectViewController *)connectViewController handleContactInfoSelected:(OCKContactInfo *)contactInfo;
 
+/** 
+ Asks the delegate to handle the selection of the contact. This can be used to provide custom handling or presenting custom
+ views controllers. If the method is not implemented or if it returns NO, then the default `OCKConnecteDetailViewController` 
+ will be displayed as usual.
+ 
+ @param connectViewController       The view controller providing the callback.
+ @param contact                     The `OCKContact` corresponding to the table cell that was selected
+ 
+ @return YES if the contact selection was handled, or NO if default handling should be performed.
+ */
 - (BOOL)connectViewController:(OCKConnectViewController *)connectViewController handleContactSelected:(OCKContact *)contact;
 
 @end

--- a/CareKit/Connect/OCKConnectViewController.h
+++ b/CareKit/Connect/OCKConnectViewController.h
@@ -80,6 +80,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)connectViewController:(OCKConnectViewController *)connectViewController handleContactInfoSelected:(OCKContactInfo *)contactInfo;
 
+- (BOOL)connectViewController:(OCKConnectViewController *)connectViewController handleContactSelected:(OCKContact *)contact;
+
 @end
 
 

--- a/CareKit/Connect/OCKConnectViewController.m
+++ b/CareKit/Connect/OCKConnectViewController.m
@@ -32,6 +32,7 @@
 
 
 #import "OCKConnectViewController.h"
+#import "OCKConnectTableViewCell.h"
 #import "OCKContact.h"
 #import "OCKConnectDetailViewController.h"
 #import "OCKHelpers.h"
@@ -241,7 +242,15 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     OCKContact *contact = [self contactForIndexPath:indexPath];
     
-    [self.navigationController pushViewController:[self detailViewControllerForContact:contact] animated:YES];
+    BOOL handled = NO;
+    if (self.delegate && [self.delegate respondsToSelector:@selector(connectViewController:handleContactSelected:)]) {
+        handled = [self.delegate connectViewController:self handleContactSelected:contact];
+    }
+    
+    if (!handled) {
+        [self.navigationController pushViewController:[self detailViewControllerForContact:contact] animated:YES];
+    }
+    
     
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }

--- a/CareKit/Connect/OCKConnectViewController.m
+++ b/CareKit/Connect/OCKConnectViewController.m
@@ -1,7 +1,7 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
  Copyright (c) 2016, Troy Tsubota. All rights reserved.
- Copyright (c) 2016, Erik Hornberger. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:


### PR DESCRIPTION
This pull request makes two changes. 
- First, it adds a new delegate method to `OCKConnectViewController` that allows for performing custom handling of contact selection events in addition to or in in lieu of the default handling that CareKit currently performs. 
- Second, it exposes `OCKConnectDetailViewController`.

The first change makes it possible to present a custom view controller when a contact is selected, and the second makes it possible for it to be a subclass of `OCKConnectDetailViewController`. The combination of the two is meant to give developers more flexibility while also making it easy to stick with the established CareKit design.

I'm confident that the changes to the code itself are correct, but this was my first time modifying an Objective-C framework, so it'd be wise to go over the changes I made to the headers and project file to make sure they're sound. 