### PR TITLE
Care card button optional image

### DIFF
--- a/CareKit/CareCard/OCKCareCardButton.h
+++ b/CareKit/CareCard/OCKCareCardButton.h
@@ -34,4 +34,6 @@
 
 @interface OCKCareCardButton : UIButton
 
+@property (nonatomic, nullable) UIImage *buttonImage;
+
 @end

--- a/CareKit/CareCard/OCKCareCardButton.h
+++ b/CareKit/CareCard/OCKCareCardButton.h
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -57,7 +57,8 @@ static const CGFloat ButtonSize = 30.0;
     }
     
     if (!_imageView) {
-        _imageView = [[UIImageView alloc] initWithFrame:rect];
+        CGRect imageRect = CGRectMake(0, 0, ButtonSize, ButtonSize);
+        _imageView = [[UIImageView alloc] initWithFrame:imageRect];
         _imageView.contentMode = UIViewContentModeScaleAspectFit;
         [self updateImageForSelection:self.isSelected];
         [self addSubview:_imageView];

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -37,6 +37,7 @@ static const CGFloat ButtonSize = 30.0;
 
 @implementation OCKCareCardButton {
     CAShapeLayer *_circleLayer;
+    UIImageView *_imageView;
 }
 
 - (void)drawRect:(CGRect)rect {
@@ -53,20 +54,33 @@ static const CGFloat ButtonSize = 30.0;
         [[UIColor clearColor] setFill];
         UIRectFill(_circleLayer.frame);
     }
+    
+    if (!_imageView) {
+        _imageView = [[UIImageView alloc] initWithFrame:rect];
+        _imageView.contentMode = UIViewContentModeScaleAspectFit;
+        [self updateImageForSelection:self.isSelected];
+        [self addSubview:_imageView];
+    }
 }
 
 - (void)setHighlighted:(BOOL)highlighted {
     [self updateFillColorForSelection:highlighted];
+    [self updateImageForSelection:highlighted];
     [super setHighlighted:highlighted];
 }
 
 - (void)setSelected:(BOOL)selected {
     [self updateFillColorForSelection:selected];
+    [self updateImageForSelection:selected];
     [super setSelected:selected];
 }
 
 - (void)updateFillColorForSelection:(BOOL)selection {
     _circleLayer.fillColor = (selection) ? self.tintColor.CGColor : [UIColor whiteColor].CGColor;
+}
+
+- (void)updateImageForSelection:(BOOL)selection {
+    [_imageView setImage: selection ? self.buttonImage : NULL];
 }
 
 @end

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2018, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardTableViewCell.h
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.h
@@ -50,6 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy) NSArray<OCKCarePlanEvent *> *interventionEvents;
 
+@property (nonatomic, nullable) UIImage *buttonImage;
+
 @property (nonatomic, weak) id<OCKCareCardCellDelegate> delegate;
 
 @end

--- a/CareKit/CareCard/OCKCareCardTableViewCell.h
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.h
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -286,6 +286,13 @@ static const CGFloat ButtonViewSize = 40.0;
     
 }
 
+-(void)setButtonImage:(UIImage *)buttonImage {
+    _buttonImage = buttonImage;
+    for (int k=0; k<_frequencyButtons.count; k++) {
+        _frequencyButtons[k].buttonImage = self.buttonImage;
+    }
+}
+
 
 #pragma mark - Accessibility
 

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -193,6 +193,13 @@ OCK_CLASS_AVAILABLE
  */
 @property (nonatomic) BOOL showEdgeIndicators;
 
+/** 
+ An image to be displayed on top of the circular `OCKCareCardButton`s in each
+ intervention items's table view cell.
+ 
+ If no image is provided, no image will be displayed and the button will simply
+ fill with a solid color when selected.
+ */
 @property (nonatomic, nullable) UIImage *buttonImage;
 @end
 

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -193,6 +193,7 @@ OCK_CLASS_AVAILABLE
  */
 @property (nonatomic) BOOL showEdgeIndicators;
 
+@property (nonatomic, nullable) UIImage *buttonImage;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -440,6 +440,7 @@
                 OCKCareCardTableViewCell *cell = [_tableView cellForRowAtIndexPath:indexPath];
                 cell.interventionEvents = events;
                 cell.showEdgeIndicator = cell.showEdgeIndicator;
+                cell.buttonImage = self.buttonImage;
             }
             break;
         }
@@ -527,6 +528,7 @@
     cell.interventionEvents = _events[indexPath.row];
     cell.delegate = self;
     cell.showEdgeIndicator = self.showEdgeIndicators;
+    cell.buttonImage = self.buttonImage;
     return cell;
 }
 


### PR DESCRIPTION
This PR adds a `buttonImage` property to `OCKCareCardViewController`. Setting this optional property populates an image view on the contained `OCKCareCardButton`s. The image is not displayed when the buttons are unchecked, or if the `buttonImage` property is left nil. 

<img src="https://cloud.githubusercontent.com/assets/22581112/25564209/2121ab76-2de9-11e7-91fc-c15ce3a6f5b4.png" width="250">

Under the hood, setting `buttonImage` passes the image to a similarly named property in all instances of `OCKCareCardTableViewCell`, which in turn passes it down to all instances of `OCKCareCardButton`, where it is added to an image view.