### PR TITLE
Directory URL Fix and Podspec Bump

### DIFF
--- a/CareKit.podspec
+++ b/CareKit.podspec
@@ -34,7 +34,7 @@
 
 Pod::Spec.new do |s|
   s.name                  = 'CareKit'
-  s.version               = '1.1.1'
+  s.version               = '1.2.0'
   s.summary               = 'CareKit is an open source software framework for creating apps that help people better understand and manage their health.'
   s.homepage              = 'https://github.com/carekit-apple/CareKit/'
   s.documentation_url     = 'http://carekit.org/docs/'

--- a/CareKit/CarePlan/OCKCarePlanStore.m
+++ b/CareKit/CarePlan/OCKCarePlanStore.m
@@ -125,6 +125,10 @@ static NSString * const OCKAttributeNameDayIndex = @"numberOfDaysSinceStart";
     return [_persistenceDirectoryURL.path stringByAppendingPathComponent:CoreDataFileName];
 }
 
+- (NSURL *)directoryURL {
+    return _persistenceDirectoryURL;
+}
+
 
 #pragma mark - generic coredata operations
 


### PR DESCRIPTION
Congrats on the release 🎉 🎊 🎉 - looks super exciting! 💯 

A few small things I noticed:

 * The `directoryURL` property on `OCKCarePlanStore` did not have a getter implementation
 * The version listed in the podspec had not been bumped to line up with the Xcode version

Let me know if you'd prefer 2 PRs. And congrats again!