### PR TITLE
Synchronize Lazy Instantiation of Schedule Calendar

### DIFF
--- a/CareKit/CarePlan/OCKCareSchedule.m
+++ b/CareKit/CarePlan/OCKCareSchedule.m
@@ -199,9 +199,11 @@
 }
 
 - (NSCalendar *)UTC_calendar {
-    if (!_calendar) {
-        _calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-        _calendar.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+    @synchronized (self) {
+        if (!_calendar) {
+            _calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+            _calendar.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+        }
     }
     return _calendar;
 }


### PR DESCRIPTION
The `UTC_calendar` property on `OCKCareSchedule` is initialized
and configured lazily on first access inside a getter. This operation
is not atomic. Because the framework may call schedule methods on
different threads (for example, some operations are on
the OCKCarePlan serial), this can create a race condition.

To resolve this issue, we synchronizing the lazy initialization on
the instance itself. This resolved crashes we'd been seeing related
to this property.