### PR TITLE
Fix for issue 177 - OCKInsightsTableViewHeaderView conflicting constraints

### DIFF
--- a/CareKit/Insights/OCKInsightsTableViewHeaderView.m
+++ b/CareKit/Insights/OCKInsightsTableViewHeaderView.m
@@ -37,7 +37,7 @@
 
 @implementation OCKInsightsTableViewHeaderView {
     UIStackView *_stackView;
-    NSMutableArray *_constraints;
+    NSMutableArray <NSLayoutConstraint *> *_constraints;
     NSMutableArray <OCKPatientWidgetView *> *_widgetViews;
     NSNumberFormatter *_numberFormatter;
 }
@@ -132,6 +132,7 @@
                                                                     multiplier:1.0
                                                                       constant:90.0]
                                         ]];
+    _constraints.lastObject.priority = 999;
     
     [NSLayoutConstraint activateConstraints:_constraints];
 }


### PR DESCRIPTION
Fix for #177 - reduce the priority of OCKInsightsTableViewHeaderView's internal height constraint to 999, so any owner of this header view can set its height with higher priority.