### PR TITLE
Implement getter method for the directoryURL property on OCKCarePlanStore

### DIFF
--- a/CareKit/CarePlan/OCKCarePlanStore.m
+++ b/CareKit/CarePlan/OCKCarePlanStore.m
@@ -125,6 +125,10 @@ static NSString * const OCKAttributeNameDayIndex = @"numberOfDaysSinceStart";
     return [_persistenceDirectoryURL.path stringByAppendingPathComponent:CoreDataFileName];
 }
 
+- (NSURL *)directoryURL {
+    return _persistenceDirectoryURL;
+}
+
 
 #pragma mark - generic coredata operations
 


### PR DESCRIPTION
Property was simply not wired to it's ivar.