### PR TITLE
Fix for displaying custom headerTitle when set

### DIFF
--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -136,10 +136,9 @@
         _headerView = [[OCKHeaderView alloc] initWithFrame:CGRectZero];
         [self.view addSubview:_headerView];
     }
-    if ([_headerTitle length] == 0) {
-        _headerTitle = OCKLocalizedString(@"CARE_CARD_HEADER_TITLE", nil);
+    if ([_headerTitle length] > 0) {
+        _headerView.title = _headerTitle;
     }
-    _headerView.title = _headerTitle;
     _headerView.tintColor = self.glyphTintColor;
     if (self.glyphType == OCKGlyphTypeCustom) {
         UIImage *glyphImage = [self createCustomImageName:self.customGlyphImageName];
@@ -305,9 +304,7 @@
 
 - (void)setHeaderTitle:(NSString *)headerTitle {
     _headerTitle = headerTitle;
-    if ([_headerTitle length] == 0) {
-        _headerView.title = OCKLocalizedString(@"CARE_CARD_HEADER_TITLE", nil);
-    } else {
+    if ([_headerTitle length] > 0) {
         _headerView.title = _headerTitle;
     }
 }

--- a/CareKit/Common/OCKHeaderView.m
+++ b/CareKit/Common/OCKHeaderView.m
@@ -101,7 +101,9 @@ static const CGFloat RingViewSize = 110.0;
 }
 
 - (void)updateView {
-    if (self.isCareCard) {
+    if (self.title.length > 0) {
+        _titleLabel.text = self.title;
+    } else if (self.isCareCard) {
         _titleLabel.text = [NSString stringWithFormat:OCKLocalizedString(@"HEADER_TITLE_CARE_OVERVIEW", nil), [self valuePercentageString]];
     } else {
         _titleLabel.text = [NSString stringWithFormat:OCKLocalizedString(@"HEADER_TITLE_ACTIVITY_STATUS", nil), [self valuePercentageString]];

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -141,10 +141,9 @@
         UIImage *glyphImage = [self createCustomImageName:self.customGlyphImageName];
         _headerView.glyphImage = glyphImage;
     }
-    if ([_headerTitle length] == 0) {
-        _headerTitle = OCKLocalizedString(@"SYMPTOM_TRACKER_HEADER_TITLE", nil);
+    if ([_headerTitle length] > 0) {
+        _headerView.title = _headerTitle;
     }
-    _headerView.title = _headerTitle;
     _headerView.isCareCard = NO;
     _headerView.glyphType = self.glyphType;
  
@@ -305,9 +304,7 @@
 
 - (void)setHeaderTitle:(NSString *)headerTitle {
     _headerTitle = headerTitle;
-    if ([_headerTitle length] == 0) {
-        _headerView.title = OCKLocalizedString(@"SYMPTOM_TRACKER_HEADER_TITLE", nil);
-    } else {
+    if ([_headerTitle length] > 0) {
         _headerView.title = _headerTitle;
     }
 }


### PR DESCRIPTION
This addresses issue #182.

Starting in CK 1.2 the following localization strings are no longer used:

- CARE_CARD_HEADER_TITLE
- SYMPTOM_TRACKER_HEADER_TITLE

They have now been replaced by the following:

- HEADER_TITLE_CARE_OVERVIEW
- HEADER_TITLE_ACTIVITY_STATUS
