### PR TITLE
Optional empty message

### DIFF
--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -204,6 +204,14 @@ OCK_CLASS_AVAILABLE
  */
 @property (nonatomic, copy) NSString *customGlyphImageName;
 
+/** 
+ A message that will be displayed in the table view's background view if there are
+ no intervention activities to display.
+ 
+ If the value is not specified, nothing will be shown when the table is empty.
+ */
+@property (nonatomic, nullable) NSString *noEventsText;
+
 /**
  The property that allows activities to be grouped.
  

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -210,7 +210,7 @@ OCK_CLASS_AVAILABLE
  
  If the value is not specified, nothing will be shown when the table is empty.
  */
-@property (nonatomic, nullable) NSString *noEventsText;
+@property (nonatomic, nullable) NSString *noActivitiesText;
 
 /**
  The property that allows activities to be grouped.

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -36,6 +36,7 @@
 #import "OCKWeekViewController.h"
 #import "NSDateComponents+CarePlanInternal.h"
 #import "OCKHeaderView.h"
+#import "OCKLabel.h"
 #import "OCKCareCardTableViewCell.h"
 #import "OCKWeekLabelsView.h"
 #import "OCKCarePlanStore_Internal.h"
@@ -69,6 +70,7 @@
     BOOL _isGrouped;
     BOOL _isSorted;
     UIRefreshControl *_refreshControl;
+    OCKLabel *_noDataLabel;
 }
 
 - (instancetype)init {
@@ -124,6 +126,15 @@
     [_refreshControl addTarget:self action:@selector(didActivatePullToRefreshControl:) forControlEvents:UIControlEventValueChanged];
     _tableView.refreshControl = _refreshControl;
     [self updatePullToRefreshControl];
+    
+    _noDataLabel = [OCKLabel new];
+    _noDataLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    _noDataLabel.textStyle = UIFontTextStyleTitle2;
+    _noDataLabel.textColor = [UIColor lightGrayColor];
+    _noDataLabel.text = self.noEventsText;
+    _noDataLabel.textAlignment = NSTextAlignmentCenter;
+    _noDataLabel.numberOfLines = 0;
+    _tableView.backgroundView = _noDataLabel;
     
     self.navigationController.navigationBar.translucent = NO;
     [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
@@ -347,6 +358,12 @@
     }
 }
 
+- (void)setNoEventsText:(NSString *)noEventsText {
+    _noEventsText = noEventsText;
+    _noDataLabel.text = noEventsText;
+}
+
+
 #pragma mark - Helpers
 
 - (void)fetchEvents {
@@ -365,6 +382,7 @@
                               [self.delegate careCardViewController:self willDisplayEvents:[_events copy] dateComponents:_selectedDate];
                           }
                           
+                          _noDataLabel.hidden = (_events.count > 0);
                           [self createGroupedEventDictionaryForEvents:_events];
                           
                           [self updateHeaderView];

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -70,7 +70,7 @@
     BOOL _isGrouped;
     BOOL _isSorted;
     UIRefreshControl *_refreshControl;
-    OCKLabel *_noDataLabel;
+    OCKLabel *_noActivitiesLabel;
 }
 
 - (instancetype)init {
@@ -127,15 +127,15 @@
     _tableView.refreshControl = _refreshControl;
     [self updatePullToRefreshControl];
     
-    _noDataLabel = [OCKLabel new];
-    _noDataLabel.hidden = YES;
-    _noDataLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    _noDataLabel.textStyle = UIFontTextStyleTitle2;
-    _noDataLabel.textColor = [UIColor lightGrayColor];
-    _noDataLabel.text = self.noEventsText;
-    _noDataLabel.textAlignment = NSTextAlignmentCenter;
-    _noDataLabel.numberOfLines = 0;
-    _tableView.backgroundView = _noDataLabel;
+    _noActivitiesLabel = [OCKLabel new];
+    _noActivitiesLabel.hidden = YES;
+    _noActivitiesLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    _noActivitiesLabel.textStyle = UIFontTextStyleTitle2;
+    _noActivitiesLabel.textColor = [UIColor lightGrayColor];
+    _noActivitiesLabel.text = self.noActivitiesText;
+    _noActivitiesLabel.textAlignment = NSTextAlignmentCenter;
+    _noActivitiesLabel.numberOfLines = 0;
+    _tableView.backgroundView = _noActivitiesLabel;
     
     self.navigationController.navigationBar.translucent = NO;
     [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
@@ -359,11 +359,10 @@
     }
 }
 
-- (void)setNoEventsText:(NSString *)noEventsText {
-    _noEventsText = noEventsText;
-    _noDataLabel.text = noEventsText;
+- (void)setNoActivitiesText:(NSString *)noActivitiesText {
+    _noActivitiesText = noActivitiesText;
+    _noActivitiesLabel.text = noActivitiesText;
 }
-
 
 #pragma mark - Helpers
 
@@ -383,7 +382,7 @@
                               [self.delegate careCardViewController:self willDisplayEvents:[_events copy] dateComponents:_selectedDate];
                           }
                           
-                          _noDataLabel.hidden = (_events.count > 0);
+                          _noActivitiesLabel.hidden = (_events.count > 0);
                           [self createGroupedEventDictionaryForEvents:_events];
                           
                           [self updateHeaderView];

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -128,6 +128,7 @@
     [self updatePullToRefreshControl];
     
     _noDataLabel = [OCKLabel new];
+    _noDataLabel.hidden = YES;
     _noDataLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     _noDataLabel.textStyle = UIFontTextStyleTitle2;
     _noDataLabel.textColor = [UIColor lightGrayColor];

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -187,30 +187,6 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, readonly, nullable) OCKCarePlanEvent *lastSelectedEvent;
 
 /**
- Indicates if any `OCKCarePlanEvents` of the type `OCKCarePlanActivityTypeIntervention`
- are currently being displayed.
- 
- This value is false to begin and gets updated each time the store is queried.
- */
-@property (nonatomic, readonly) BOOL hasInterventions;
-
-/**
- Indicates if any `OCKCarePlanEvents` of the type `OCKCarePlanActivityTypeAssessment`
- are currently being displayed.
- 
- This value is false to begin and get updated each time the store is queried.
- */
-@property (nonatomic, readonly) BOOL hasAssesments;
-
-/**
- Indicates if any `OCKCarePlanEvents` of the type `OCKCarePlanActivityTypeReadOnly`
- are currently being displayed.
- 
- This value is false to begin and gets updated each time the store is queried.
- */
-@property (nonatomic, readonly) BOOL hasReadOnlyItems;
-
-/**
  The image that will be used to mask the fill shape in the week view.
  
  In order to provide a custom maskImage, you must have a regular size and small size.
@@ -257,7 +233,7 @@ OCK_CLASS_AVAILABLE
  Optional: A message that will be displayed in the table view's background view
  if there are no interventions, assessments, or ReadOnly activities to display.
  */
-@property (nonatomic, nullable) NSString *noEventsText;
+@property (nonatomic, nullable) NSString *noActivitiesText;
 
 /**
  The property that allows activities to be grouped.

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -254,10 +254,8 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, nullable) NSString *readOnlySectionHeader;
 
 /**
- A message that will be displayed in the table view's background view if there are
- no intervention activities to display.
- 
- If the value is not specified, nothing will be shown when the table is empty.
+ Optional: A message that will be displayed in the table view's background view
+ if there are no interventions, assessments, or ReadOnly activities to display.
  */
 @property (nonatomic, nullable) NSString *noEventsText;
 

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2017, Apple Inc. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -228,6 +229,14 @@ OCK_CLASS_AVAILABLE
  The section header title for all the ReadOnly activities. Default is `Read Only` if nil.
  */
 @property (nonatomic, nullable) NSString *readOnlySectionHeader;
+
+/**
+ A message that will be displayed in the table view's background view if there are
+ no intervention activities to display.
+ 
+ If the value is not specified, nothing will be shown when the table is empty.
+ */
+@property (nonatomic, nullable) NSString *noEventsText;
 
 /**
  The property that allows activities to be grouped.

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -186,6 +186,29 @@ OCK_CLASS_AVAILABLE
  */
 @property (nonatomic, readonly, nullable) OCKCarePlanEvent *lastSelectedEvent;
 
+/**
+ Indicates if any `OCKCarePlanEvents` of the type `OCKCarePlanActivityTypeIntervention`
+ are currently being displayed.
+ 
+ This value is false to begin and gets updated each time the store is queried.
+ */
+@property (nonatomic, readonly) BOOL hasInterventions;
+
+/**
+ Indicates if any `OCKCarePlanEvents` of the type `OCKCarePlanActivityTypeAssessment`
+ are currently being displayed.
+ 
+ This value is false to begin and get updated each time the store is queried.
+ */
+@property (nonatomic, readonly) BOOL hasAssesments;
+
+/**
+ Indicates if any `OCKCarePlanEvents` of the type `OCKCarePlanActivityTypeReadOnly`
+ are currently being displayed.
+ 
+ This value is false to begin and gets updated each time the store is queried.
+ */
+@property (nonatomic, readonly) BOOL hasReadOnlyItems;
 
 /**
  The image that will be used to mask the fill shape in the week view.

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -92,6 +92,9 @@
         _glyphTintColor = nil;
         _isGrouped = YES;
         _isSorted = YES;
+        _hasInterventions = NO;
+        _hasAssesments = NO;
+        _hasReadOnlyItems = NO;
     }
     return self;
 }
@@ -398,7 +401,24 @@
                               [self updateHeaderView];
                               [self updateWeekView];
                           }
-                          _noDataLabel.hidden = _events.count > 0;
+                          
+                          switch (type) {
+                              case OCKCarePlanActivityTypeIntervention:
+                                  _hasInterventions = _events.count > 0;
+                                  break;
+                                  
+                              case OCKCarePlanActivityTypeAssessment:
+                                  _hasAssesments = _events.count > 0;
+                                  break;
+                                  
+                              case OCKCarePlanActivityTypeReadOnly:
+                                  _hasReadOnlyItems = _events.count > 0;
+                                  break;
+                                  
+                              default:
+                                  break;
+                          }
+                          _noDataLabel.hidden = _hasAssesments || _hasInterventions || _hasReadOnlyItems;
                           [_tableView reloadData];
                       });
                   }];

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -142,6 +142,7 @@
     [self updatePullToRefreshControl];
     
     _noDataLabel = [OCKLabel new];
+    _noDataLabel.hidden = YES;
     _noDataLabel.textStyle = UIFontTextStyleTitle2;
     _noDataLabel.textColor = [UIColor lightGrayColor];
     _noDataLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -60,7 +60,7 @@
 @implementation OCKCareContentsViewController {
     UITableView *_tableView;
     UIRefreshControl *_refreshControl;
-    OCKLabel *_noDataLabel;
+    OCKLabel *_noActivitiesLabel;
     NSMutableArray<NSMutableArray<OCKCarePlanEvent *> *> *_events;
     NSMutableArray *_weekValues;
     OCKHeaderView *_headerView;
@@ -71,6 +71,10 @@
     NSMutableArray *_sectionTitles;
     NSMutableArray<NSMutableArray <NSMutableArray <OCKCarePlanEvent *> *> *> *_tableViewData;
     NSMutableDictionary *_allEvents;
+    
+    BOOL _hasInterventions;
+    BOOL _hasAssessments;
+    BOOL _hasReadOnlyItems;
     
     NSString *_otherString;
     NSString *_optionalString;
@@ -92,9 +96,6 @@
         _glyphTintColor = nil;
         _isGrouped = YES;
         _isSorted = YES;
-        _hasInterventions = NO;
-        _hasAssesments = NO;
-        _hasReadOnlyItems = NO;
     }
     return self;
 }
@@ -144,15 +145,15 @@
     _tableView.refreshControl = _refreshControl;
     [self updatePullToRefreshControl];
     
-    _noDataLabel = [OCKLabel new];
-    _noDataLabel.hidden = YES;
-    _noDataLabel.textStyle = UIFontTextStyleTitle2;
-    _noDataLabel.textColor = [UIColor lightGrayColor];
-    _noDataLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    _noDataLabel.text = self.noEventsText;
-    _noDataLabel.numberOfLines = 0;
-    _noDataLabel.textAlignment = NSTextAlignmentCenter;
-    _tableView.backgroundView = _noDataLabel;
+    _noActivitiesLabel = [OCKLabel new];
+    _noActivitiesLabel.hidden = YES;
+    _noActivitiesLabel.textStyle = UIFontTextStyleTitle2;
+    _noActivitiesLabel.textColor = [UIColor lightGrayColor];
+    _noActivitiesLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    _noActivitiesLabel.text = self.noActivitiesText;
+    _noActivitiesLabel.numberOfLines = 0;
+    _noActivitiesLabel.textAlignment = NSTextAlignmentCenter;
+    _tableView.backgroundView = _noActivitiesLabel;
     
     self.navigationController.navigationBar.translucent = NO;
     [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
@@ -365,9 +366,10 @@
         [self updatePullToRefreshControl];
     }
 }
-- (void)setNoEventsText:(NSString *)noEventsText {
-    _noEventsText = noEventsText;
-    _noDataLabel.text = noEventsText;
+
+- (void)setNoActivitiesText:(NSString *)noActivitiesText {
+    _noActivitiesText = noActivitiesText;
+    _noActivitiesLabel.text = noActivitiesText;
 }
 
 #pragma mark - Helpers
@@ -408,7 +410,7 @@
                                   break;
                                   
                               case OCKCarePlanActivityTypeAssessment:
-                                  _hasAssesments = _events.count > 0;
+                                  _hasAssessments = _events.count > 0;
                                   break;
                                   
                               case OCKCarePlanActivityTypeReadOnly:
@@ -418,7 +420,7 @@
                               default:
                                   break;
                           }
-                          _noDataLabel.hidden = _hasAssesments || _hasInterventions || _hasReadOnlyItems;
+                          _noActivitiesLabel.hidden = _hasAssessments || _hasInterventions || _hasReadOnlyItems;
                           [_tableView reloadData];
                       });
                   }];

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2017, Apple Inc. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -35,6 +36,7 @@
 #import "OCKWeekViewController.h"
 #import "NSDateComponents+CarePlanInternal.h"
 #import "OCKHeaderView.h"
+#import "OCKLabel.h"
 #import "OCKCareCardTableViewCell.h"
 #import "OCKSymptomTrackerTableViewCell.h"
 #import "OCKReadOnlyTableViewCell.h"
@@ -58,6 +60,7 @@
 @implementation OCKCareContentsViewController {
     UITableView *_tableView;
     UIRefreshControl *_refreshControl;
+    OCKLabel *_noDataLabel;
     NSMutableArray<NSMutableArray<OCKCarePlanEvent *> *> *_events;
     NSMutableArray *_weekValues;
     OCKHeaderView *_headerView;
@@ -137,6 +140,15 @@
     [_refreshControl addTarget:self action:@selector(didActivatePullToRefreshControl:) forControlEvents:UIControlEventValueChanged];
     _tableView.refreshControl = _refreshControl;
     [self updatePullToRefreshControl];
+    
+    _noDataLabel = [OCKLabel new];
+    _noDataLabel.textStyle = UIFontTextStyleTitle2;
+    _noDataLabel.textColor = [UIColor lightGrayColor];
+    _noDataLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    _noDataLabel.text = self.noEventsText;
+    _noDataLabel.numberOfLines = 0;
+    _noDataLabel.textAlignment = NSTextAlignmentCenter;
+    _tableView.backgroundView = _noDataLabel;
     
     self.navigationController.navigationBar.translucent = NO;
     [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
@@ -349,6 +361,10 @@
         [self updatePullToRefreshControl];
     }
 }
+- (void)setNoEventsText:(NSString *)noEventsText {
+    _noEventsText = noEventsText;
+    _noDataLabel.text = noEventsText;
+}
 
 #pragma mark - Helpers
 
@@ -381,6 +397,7 @@
                               [self updateHeaderView];
                               [self updateWeekView];
                           }
+                          _noDataLabel.hidden = _events.count > 0;
                           [_tableView reloadData];
                       });
                   }];

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -167,6 +167,14 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic) NSString *customGlyphImageName;
 
 /**
+ A message that will be displayed in the table view's background view if there are
+ no intervention activities to display.
+ 
+ If the value is not specified, nothing will be shown when the table is empty.
+ */
+@property (nonatomic, nullable) NSString *noEventsText;
+
+/**
  The property that allows activities to be grouped.
  
  If true, the activities will be grouped by groupIdentifier into sections,

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -168,9 +168,9 @@ OCK_CLASS_AVAILABLE
 
 /**
  Optional: A message that will be displayed in the table view's background view
- if there are no interventions, assessments, or ReadOnly activities to display.
+ if there are no assessments to display.
  */
-@property (nonatomic, nullable) NSString *noEventsText;
+@property (nonatomic, nullable) NSString *noActivitiesText;
 
 /**
  The property that allows activities to be grouped.

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -167,10 +167,8 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic) NSString *customGlyphImageName;
 
 /**
- A message that will be displayed in the table view's background view if there are
- no intervention activities to display.
- 
- If the value is not specified, nothing will be shown when the table is empty.
+ Optional: A message that will be displayed in the table view's background view
+ if there are no interventions, assessments, or ReadOnly activities to display.
  */
 @property (nonatomic, nullable) NSString *noEventsText;
 

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -120,6 +120,7 @@
     _tableView.estimatedSectionFooterHeight = 0;
     
     _noDataLabel = [OCKLabel new];
+    _noDataLabel.hidden = YES;
     _noDataLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     _noDataLabel.textStyle = UIFontTextStyleTitle2;
     _noDataLabel.textColor = [UIColor lightGrayColor];

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -381,7 +381,7 @@
                               [self.delegate symptomTrackerViewController:self willDisplayEvents:[_events copy] dateComponents:_selectedDate];
                           }
                           
-                          _noDataLabel.hidden = (_events > 0);
+                          _noDataLabel.hidden = (_events.count > 0);
                           [self createGroupedEventDictionaryForEvents:_events];
                           
                           [self updateHeaderView];

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -65,7 +65,7 @@
     NSMutableArray<NSMutableArray <NSMutableArray <OCKCarePlanEvent *> *> *> *_tableViewData;
     NSString *_otherString;
     NSString *_optionalString;
-    OCKLabel *_noDataLabel;
+    OCKLabel *_noActivitiesLabel;
     BOOL _isGrouped;
     BOOL _isSorted;
 }
@@ -119,15 +119,15 @@
     _tableView.estimatedSectionHeaderHeight = 0;
     _tableView.estimatedSectionFooterHeight = 0;
     
-    _noDataLabel = [OCKLabel new];
-    _noDataLabel.hidden = YES;
-    _noDataLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    _noDataLabel.textStyle = UIFontTextStyleTitle2;
-    _noDataLabel.textColor = [UIColor lightGrayColor];
-    _noDataLabel.textAlignment = NSTextAlignmentCenter;
-    _noDataLabel.numberOfLines = 0;
-    _noDataLabel.text = self.noEventsText;
-    _tableView.backgroundView = _noDataLabel;
+    _noActivitiesLabel = [OCKLabel new];
+    _noActivitiesLabel.hidden = YES;
+    _noActivitiesLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    _noActivitiesLabel.textStyle = UIFontTextStyleTitle2;
+    _noActivitiesLabel.textColor = [UIColor lightGrayColor];
+    _noActivitiesLabel.textAlignment = NSTextAlignmentCenter;
+    _noActivitiesLabel.numberOfLines = 0;
+    _noActivitiesLabel.text = self.noActivitiesText;
+    _tableView.backgroundView = _noActivitiesLabel;
     
     _refreshControl = [[UIRefreshControl alloc] init];
     _refreshControl.tintColor = [UIColor grayColor];
@@ -358,11 +358,10 @@
     }
 }
 
-- (void)setNoEventsText:(NSString *)noEventsText {
-    _noEventsText = noEventsText;
-    _noDataLabel.text = noEventsText;
+- (void)setNoActivitiesText:(NSString *)noActivitiesText {
+    _noActivitiesText = noActivitiesText;
+    _noActivitiesLabel.text = noActivitiesText;
 }
-
 
 #pragma mark - Helpers
 
@@ -382,7 +381,7 @@
                               [self.delegate symptomTrackerViewController:self willDisplayEvents:[_events copy] dateComponents:_selectedDate];
                           }
                           
-                          _noDataLabel.hidden = (_events.count > 0);
+                          _noActivitiesLabel.hidden = (_events.count > 0);
                           [self createGroupedEventDictionaryForEvents:_events];
                           
                           [self updateHeaderView];

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -35,6 +35,7 @@
 #import "NSDateComponents+CarePlanInternal.h"
 #import "OCKWeekView.h"
 #import "OCKHeaderView.h"
+#import "OCKLabel.h"
 #import "OCKSymptomTrackerTableViewCell.h"
 #import "OCKWeekLabelsView.h"
 #import "OCKCarePlanStore_Internal.h"
@@ -64,6 +65,7 @@
     NSMutableArray<NSMutableArray <NSMutableArray <OCKCarePlanEvent *> *> *> *_tableViewData;
     NSString *_otherString;
     NSString *_optionalString;
+    OCKLabel *_noDataLabel;
     BOOL _isGrouped;
     BOOL _isSorted;
 }
@@ -116,6 +118,15 @@
     _tableView.tableFooterView = [UIView new];
     _tableView.estimatedSectionHeaderHeight = 0;
     _tableView.estimatedSectionFooterHeight = 0;
+    
+    _noDataLabel = [OCKLabel new];
+    _noDataLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    _noDataLabel.textStyle = UIFontTextStyleTitle2;
+    _noDataLabel.textColor = [UIColor lightGrayColor];
+    _noDataLabel.textAlignment = NSTextAlignmentCenter;
+    _noDataLabel.numberOfLines = 0;
+    _noDataLabel.text = self.noEventsText;
+    _tableView.backgroundView = _noDataLabel;
     
     _refreshControl = [[UIRefreshControl alloc] init];
     _refreshControl.tintColor = [UIColor grayColor];
@@ -346,6 +357,12 @@
     }
 }
 
+- (void)setNoEventsText:(NSString *)noEventsText {
+    _noEventsText = noEventsText;
+    _noDataLabel.text = noEventsText;
+}
+
+
 #pragma mark - Helpers
 
 - (void)fetchEvents {
@@ -364,6 +381,7 @@
                               [self.delegate symptomTrackerViewController:self willDisplayEvents:[_events copy] dateComponents:_selectedDate];
                           }
                           
+                          _noDataLabel.hidden = (_events > 0);
                           [self createGroupedEventDictionaryForEvents:_events];
                           
                           [self updateHeaderView];
@@ -371,6 +389,7 @@
                           [_tableView reloadData];
                       });
                   }];
+                      
 }
 
 - (void)updateHeaderView {

--- a/Sample/OCKSample/RootViewController.swift
+++ b/Sample/OCKSample/RootViewController.swift
@@ -120,7 +120,7 @@ class RootViewController: UITabBarController {
         let viewController = OCKCareContentsViewController(carePlanStore: storeManager.store)
         viewController.title = NSLocalizedString("Care Contents", comment: "")
         viewController.tabBarItem = UITabBarItem(title: viewController.title, image: UIImage(named:"carecard"), selectedImage: UIImage(named: "carecard-filled"))
-        viewController.noEventsText = "No events to show yet!";
+        viewController.noActivitiesText = NSLocalizedString("There are no activities to show!", comment: "")
         viewController.delegate = self;
         return viewController
 

--- a/Sample/OCKSample/RootViewController.swift
+++ b/Sample/OCKSample/RootViewController.swift
@@ -120,6 +120,7 @@ class RootViewController: UITabBarController {
         let viewController = OCKCareContentsViewController(carePlanStore: storeManager.store)
         viewController.title = NSLocalizedString("Care Contents", comment: "")
         viewController.tabBarItem = UITabBarItem(title: viewController.title, image: UIImage(named:"carecard"), selectedImage: UIImage(named: "carecard-filled"))
+        viewController.noEventsText = "No events to show yet!";
         viewController.delegate = self;
         return viewController
 


### PR DESCRIPTION
This is a continuation of #155. The original pull request fell too far behind the master and rebasing became unwieldy, so the decision was made to resubmit the PR on a fresh branch.

I also made some minor changes to styling to make it match the rest of CareKit better. The `UILabel`s have been swapped out for `OCKLabel`s and the styling has been changed to match the `_noContactsLabel` from the OCKConnectViewController.

I've also fixed a bug in which the label hid under the header by adjusting the autoresizing mask, and another bug in which the `noEventsText` was not being updated in its setter method. Changes were tested in the CareKit sample app by replacing the sample data activities with an empty array. 

Touching the empty table view causes the app to crash, but this is a pre-existing bug (see #192), not one introduced by this PR. 