### PR TITLE
Synchronize lazy instantiation of UTC_gregorianCalendar

### DIFF
--- a/CareKit/CarePlan/NSDateComponents+CarePlan.m
+++ b/CareKit/CarePlan/NSDateComponents+CarePlan.m
@@ -119,9 +119,11 @@
 
 - (NSCalendar *)UTC_gregorianCalendar {
     static NSCalendar *calendar;
-    if (calendar == nil) {
-        calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
-        calendar.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+    @synchronized (self) {
+        if (calendar == nil) {
+            calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+            calendar.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+        }
     }
     return calendar;
 }


### PR DESCRIPTION
Similar to fixed PR #169, this commit synchronizes the lazy instantiation of the UTC_gregorianCalendar to avoid crashes due to race conditions.