### PR TITLE
Fix to prevent navigating to future dates in the Care Card, Symptom Tracker, and Care Contents views

### DIFF
--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -286,7 +286,8 @@
 }
 
 - (void)setSelectedDate:(NSDateComponents *)selectedDate {
-    _selectedDate = selectedDate;
+    NSDateComponents *today = [self today];
+    _selectedDate = [selectedDate isLaterThan:today] ? today : selectedDate;
     
     _weekViewController.weekView.isToday = [[self today] isEqualToDate:selectedDate];
     _weekViewController.weekView.selectedIndex = self.selectedDate.weekday - 1;
@@ -382,7 +383,9 @@
                                     startDate:[NSDateComponents ock_componentsWithDate:startOfWeek calendar:_calendar]
                                       endDate:[NSDateComponents ock_componentsWithDate:endOfWeek calendar:_calendar]
                                       handler:^(NSDateComponents *date, NSUInteger completedEvents, NSUInteger totalEvents) {
-                                          if (totalEvents == 0) {
+                                          if ([date isLaterThan:[self today]]) {
+                                              [values addObject:@(0)];
+                                          } else if (totalEvents == 0) {
                                               [values addObject:@(1)];
                                           } else {
                                               [values addObject:@((float)completedEvents/totalEvents)];
@@ -502,6 +505,11 @@
     self.selectedDate = selectedDate;
 }
 
+- (BOOL)weekViewCanSelectDayAtIndex:(NSUInteger)index {
+    NSDateComponents *today = [self today];
+    NSDateComponents *selectedDate = [self dateFromSelectedIndex:index];
+    return ![selectedDate isLaterThan:today];
+}
 
 #pragma mark - OCKCareCardCellDelegate
 
@@ -621,7 +629,7 @@
     controller.weekView.tintColor = self.glyphTintColor;
     controller.weekView.isCareCard = YES;
     controller.weekView.glyphType = self.glyphType;
-    return controller;
+    return (![self.selectedDate isInSameWeekAsDate:[self today]]) ? controller : nil;
 }
 
 

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -296,7 +296,8 @@
 }
 
 - (void)setSelectedDate:(NSDateComponents *)selectedDate {
-    _selectedDate = selectedDate;
+    NSDateComponents *today = [self today];
+    _selectedDate = [selectedDate isLaterThan:today] ? today : selectedDate;
     
     _weekViewController.weekView.isToday = [[self today] isEqualToDate:selectedDate];
     _weekViewController.weekView.selectedIndex = self.selectedDate.weekday - 1;
@@ -583,6 +584,11 @@
     self.selectedDate = selectedDate;
 }
 
+- (BOOL)weekViewCanSelectDayAtIndex:(NSUInteger)index {
+    NSDateComponents *today = [self today];
+    NSDateComponents *selectedDate = [self dateFromSelectedIndex:index];
+    return ![selectedDate isLaterThan:today];
+}
 
 #pragma mark - OCKCarePlanStoreDelegate
 
@@ -658,7 +664,7 @@
     controller.weekView.tintColor = self.glyphTintColor;
     controller.weekView.isCareCard = YES;
     controller.weekView.glyphType = self.glyphType;
-    return controller;
+    return (![self.selectedDate isInSameWeekAsDate:[self today]]) ? controller : nil;
 }
 
 

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -285,7 +285,8 @@
 }
 
 - (void)setSelectedDate:(NSDateComponents *)selectedDate {
-    _selectedDate = selectedDate;
+    NSDateComponents *today = [self today];
+    _selectedDate = [selectedDate isLaterThan:today] ? today : selectedDate;
     
     _weekViewController.weekView.isToday = [[self today] isEqualToDate:selectedDate];
     _weekViewController.weekView.selectedIndex = self.selectedDate.weekday - 1;
@@ -396,7 +397,9 @@
                                     startDate:[NSDateComponents ock_componentsWithDate:startOfWeek calendar:_calendar]
                                       endDate:[NSDateComponents ock_componentsWithDate:endOfWeek calendar:_calendar]
                                       handler:^(NSDateComponents *date, NSUInteger completedEvents, NSUInteger totalEvents) {
-                                          if (totalEvents == 0) {
+                                          if ([date isLaterThan:[self today]]) {
+                                              [values addObject:@(0)];
+                                          } else if (totalEvents == 0) {
                                               [values addObject:@(1)];
                                           } else {
                                               [values addObject:@((float)completedEvents/totalEvents)];
@@ -490,6 +493,11 @@
     self.selectedDate = selectedDate;
 }
 
+- (BOOL)weekViewCanSelectDayAtIndex:(NSUInteger)index {
+    NSDateComponents *today = [self today];
+    NSDateComponents *selectedDate = [self dateFromSelectedIndex:index];
+    return ![selectedDate isLaterThan:today];
+}
 
 #pragma mark - OCKCarePlanStoreDelegate
 


### PR DESCRIPTION
Prior to CK 1.2, navigating to future date in Care Card and Symptom Tracker is prevented.  In CK 1.2 this was broken.  This PR fixes the issue.