### PR TITLE
Allow developers to enable pull to refresh on activity listing view controllers

### DIFF
--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -94,8 +94,27 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)careCardViewController:(OCKCareCardViewController *)viewController willDisplayEvents:(NSArray<NSArray<OCKCarePlanEvent*>*>*)events dateComponents:(NSDateComponents *)dateComponents;
 
+/**
+ Asks the delegate if the care card view controller should enable pull-to-refresh behavior on the activities list. If not implemented,
+ pull-to-refresh will not be enabled.
+ 
+ If returned YES, the `careCardViewController:didActivatePullToRefreshControl:` method should be implemented to provide custom 
+ refreshing behavior when triggered by the user.
+ 
+ @param viewController              The view controller providing the callback.
+ */
 - (BOOL)shouldEnablePullToRefreshInCareCardViewController:(OCKCareCardViewController *)viewController;
 
+/**
+ Tells the delegate the user has triggered pull to refresh on the activities list.
+ 
+ Provides the opportunity to refresh data in the local store by, for example, fetching from a cloud data store.
+ This method should always be implmented in cases where `shouldEnablePullToRefreshInCareCardViewController:` might return YES.
+ 
+ @param viewController              The view controller providing the callback.
+ @param refreshControl              The refresh control which has been triggered, where `isRefreshing` should always be YES.
+                                    It is the developers responsibility to call `endRefreshing` as appropriate, on the main thread.
+ */
 - (void)careCardViewController:(OCKCareCardViewController *)viewController didActivatePullToRefreshControl:(UIRefreshControl *)refreshControl;
 
 @end

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -94,6 +94,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)careCardViewController:(OCKCareCardViewController *)viewController willDisplayEvents:(NSArray<NSArray<OCKCarePlanEvent*>*>*)events dateComponents:(NSDateComponents *)dateComponents;
 
+- (BOOL)shouldEnablePullToRefreshInCareCardViewController:(OCKCareCardViewController *)viewController;
+
+- (void)careCardViewController:(OCKCareCardViewController *)viewController didActivatePullToRefreshControl:(UIRefreshControl *)refreshControl;
+
 @end
 
 

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -114,6 +114,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)careContentsViewController:(OCKCareContentsViewController *)viewController willDisplayEvents:(NSArray<NSArray<OCKCarePlanEvent*>*>*)events dateComponents:(NSDateComponents *)dateComponents;
 
+- (BOOL)shouldEnablePullToRefreshInCareContentsViewController:(OCKCareContentsViewController *)viewController;
+
+- (void)careContentsViewController:(OCKCareContentsViewController *)viewController didActivatePullToRefreshControl:(UIRefreshControl *)refreshControl;
+
 @end
 
 

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -114,8 +114,27 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)careContentsViewController:(OCKCareContentsViewController *)viewController willDisplayEvents:(NSArray<NSArray<OCKCarePlanEvent*>*>*)events dateComponents:(NSDateComponents *)dateComponents;
 
+/**
+ Asks the delegate if the care contents view controller should enable pull-to-refresh behavior on the activities list. If not implemented,
+ pull-to-refresh will not be enabled.
+ 
+ If returned YES, the `careContentsViewController:didActivatePullToRefreshControl:` method should be implemented to provide custom
+ refreshing behavior when triggered by the user.
+ 
+ @param viewController              The view controller providing the callback.
+ */
 - (BOOL)shouldEnablePullToRefreshInCareContentsViewController:(OCKCareContentsViewController *)viewController;
 
+/**
+ Tells the delegate the user has triggered pull to refresh on the activities list.
+ 
+ Provides the opportunity to refresh data in the local store by, for example, fetching from a cloud data store.
+ This method should always be implmented in cases where `shouldEnablePullToRefreshInCareContentsViewController:` might return YES.
+ 
+ @param viewController              The view controller providing the callback.
+ @param refreshControl              The refresh control which has been triggered, where `isRefreshing` should always be YES.
+                                    It is the developers responsibility to call `endRefreshing` as appropriate, on the main thread.
+ */
 - (void)careContentsViewController:(OCKCareContentsViewController *)viewController didActivatePullToRefreshControl:(UIRefreshControl *)refreshControl;
 
 @end

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -68,6 +68,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)symptomTrackerViewController:(OCKSymptomTrackerViewController *)viewController willDisplayEvents:(NSArray<NSArray<OCKCarePlanEvent*>*>*)events dateComponents:(NSDateComponents *)dateComponents;
 
+- (BOOL)shouldEnablePullToRefreshInSymptomTrackerViewController:(OCKSymptomTrackerViewController *)viewController;
+
+- (void)symptomTrackerViewController:(OCKSymptomTrackerViewController *)viewController didActivatePullToRefreshControl:(UIRefreshControl *)refreshControl;
+
 @end
 
 

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -68,8 +68,27 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)symptomTrackerViewController:(OCKSymptomTrackerViewController *)viewController willDisplayEvents:(NSArray<NSArray<OCKCarePlanEvent*>*>*)events dateComponents:(NSDateComponents *)dateComponents;
 
+/**
+ Asks the delegate if the symptom tracker view controller should enable pull-to-refresh behavior on the activities list. If not implemented,
+ pull-to-refresh will not be enabled.
+ 
+ If returned YES, the `symptomTrackerViewController:didActivatePullToRefreshControl:` method should be implemented to provide custom
+ refreshing behavior when triggered by the user.
+ 
+ @param viewController              The view controller providing the callback.
+ */
 - (BOOL)shouldEnablePullToRefreshInSymptomTrackerViewController:(OCKSymptomTrackerViewController *)viewController;
 
+/**
+ Tells the delegate the user has triggered pull to refresh on the activities list.
+ 
+ Provides the opportunity to refresh data in the local store by, for example, fetching from a cloud data store.
+ This method should always be implmented in cases where `shouldEnablePullToRefreshInSymptomTrackerViewController:` might return YES.
+ 
+ @param viewController              The view controller providing the callback.
+ @param refreshControl              The refresh control which has been triggered, where `isRefreshing` should always be YES.
+                                    It is the developers responsibility to call `endRefreshing` as appropriate, on the main thread.
+ */
 - (void)symptomTrackerViewController:(OCKSymptomTrackerViewController *)viewController didActivatePullToRefreshControl:(UIRefreshControl *)refreshControl;
 
 @end

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -52,6 +52,7 @@
 
 @implementation OCKSymptomTrackerViewController {
     UITableView *_tableView;
+    UIRefreshControl *_refreshControl;
     NSMutableArray<NSMutableArray<OCKCarePlanEvent *> *> *_events;
     NSMutableArray *_weekValues;
     OCKHeaderView *_headerView;
@@ -116,6 +117,12 @@
     _tableView.estimatedSectionHeaderHeight = 0;
     _tableView.estimatedSectionFooterHeight = 0;
     
+    _refreshControl = [[UIRefreshControl alloc] init];
+    _refreshControl.tintColor = [UIColor grayColor];
+    [_refreshControl addTarget:self action:@selector(didActivatePullToRefreshControl:) forControlEvents:UIControlEventValueChanged];
+    _tableView.refreshControl = _refreshControl;
+    [self updatePullToRefreshControl];
+    
     self.navigationController.navigationBar.translucent = NO;
     [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
 }
@@ -133,6 +140,17 @@
     if (_tableViewData.count > 0) {
         [_tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:NSNotFound inSection:0] atScrollPosition:UITableViewScrollPositionMiddle animated:YES];
     }
+}
+
+- (void)didActivatePullToRefreshControl:(UIRefreshControl *)sender
+{
+    if (nil == _delegate ||
+        ![_delegate respondsToSelector:@selector(symptomTrackerViewController:didActivatePullToRefreshControl:)]) {
+        
+        return;
+    }
+    
+    [_delegate symptomTrackerViewController:self didActivatePullToRefreshControl:sender];
 }
 
 - (void)prepareView {
@@ -315,6 +333,18 @@
     }
 }
 
+- (void)setDelegate:(id<OCKSymptomTrackerViewControllerDelegate>)delegate
+{
+    _delegate = delegate;
+    
+    if ([NSOperationQueue currentQueue] != [NSOperationQueue mainQueue]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self updatePullToRefreshControl];
+        });
+    } else {
+        [self updatePullToRefreshControl];
+    }
+}
 
 #pragma mark - Helpers
 
@@ -369,6 +399,19 @@
                                               _headerView.value = [values.firstObject doubleValue];
                                           });
                                       }];
+}
+
+- (void)updatePullToRefreshControl
+{
+    if (nil != _delegate &&
+        [_delegate respondsToSelector:@selector(shouldEnablePullToRefreshInSymptomTrackerViewController:)] &&
+        [_delegate shouldEnablePullToRefreshInSymptomTrackerViewController:self]) {
+        
+        _tableView.refreshControl = _refreshControl;
+    } else {
+        [_tableView.refreshControl endRefreshing];
+        _tableView.refreshControl = nil;
+    }
 }
 
 - (UIImage *)createCustomImageName:(NSString*)customImageName {


### PR DESCRIPTION
Adds functionality which allows developers to support pull to refresh style behavior in their CareKit apps. The delegates of each of the three activity-listing view controllers now include methods which allow the developer to enable pull to refresh and to perform a custom action when refreshing is triggered by the user.

This is especially useful for developers leveraging the bridge API's to connect their CareKit apps to a cloud backend and synchronize data across account logins or sessions.