### PR TITLE
Fix testThresholds test which was incorrectly failing.

### DIFF
--- a/CareKitTests/CareKitCarePlanTests.m
+++ b/CareKitTests/CareKitCarePlanTests.m
@@ -932,7 +932,7 @@
     
     [store evaluateAdheranceThresholdForActivity:activity date:startDate completion:^(BOOL success, OCKCarePlanThreshold * _Nullable cdThreshold, NSError * _Nullable error) {
         XCTAssertNil(error);
-        XCTAssertNil(cdThreshold);
+        XCTAssertEqualObjects(threshold, cdThreshold);
     }];
     
     [store evaluateAdheranceThresholdForActivity:activity date:[startDate dateCompByAddingDays:1] completion:^(BOOL success, OCKCarePlanThreshold * _Nullable cdThreshold, NSError * _Nullable error) {


### PR DESCRIPTION
I believe there is an error in the actual assertion on line 935, and CareKit itself is fine. The schedule for this activity is a "twice every other day" schedule (occurrencesPerDay = 2, daysToSkip = 1), and most of the other assertions in this test are asserting the threshold is correct on startDate and nil on startDate + 1 day. On line 935, the test is asserting the threshold is nil on startDate. 

The threshold should not be nil on startDate, it should be equal to the original threshold on startDate.