### PR TITLE
Share CareKit framework scheme

### DIFF
--- a/CareKit.xcodeproj/xcshareddata/xcschemes/CareKit.xcscheme
+++ b/CareKit.xcodeproj/xcshareddata/xcschemes/CareKit.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8605A5B91C4F04EC00DD65FF"
+               BuildableName = "CareKit.framework"
+               BlueprintName = "CareKit"
+               ReferencedContainer = "container:CareKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8605A5C31C4F04EC00DD65FF"
+               BuildableName = "CareKitTests.xctest"
+               BlueprintName = "CareKitTests"
+               ReferencedContainer = "container:CareKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8605A5B91C4F04EC00DD65FF"
+            BuildableName = "CareKit.framework"
+            BlueprintName = "CareKit"
+            ReferencedContainer = "container:CareKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8605A5B91C4F04EC00DD65FF"
+            BuildableName = "CareKit.framework"
+            BlueprintName = "CareKit"
+            ReferencedContainer = "container:CareKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8605A5B91C4F04EC00DD65FF"
+            BuildableName = "CareKit.framework"
+            BlueprintName = "CareKit"
+            ReferencedContainer = "container:CareKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
I believe this addresses the issue in #172 and allows building with [Carthage](https://github.com/Carthage/Carthage/).

Here is a sample project you can use to test this functionality.

[CareKitDemo.zip](https://github.com/carekit-apple/CareKit/files/1609338/CareKitDemo.zip)

Download the sample project. In terminal change to the demo project's root directory and run `carthage bootstrap`. The output in your terminal should look similar to this:
```
$ carthage bootstrap
*** No Cartfile.resolved found, updating dependencies
*** Cloning CareKit
*** Checking out CareKit at "b38ebd184a29313304adf08fcb5a1422eb2de4cf"
*** xcodebuild output can be found in /var/folders/t7/4ql0gqm55_z8dl5f7kk2g3h00000gn/T/carthage-xcodebuild.FlMXMa.log
*** Building scheme "CareKit" in CKWorkspace.xcworkspace
```

You can then verify that the demo project will build and run.