### PR TITLE
Make table view public on OCKCareCardDetailViewController

### DIFF
--- a/CareKit/CareCard/OCKCareCardDetailViewController.h
+++ b/CareKit/CareCard/OCKCareCardDetailViewController.h
@@ -41,6 +41,9 @@ OCK_CLASS_AVAILABLE
 
 @property (nonatomic, readonly) OCKCarePlanActivity *intervention;
 
+@property (nonatomic, nonnull) UITableView *tableView;
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CareKit/CareCard/OCKCareCardDetailViewController.m
+++ b/CareKit/CareCard/OCKCareCardDetailViewController.m
@@ -43,7 +43,6 @@ static const CGFloat HeaderViewHeight = 100.0;
     NSMutableArray<NSString *> *_sectionTitles;
     NSString *_instructionsSectionTitle;
     NSString *_additionalInfoSectionTitle;
-    UITableView *_tableView;
     NSMutableArray *_constraints;
 }
 


### PR DESCRIPTION
This PR is to make the tableview in `OCKCareCardDetailViewController` public so that it's header and footer can be customized.

I submitted a handful of PR in the past to make the tableviews in other controllers visible, and I currently have a use case in which I need the same flexibility in the care card detail view controller, so I'm submitting this as an additional PR in the same vein as the previous ones. See #130 for reference.