### PR TITLE
Make OCKConnectDetailViewController public for subclassing

### DIFF
--- a/CareKit.xcodeproj/project.pbxproj
+++ b/CareKit.xcodeproj/project.pbxproj
@@ -58,7 +58,7 @@
 		244A92481CA210F7007B42D6 /* OCKWeekLabelsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 244A92421CA210F7007B42D6 /* OCKWeekLabelsView.m */; };
 		244A92491CA210F7007B42D6 /* OCKWeekViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 244A92431CA210F7007B42D6 /* OCKWeekViewController.h */; };
 		244A924A1CA210F7007B42D6 /* OCKWeekViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 244A92441CA210F7007B42D6 /* OCKWeekViewController.m */; };
-		248929751C90E70100EBBE1F /* OCKConnectDetailViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 248929641C90E70100EBBE1F /* OCKConnectDetailViewController.h */; };
+		248929751C90E70100EBBE1F /* OCKConnectDetailViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 248929641C90E70100EBBE1F /* OCKConnectDetailViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		248929761C90E70100EBBE1F /* OCKConnectDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 248929651C90E70100EBBE1F /* OCKConnectDetailViewController.m */; };
 		248929771C90E70100EBBE1F /* OCKConnectTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 248929661C90E70100EBBE1F /* OCKConnectTableViewCell.h */; };
 		248929781C90E70100EBBE1F /* OCKConnectTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 248929671C90E70100EBBE1F /* OCKConnectTableViewCell.m */; };
@@ -900,6 +900,8 @@
 				241707DD1C9A3AB7005D7123 /* OCKMessageItem.h in Headers */,
 				241707D51C9A3AB7005D7123 /* OCKInsightsMessageTableViewCell.h in Headers */,
 				242DBA9C1C9F7F8700529386 /* OCKRingView.h in Headers */,
+				5A9D2C931D5E432B00D0F13B /* OCKContactInfo.h in Headers */,
+				248929751C90E70100EBBE1F /* OCKConnectDetailViewController.h in Headers */,
 				24EA9FB81C9A3D420036028E /* OCKCareCardDetailViewController.h in Headers */,
 				8677EE1A1C9775EB00588CD6 /* OCKCarePlanStore_Internal.h in Headers */,
 				2489297D1C90E70100EBBE1F /* OCKConnectViewController.h in Headers */,
@@ -910,7 +912,6 @@
 				8677EE0E1C9775EB00588CD6 /* OCKCarePlanActivity.h in Headers */,
 				248929771C90E70100EBBE1F /* OCKConnectTableViewCell.h in Headers */,
 				BA3793EC1EB66D7D0004A540 /* OCKPatientWidget_Internal.h in Headers */,
-				248929751C90E70100EBBE1F /* OCKConnectDetailViewController.h in Headers */,
 				BA8A8CA01D9DAC680078C5EA /* OCKWeekView.h in Headers */,
 				242DBA901C9F7F8700529386 /* OCKSymptomTrackerTableViewCell.h in Headers */,
 				BA274F421EB6F75300DD17EF /* OCKConnectMessageTableViewCell.h in Headers */,

--- a/CareKit/CareKit.h
+++ b/CareKit/CareKit.h
@@ -1,5 +1,6 @@
 /*
- Copyright (c) 2017, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -73,6 +74,7 @@
 #import <CareKit/OCKContact.h>
 #import <CareKit/OCKConnectMessageItem.h>
 #import <CareKit/OCKConnectViewController.h>
+#import <CareKit/OCKConnectDetailViewController.h>
 
 // PDF
 #import <CareKit/OCKDocument.h>

--- a/CareKit/Common/OCKTableViewCell.h
+++ b/CareKit/Common/OCKTableViewCell.h
@@ -31,7 +31,6 @@
 
 #import <CareKit/CareKit.h>
 
-
 @interface OCKTableViewCell : UITableViewCell
 
 - (void)prepareView;

--- a/CareKit/Connect/OCKConnectDetailViewController.h
+++ b/CareKit/Connect/OCKConnectDetailViewController.h
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
  Copyright (c) 2016, WWT Asynchrony Labs. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -32,24 +33,50 @@
 
 #import <CareKit/CareKit.h>
 #import <MessageUI/MessageUI.h>
-#import "OCKContactInfoTableViewCell.h"
-#import "OCKContactSharingTableViewCell.h"
-
 
 NS_ASSUME_NONNULL_BEGIN
+@class OCKConnectViewController;
+@protocol OCKConnectViewControllerDelegate, OCKContactInfoTableViewCellDelegate, OCKContactSharingTableViewCellDelegate;
 
-@protocol OCKConnectViewControllerDelegate;
+/** 
+ The `OCKConnectDetailViewController` class is a view controller that
+ displays the contact information for a single `OCKContact`. It is typically
+ embedded in a navigation controller as the detail view of a master detail pair.
+ */
+OCK_CLASS_AVAILABLE
+@interface OCKConnectDetailViewController : UITableViewController
 
-@interface OCKConnectDetailViewController : UITableViewController <MFMessageComposeViewControllerDelegate, MFMailComposeViewControllerDelegate, OCKContactInfoTableViewCellDelegate, OCKContactSharingTableViewCellDelegate>
-
+/** 
+ Returns an initialized connect detail view controller using the specified contact.
+ 
+ @param contact     An `OCKContact` object.
+ 
+ @return An initialized view controller
+ */
 - (instancetype)initWithContact:(OCKContact *)contact;
 
+/** 
+ The contact whose information will be displayed in the table view.
+ */
 @property (nonatomic) OCKContact *contact;
 
+/** 
+ The delegate is used for the sharing section
+ 
+ See the `OCKConnectViewControllerDelegate` protocol
+ */
 @property (nonatomic, weak, nullable) id<OCKConnectViewControllerDelegate> delegate;
 
+/** 
+ A reference to the master view controller
+ */
 @property (nonatomic, weak) OCKConnectViewController *masterViewController;
 
+/** 
+ A boolean to show the edge indicators.
+ 
+ The default value is NO.
+ */
 @property (nonatomic) BOOL showEdgeIndicator;
 
 @end

--- a/CareKit/Connect/OCKConnectDetailViewController.m
+++ b/CareKit/Connect/OCKConnectDetailViewController.m
@@ -2,6 +2,7 @@
  Copyright (c) 2016, Apple Inc. All rights reserved.
  Copyright (c) 2016, Troy Tsubota. All rights reserved.
  Copyright (c) 2016, WWT Asynchrony Labs. All rights reserved.
+ Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -35,7 +36,11 @@
 #import "OCKConnectTableViewHeader.h"
 #import "OCKDefines_Private.h"
 #import "OCKHelpers.h"
+#import "OCKContactSharingTableViewCell.h"
+#import "OCKContactInfoTableViewCell.h"
 
+@interface OCKConnectDetailViewController () <MFMessageComposeViewControllerDelegate, MFMailComposeViewControllerDelegate, OCKContactInfoTableViewCellDelegate, OCKContactSharingTableViewCellDelegate>
+@end
 
 static const CGFloat HeaderViewHeight = 225.0;
 

--- a/CareKit/Connect/OCKConnectTableViewCell.h
+++ b/CareKit/Connect/OCKConnectTableViewCell.h
@@ -32,7 +32,6 @@
 #import <CareKit/CareKit.h>
 #import "OCKTableViewCell.h"
 
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OCKConnectTableViewCell : OCKTableViewCell

--- a/CareKit/Connect/OCKConnectViewController.m
+++ b/CareKit/Connect/OCKConnectViewController.m
@@ -1,6 +1,6 @@
 /*
- Copyright (c) 2017, Apple Inc. All rights reserved.
- Copyright (c) 2017, Troy Tsubota. All rights reserved.
+ Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Troy Tsubota. All rights reserved.
  Copyright (c) 2017, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
@@ -32,6 +32,7 @@
 
 
 #import "OCKConnectViewController.h"
+#import "OCKConnectTableViewCell.h"
 #import "OCKContact.h"
 #import "OCKConnectDetailViewController.h"
 #import "OCKHelpers.h"
@@ -334,7 +335,7 @@
         OCKContact *contact = [self contactForIndexPath:indexPath];
         [self.navigationController pushViewController:[self detailViewControllerForContact:contact] animated:YES];
     }
-    
+
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 


### PR DESCRIPTION
This PR is to make `OCKConnectDetailViewController` a public class open to subclassing. We have a use case in which being able to subclass the connect detail view controller is helpful, and having this change adopted into the official repository could help other developers wishing to do something similar.