### PR TITLE
Added optional image to the carekit buttons

### DIFF
--- a/CareKit/CareCard/OCKCareCardButton.h
+++ b/CareKit/CareCard/OCKCareCardButton.h
@@ -34,4 +34,6 @@
 
 @interface OCKCareCardButton : UIButton
 
+@property (nonatomic, nullable) UIImage *buttonImage;
+
 @end

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -37,6 +37,7 @@ static const CGFloat ButtonSize = 30.0;
 
 @implementation OCKCareCardButton {
     CAShapeLayer *_circleLayer;
+    UIImageView *_imageView;
 }
 
 - (void)drawRect:(CGRect)rect {
@@ -53,10 +54,25 @@ static const CGFloat ButtonSize = 30.0;
         [[UIColor clearColor] setFill];
         UIRectFill(_circleLayer.frame);
     }
+    
+    if (!_imageView) {
+        CGRect imageRect = CGRectMake(0, 0, ButtonSize, ButtonSize);
+        _imageView = [[UIImageView alloc] initWithFrame:imageRect];
+        _imageView.contentMode = UIViewContentModeScaleAspectFit;
+        [self updateImageForSelection:self.isSelected];
+        [self addSubview:_imageView];
+    }
+}
+
+- (void)setHighlighted:(BOOL)highlighted {
+    [self updateFillColorForSelection:highlighted];
+    [self updateImageForSelection:highlighted];
+    [super setHighlighted:highlighted];
 }
 
 - (void)setSelected:(BOOL)selected {
     [self updateFillColorForSelection:selected];
+    [self updateImageForSelection:selected];
     [super setSelected:selected];
 }
 
@@ -66,6 +82,10 @@ static const CGFloat ButtonSize = 30.0;
     } else {
         _circleLayer.fillColor = [UIColor whiteColor].CGColor;
     }
+}
+
+- (void)updateImageForSelection:(BOOL)selection {
+    [_imageView setImage: selection ? self.buttonImage : NULL];
 }
 
 - (CABasicAnimation *)animFillColorWithDur:(CGFloat)dur startCol:(UIColor *)start endColor:(UIColor *)end {

--- a/CareKit/CareCard/OCKCareCardTableViewCell.h
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.h
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy) NSArray<OCKCarePlanEvent *> *interventionEvents;
 
+@property (nonatomic, nullable) UIImage *buttonImage;
+
 @property (nonatomic, weak) id<OCKCareCardCellDelegate> delegate;
 
 @end

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -101,6 +101,7 @@ static const CGFloat ButtonViewSize = 40.0;
         frequencyButton.tintColor = self.tintColor;
         frequencyButton.selected = (event.state == OCKCarePlanEventStateCompleted);
         frequencyButton.translatesAutoresizingMaskIntoConstraints = NO;
+        frequencyButton.buttonImage = self.buttonImage;
         
         [frequencyButton addTarget:self
                             action:@selector(toggleFrequencyButton:)
@@ -326,6 +327,13 @@ static const CGFloat ButtonViewSize = 40.0;
     if (self.delegate &&
         [self.delegate respondsToSelector:@selector(careCardTableViewCell:didSelectInterventionActivity:)]) {
         [self.delegate careCardTableViewCell:self didSelectInterventionActivity:self.interventionEvents.firstObject.activity];
+    }
+}
+
+-(void)setButtonImage:(UIImage *)buttonImage {
+    _buttonImage = buttonImage;
+    for (int k=0; k<_frequencyButtons.count; k++) {
+        _frequencyButtons[k].buttonImage = self.buttonImage;
     }
 }
 

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -224,6 +224,10 @@ OCK_CLASS_AVAILABLE
  */
 @property (nonatomic) BOOL isSorted;
 
+/**
+ An optional image to display on `OCKCareCardButtons`
+ */
+@property (nonatomic, nullable) UIImage *buttonImage;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -737,6 +737,7 @@
     }
     cell.interventionEvents = _tableViewData[indexPath.section][indexPath.row];
     cell.delegate = self;
+    cell.buttonImage = self.buttonImage;
     return cell;
 }
 

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -249,6 +249,11 @@ OCK_CLASS_AVAILABLE
  */
 @property (nonatomic) BOOL isSorted;
 
+/**
+ An optional image to display on `OCKCareCardButtons`
+ */
+@property (nonatomic, nullable) UIImage *buttonImage;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -808,7 +808,6 @@
         }
         
         cell.assessmentEvent = event;
-        
         return cell;
     }
     else if (type == OCKCarePlanActivityTypeReadOnly) {
@@ -834,6 +833,7 @@
         }
         
         cell.interventionEvents = events;
+        cell.buttonImage = _buttonImage;
         cell.delegate = self;
         
         return cell;


### PR DESCRIPTION
This PR is to add an optional button image for display on the `OCKCareCardButton` shown on the care card and care contents screens. The default is `nil`, so it will not effect current users, but will provide the option to customize the appearance of the buttons to those who would like it.

<img src="https://user-images.githubusercontent.com/22581112/35184441-3a5c244c-fe39-11e7-8ef6-02fdefa0db1e.png" width="300">
