### PR TITLE
Added selected and deselected text properties to OCKCareCardButton

### DIFF
--- a/CareKit/CareCard/OCKCareCardButton.h
+++ b/CareKit/CareCard/OCKCareCardButton.h
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
- Copyright (c) 2018, Erik Hornberger. All rights reserved.s
+ Copyright (c) 2018, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardButton.h
+++ b/CareKit/CareCard/OCKCareCardButton.h
@@ -34,4 +34,6 @@
 
 @interface OCKCareCardButton : UIButton
 
+@property (nonatomic, nullable) NSString *deselectedText;
+@property (nonatomic, nullable) NSString *selectedText;
 @end

--- a/CareKit/CareCard/OCKCareCardButton.h
+++ b/CareKit/CareCard/OCKCareCardButton.h
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2018, Erik Hornberger. All rights reserved.s
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -62,7 +62,7 @@ static const CGFloat LabelOffset = 8.0;
         _label.font = [UIFont systemFontOfSize:9 weight:UIFontWeightHeavy];
         _label.textColor = self.tintColor;
         _label.textAlignment = NSTextAlignmentCenter;
-        [self updateTextForSelection:self.isSelected];
+        [self updateTextForSelection];
     }
         [self addSubview:_label];
     
@@ -81,7 +81,7 @@ static const CGFloat LabelOffset = 8.0;
     }
 }
 
-- (void)updateTextForSelection:(BOOL)selection {
+- (void)updateTextForSelection {
     _label.text = self.isSelected ? self.selectedText : self.deselectedText;
 }
 

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -59,7 +59,7 @@ static const CGFloat LabelOffset = 8.0;
     if (!_label) {
         CGRect labelRect = CGRectMake(0, ButtonSize/2 + LabelOffset, ButtonSize, ButtonSize);
         _label = [[UILabel alloc] initWithFrame:labelRect];
-        _label.font = [UIFont systemFontOfSize:9 weight:300];
+        _label.font = [UIFont systemFontOfSize:9 weight:UIFontWeightHeavy];
         _label.textColor = self.tintColor;
         _label.textAlignment = NSTextAlignmentCenter;
         [self updateTextForSelection:self.isSelected];

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -35,6 +35,7 @@
 
 
 static const CGFloat ButtonSize = 30.0;
+static const CGFloat LabelOffset = 8.0;
 
 @implementation OCKCareCardButton {
     CAShapeLayer *_circleLayer;
@@ -56,7 +57,7 @@ static const CGFloat ButtonSize = 30.0;
         UIRectFill(_circleLayer.frame);
     }
     if (!_label) {
-        CGRect labelRect = CGRectMake(0, ButtonSize/2 + 8, ButtonSize, ButtonSize);
+        CGRect labelRect = CGRectMake(0, ButtonSize/2 + LabelOffset, ButtonSize, ButtonSize);
         _label = [[UILabel alloc] initWithFrame:labelRect];
         _label.font = [UIFont systemFontOfSize:9 weight:300];
         _label.textColor = self.tintColor;

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2018, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -79,6 +79,10 @@ static const CGFloat ButtonSize = 30.0;
     }
 }
 
+- (void)updateTextForSelection:(BOOL)selection {
+    _label.text = self.isSelected ? self.selectedText : self.deselectedText;
+}
+
 - (CABasicAnimation *)animFillColorWithDur:(CGFloat)dur startCol:(UIColor *)start endColor:(UIColor *)end {
     CABasicAnimation *animFill = [CABasicAnimation animationWithKeyPath:@"fillColor"];
     [animFill setDuration:dur];
@@ -87,10 +91,6 @@ static const CGFloat ButtonSize = 30.0;
     [animFill setRemovedOnCompletion:NO];
     [animFill setFillMode:kCAFillModeBoth];
     return animFill;
-}
-
-- (void)updateTextForSelection:(BOOL)selection {
-    _label.text = self.isSelected ? self.selectedText : self.deselectedText;
 }
 
 @end

--- a/CareKit/CareCard/OCKCareCardButton.m
+++ b/CareKit/CareCard/OCKCareCardButton.m
@@ -37,6 +37,7 @@ static const CGFloat ButtonSize = 30.0;
 
 @implementation OCKCareCardButton {
     CAShapeLayer *_circleLayer;
+    UILabel *_label;
 }
 
 - (void)drawRect:(CGRect)rect {
@@ -53,6 +54,16 @@ static const CGFloat ButtonSize = 30.0;
         [[UIColor clearColor] setFill];
         UIRectFill(_circleLayer.frame);
     }
+    if (!_label) {
+        CGRect labelRect = CGRectMake(0, ButtonSize/2 + 8, ButtonSize, ButtonSize);
+        _label = [[UILabel alloc] initWithFrame:labelRect];
+        _label.font = [UIFont systemFontOfSize:9 weight:300];
+        _label.textColor = self.tintColor;
+        _label.textAlignment = NSTextAlignmentCenter;
+        [self updateTextForSelection:self.isSelected];
+    }
+        [self addSubview:_label];
+    
 }
 
 - (void)setSelected:(BOOL)selected {
@@ -76,6 +87,10 @@ static const CGFloat ButtonSize = 30.0;
     [animFill setRemovedOnCompletion:NO];
     [animFill setFillMode:kCAFillModeBoth];
     return animFill;
+}
+
+- (void)updateTextForSelection:(BOOL)selection {
+    _label.text = self.isSelected ? self.selectedText : self.deselectedText;
 }
 
 @end

--- a/CareKit/CareCard/OCKCareCardTableViewCell.h
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.h
@@ -48,9 +48,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)careCardTableViewCell:(OCKCareCardTableViewCell *)cell didSelectInterventionActivity:(OCKCarePlanActivity *)activity;
 
-- (nullable NSString *)careCardTableViewCell:(OCKCareCardTableViewCell *)cell selectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger) index;
+- (nullable NSString *)careCardTableViewCell:(OCKCareCardTableViewCell *)cell selectedStateTextForCarePlanEvent: (OCKCarePlanEvent *)carePlanEvent atIndex:(NSInteger) index;
 
-- (nullable NSString *)careCardTableViewCell:(OCKCareCardTableViewCell *)cell deselectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger) index;
+- (nullable NSString *)careCardTableViewCell:(OCKCareCardTableViewCell *)cell deselectedStateTextForCarePlanEvent: (OCKCarePlanEvent *)carePlanEvent atIndex:(NSInteger) index;
 
 @end
 

--- a/CareKit/CareCard/OCKCareCardTableViewCell.h
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.h
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2017, Apple Inc. All rights reserved.
+ Copyright (c) 2018, Erik Hornberger. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareCard/OCKCareCardTableViewCell.h
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.h
@@ -47,6 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)careCardTableViewCell:(OCKCareCardTableViewCell *)cell didSelectInterventionActivity:(OCKCarePlanActivity *)activity;
 
+- (nullable NSString *)careCardTableViewCell:(OCKCareCardTableViewCell *)cell selectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger) index;
+
+- (nullable NSString *)careCardTableViewCell:(OCKCareCardTableViewCell *)cell deselectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger) index;
+
 @end
 
 

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -109,13 +109,13 @@ static const CGFloat ButtonViewSize = 40.0;
                   forControlEvents:UIControlEventTouchUpInside];
         
         if (self.delegate &&
-            [self.delegate respondsToSelector:@selector(careCardTableViewCell:selectedStateTextForInterventionActivity:atIndex:)]) {
-            frequencyButton.selectedText = [self.delegate careCardTableViewCell:self selectedStateTextForInterventionActivity:event atIndex:index];
+            [self.delegate respondsToSelector:@selector(careCardTableViewCell:selectedStateTextForCarePlanEvent:atIndex:)]) {
+            frequencyButton.selectedText = [self.delegate careCardTableViewCell:self selectedStateTextForCarePlanEvent:event atIndex:index];
         }
         
         if (self.delegate &&
-            [self.delegate respondsToSelector:@selector(careCardTableViewCell:deselectedStateTextForInterventionActivity:atIndex:)]) {
-            frequencyButton.deselectedText = [self.delegate careCardTableViewCell:self deselectedStateTextForInterventionActivity:event atIndex:index];
+            [self.delegate respondsToSelector:@selector(careCardTableViewCell:deselectedStateTextForCarePlanEvent:atIndex:)]) {
+            frequencyButton.deselectedText = [self.delegate careCardTableViewCell:self deselectedStateTextForCarePlanEvent:event atIndex:index];
         }
         
         [buttons addObject:frequencyButton];

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -96,6 +96,8 @@ static const CGFloat ButtonViewSize = 40.0;
     
     _frequencyButtons = [NSArray new];
     NSMutableArray *buttons = [NSMutableArray new];
+
+    NSUInteger index = 0;
     for (OCKCarePlanEvent *event in self.interventionEvents) {
         OCKCareCardButton *frequencyButton = [[OCKCareCardButton alloc] initWithFrame:CGRectZero];
         frequencyButton.tintColor = self.tintColor;
@@ -105,9 +107,21 @@ static const CGFloat ButtonViewSize = 40.0;
         [frequencyButton addTarget:self
                             action:@selector(toggleFrequencyButton:)
                   forControlEvents:UIControlEventTouchUpInside];
+        
+        if (self.delegate &&
+            [self.delegate respondsToSelector:@selector(careCardTableViewCell:selectedStateTextForInterventionActivity:atIndex:)]) {
+            frequencyButton.selectedText = [self.delegate careCardTableViewCell:self selectedStateTextForInterventionActivity:event atIndex:index];
+        }
+        
+        if (self.delegate &&
+            [self.delegate respondsToSelector:@selector(careCardTableViewCell:deselectedStateTextForInterventionActivity:atIndex:)]) {
+            frequencyButton.deselectedText = [self.delegate careCardTableViewCell:self deselectedStateTextForInterventionActivity:event atIndex:index];
+        }
+        
         [buttons addObject:frequencyButton];
         
         [self addSubview:frequencyButton];
+        index++;
     }
     _frequencyButtons = [buttons copy];
     

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -261,7 +261,7 @@ static const CGFloat ButtonViewSize = 40.0;
                                                                                 toItem:_frequencyButtons[0]
                                                                              attribute:NSLayoutAttributeBottom
                                                                             multiplier:1.0
-                                                                              constant:0.0]
+                                                                              constant:VerticalMargin]
                                                 ]];
         } else {
             [_constraints addObjectsFromArray:@[

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -96,14 +96,11 @@ static const CGFloat ButtonViewSize = 40.0;
     
     _frequencyButtons = [NSArray new];
     NSMutableArray *buttons = [NSMutableArray new];
-    int index = 0;
     for (OCKCarePlanEvent *event in self.interventionEvents) {
         OCKCareCardButton *frequencyButton = [[OCKCareCardButton alloc] initWithFrame:CGRectZero];
         frequencyButton.tintColor = self.tintColor;
         frequencyButton.selected = (event.state == OCKCarePlanEventStateCompleted);
         frequencyButton.translatesAutoresizingMaskIntoConstraints = NO;
-        frequencyButton.deselectedText = [self deselectedButtonTextForActivity:event.activity][index];
-        frequencyButton.selectedText = [self selectedButtonTextForActivity:event.activity][index];
         
         [frequencyButton addTarget:self
                             action:@selector(toggleFrequencyButton:)
@@ -111,7 +108,6 @@ static const CGFloat ButtonViewSize = 40.0;
         [buttons addObject:frequencyButton];
         
         [self addSubview:frequencyButton];
-        index++;
     }
     _frequencyButtons = [buttons copy];
     
@@ -129,16 +125,6 @@ static const CGFloat ButtonViewSize = 40.0;
 - (void)updateView {
     _titleLabel.text = _intervention.title;
     _textLabel.text = _intervention.text;
-}
-
-- (NSArray<NSString*>*)selectedButtonTextForActivity:(OCKCarePlanActivity*) activity {
-    NSDictionary *info = activity.userInfo;
-    return [info objectForKey:@"selectedText"];
-}
-
-- (NSArray<NSString*>*)deselectedButtonTextForActivity:(OCKCarePlanActivity*) activity {
-    NSDictionary *info = activity.userInfo;
-    return [info objectForKey:@"deselectedText"];
 }
 
 - (void)setUpConstraints {

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -96,11 +96,14 @@ static const CGFloat ButtonViewSize = 40.0;
     
     _frequencyButtons = [NSArray new];
     NSMutableArray *buttons = [NSMutableArray new];
+    int index = 0;
     for (OCKCarePlanEvent *event in self.interventionEvents) {
         OCKCareCardButton *frequencyButton = [[OCKCareCardButton alloc] initWithFrame:CGRectZero];
         frequencyButton.tintColor = self.tintColor;
         frequencyButton.selected = (event.state == OCKCarePlanEventStateCompleted);
         frequencyButton.translatesAutoresizingMaskIntoConstraints = NO;
+        frequencyButton.deselectedText = [self deselectedButtonTextForActivity:event.activity][index];
+        frequencyButton.selectedText = [self selectedButtonTextForActivity:event.activity][index];
         
         [frequencyButton addTarget:self
                             action:@selector(toggleFrequencyButton:)
@@ -108,6 +111,7 @@ static const CGFloat ButtonViewSize = 40.0;
         [buttons addObject:frequencyButton];
         
         [self addSubview:frequencyButton];
+        index++;
     }
     _frequencyButtons = [buttons copy];
     
@@ -125,6 +129,16 @@ static const CGFloat ButtonViewSize = 40.0;
 - (void)updateView {
     _titleLabel.text = _intervention.title;
     _textLabel.text = _intervention.text;
+}
+
+- (NSArray<NSString*>*)selectedButtonTextForActivity:(OCKCarePlanActivity*) activity {
+    NSDictionary *info = activity.userInfo;
+    return [info objectForKey:@"selectedText"];
+}
+
+- (NSArray<NSString*>*)deselectedButtonTextForActivity:(OCKCarePlanActivity*) activity {
+    NSDictionary *info = activity.userInfo;
+    return [info objectForKey:@"deselectedText"];
 }
 
 - (void)setUpConstraints {

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -121,19 +121,19 @@ NS_ASSUME_NONNULL_BEGIN
  Asks the delegate for text to display below each `OCKCareCardButton` in the cell when in a selected state.
  
  @param viewController              The view controller providing the callback.
- @param interventionActivity        The `OCKCarePlanEvent` that the button represents
+ @param carePlanEvent               The `OCKCarePlanEvent` that the button represents
  @param index                       The index of the `OCKCareCardButton` within the cell
  */
-- (nullable NSString *)careCardViewController:(OCKCareCardViewController *)viewController selectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atButtonIndex: (NSInteger)index;
+- (nullable NSString *)careCardViewController:(OCKCareCardViewController *)viewController selectedStateTextForCarePlanEvent: (OCKCarePlanEvent *)carePlanEvent atButtonIndex: (NSInteger)index;
 
 /**
  Asks the delegate for text to display below each `OCKCareCardButton` in the cell when in a deselected state.
  
  @param viewController              The view controller providing the callback.
- @param interventionActivity        The `OCKCarePlanEvent` that the button represents
+ @param carePlanEvent               The `OCKCarePlanEvent` that the button represents
  @param index                       The index of the `OCKCareCardButton` within the cell
  */
-- (nullable NSString *)careCardViewController:(OCKCareCardViewController *)viewController deselectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atButtonIndex: (NSInteger)index;
+- (nullable NSString *)careCardViewController:(OCKCareCardViewController *)viewController deselectedStateTextForCarePlanEvent: (OCKCarePlanEvent *)carePlanEvent atButtonIndex: (NSInteger)index;
 
 @end
 

--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -117,6 +117,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)careCardViewController:(OCKCareCardViewController *)viewController didActivatePullToRefreshControl:(UIRefreshControl *)refreshControl;
 
+/**
+ Asks the delegate for text to display below each `OCKCareCardButton` in the cell when in a selected state.
+ 
+ @param viewController              The view controller providing the callback.
+ @param interventionActivity        The `OCKCarePlanEvent` that the button represents
+ @param index                       The index of the `OCKCareCardButton` within the cell
+ */
+- (nullable NSString *)careCardViewController:(OCKCareCardViewController *)viewController selectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atButtonIndex: (NSInteger)index;
+
+/**
+ Asks the delegate for text to display below each `OCKCareCardButton` in the cell when in a deselected state.
+ 
+ @param viewController              The view controller providing the callback.
+ @param interventionActivity        The `OCKCarePlanEvent` that the button represents
+ @param index                       The index of the `OCKCareCardButton` within the cell
+ */
+- (nullable NSString *)careCardViewController:(OCKCareCardViewController *)viewController deselectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atButtonIndex: (NSInteger)index;
+
 @end
 
 

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -645,6 +645,19 @@
     }
 }
 
+- (nullable NSString*) careCardTableViewCell:(OCKCareCardTableViewCell *)cell selectedStateTextForInterventionActivity:(OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger)index {
+    if ([self.delegate respondsToSelector:@selector(careCardTableViewCell:selectedStateTextForInterventionActivity:atIndex:)]){
+        return [self.delegate careCardViewController:self selectedStateTextForInterventionActivity:interventionActivity atButtonIndex:index];
+    }
+    return NULL;
+}
+
+- (nullable NSString*) careCardTableViewCell:(OCKCareCardTableViewCell *)cell deselectedStateTextForInterventionActivity:(OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger)index {
+    if ([self.delegate respondsToSelector:@selector(careCardTableViewCell:deselectedStateTextForInterventionActivity:atIndex:)]){
+        return [self.delegate careCardViewController:self deselectedStateTextForInterventionActivity:interventionActivity atButtonIndex:index];
+    }
+    return NULL;
+}
 
 #pragma mark - OCKCarePlanStoreDelegate
 
@@ -753,8 +766,9 @@
         cell = [[OCKCareCardTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
                                                reuseIdentifier:CellIdentifier];
     }
-    cell.interventionEvents = _tableViewData[indexPath.section][indexPath.row];
+    
     cell.delegate = self;
+    cell.interventionEvents = _tableViewData[indexPath.section][indexPath.row];
     return cell;
 }
 

--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -645,16 +645,16 @@
     }
 }
 
-- (nullable NSString*) careCardTableViewCell:(OCKCareCardTableViewCell *)cell selectedStateTextForInterventionActivity:(OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger)index {
-    if ([self.delegate respondsToSelector:@selector(careCardTableViewCell:selectedStateTextForInterventionActivity:atIndex:)]){
-        return [self.delegate careCardViewController:self selectedStateTextForInterventionActivity:interventionActivity atButtonIndex:index];
+- (nullable NSString*) careCardTableViewCell:(OCKCareCardTableViewCell *)cell selectedStateTextForCarePlanEvent:(OCKCarePlanEvent *)carePlanEvent atIndex:(NSInteger)index {
+    if ([self.delegate respondsToSelector:@selector(careCardViewController:selectedStateTextForCarePlanEvent:atButtonIndex:)]) {
+        return [self.delegate careCardViewController:self selectedStateTextForCarePlanEvent:carePlanEvent atButtonIndex:index];
     }
     return NULL;
 }
 
-- (nullable NSString*) careCardTableViewCell:(OCKCareCardTableViewCell *)cell deselectedStateTextForInterventionActivity:(OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger)index {
-    if ([self.delegate respondsToSelector:@selector(careCardTableViewCell:deselectedStateTextForInterventionActivity:atIndex:)]){
-        return [self.delegate careCardViewController:self deselectedStateTextForInterventionActivity:interventionActivity atButtonIndex:index];
+- (nullable NSString*) careCardTableViewCell:(OCKCareCardTableViewCell *)cell deselectedStateTextForCarePlanEvent:(OCKCarePlanEvent *)carePlanEvent atIndex:(NSInteger)index {
+    if ([self.delegate respondsToSelector:@selector(careCardViewController:deselectedStateTextForCarePlanEvent:atButtonIndex:)]) {
+        return [self.delegate careCardViewController:self deselectedStateTextForCarePlanEvent:carePlanEvent atButtonIndex:index];
     }
     return NULL;
 }

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -1,6 +1,8 @@
 /*
  Copyright (c) 2017, Apple Inc. All rights reserved.
  Copyright (c) 2017, Erik Hornberger. All rights reserved.
+ Copyright (c) 2017, EExT LLC. All rights reserved.
+ Copyright (c) 2018, Swift愛好会. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -144,19 +144,19 @@ NS_ASSUME_NONNULL_BEGIN
  Asks the delegate for text to display below each `OCKCareCardButton` in the cell when in a selected state.
  
  @param viewController              The view controller providing the callback.
- @param interventionActivity        The `OCKCarePlanEvent` that the button represents
+ @param carePlanEvent               The `OCKCarePlanEvent` that the button represents
  @param index                       The index of the `OCKCareCardButton` within the cell
  */
-- (nullable NSString *)careContentsViewController:(OCKCareContentsViewController *)viewController selectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atButtonIndex: (NSInteger)index;
+- (nullable NSString *)careContentsViewController:(OCKCareContentsViewController *)viewController selectedStateTextForCarePlanEvent: (OCKCarePlanEvent *)carePlanEvent atButtonIndex: (NSInteger)index;
 
 /**
  Asks the delegate for text to display below each `OCKCareCardButton` in the cell when in a deselected state.
  
  @param viewController              The view controller providing the callback.
- @param interventionActivity        The `OCKCarePlanEvent` that the button represents
+ @param carePlanEvent               The `OCKCarePlanEvent` that the button represents
  @param index                       The index of the `OCKCareCardButton` within the cell
  */
-- (nullable NSString *)careContentsViewController:(OCKCareContentsViewController *)viewController deselectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atButtonIndex: (NSInteger)index;
+- (nullable NSString *)careContentsViewController:(OCKCareContentsViewController *)viewController deselectedStateTextForCarePlanEvent: (OCKCarePlanEvent *)carePlanEvent atButtonIndex: (NSInteger)index;
 
 @end
 

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -138,6 +138,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)careContentsViewController:(OCKCareContentsViewController *)viewController didActivatePullToRefreshControl:(UIRefreshControl *)refreshControl;
 
+/**
+ Asks the delegate for text to display below each `OCKCareCardButton` in the cell when in a selected state.
+ 
+ @param viewController              The view controller providing the callback.
+ @param interventionActivity        The `OCKCarePlanEvent` that the button represents
+ @param index                       The index of the `OCKCareCardButton` within the cell
+ */
+- (nullable NSString *)careContentsViewController:(OCKCareContentsViewController *)viewController selectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atButtonIndex: (NSInteger)index;
+
+/**
+ Asks the delegate for text to display below each `OCKCareCardButton` in the cell when in a deselected state.
+ 
+ @param viewController              The view controller providing the callback.
+ @param interventionActivity        The `OCKCarePlanEvent` that the button represents
+ @param index                       The index of the `OCKCareCardButton` within the cell
+ */
+- (nullable NSString *)careContentsViewController:(OCKCareContentsViewController *)viewController deselectedStateTextForInterventionActivity: (OCKCarePlanEvent *)interventionActivity atButtonIndex: (NSInteger)index;
+
 @end
 
 

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -948,16 +948,16 @@
     }
 }
 
-- (nullable NSString*)careCardTableViewCell:(OCKCareCardTableViewCell *)cell selectedStateTextForInterventionActivity:(OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger)index {
-    if ([self.delegate respondsToSelector:@selector(careCardTableViewCell:selectedStateTextForInterventionActivity:atIndex:)]){
-        return [self.delegate careContentsViewController:self selectedStateTextForInterventionActivity:interventionActivity atButtonIndex:index];
+- (nullable NSString*)careCardTableViewCell:(OCKCareCardTableViewCell *)cell selectedStateTextForCarePlanEvent:(OCKCarePlanEvent *)carePlanEvent atIndex:(NSInteger)index {
+    if([self.delegate respondsToSelector:@selector(careContentsViewController:selectedStateTextForCarePlanEvent:atButtonIndex:)]) {
+        return [self.delegate careContentsViewController:self selectedStateTextForCarePlanEvent:carePlanEvent atButtonIndex:index];
     }
     return NULL;
 }
 
-- (nullable NSString*)careCardTableViewCell:(OCKCareCardTableViewCell *)cell deselectedStateTextForInterventionActivity:(OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger)index {
-    if ([self.delegate respondsToSelector:@selector(careCardTableViewCell:deselectedStateTextForInterventionActivity:atIndex:)]){
-        return [self.delegate careContentsViewController:self deselectedStateTextForInterventionActivity:interventionActivity atButtonIndex:index];
+- (nullable NSString*)careCardTableViewCell:(OCKCareCardTableViewCell *)cell deselectedStateTextForCarePlanEvent:(OCKCarePlanEvent *)carePlanEvent atIndex:(NSInteger)index {
+    if([self.delegate respondsToSelector:@selector(careContentsViewController:deselectedStateTextForCarePlanEvent:atButtonIndex:)]) {
+        return [self.delegate careContentsViewController:self deselectedStateTextForCarePlanEvent:carePlanEvent atButtonIndex:index];
     }
     return NULL;
 }

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -861,7 +861,6 @@
         }
         
         cell.readOnlyEvent = event;
-
         return cell;
     }
     else {

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -1,6 +1,8 @@
 /*
  Copyright (c) 2017, Apple Inc. All rights reserved.
  Copyright (c) 2017, Erik Hornberger. All rights reserved.
+ Copyright (c) 2017, EExT LLC. All rights reserved.
+ Copyright (c) 2018, Swift愛好会. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -871,10 +871,9 @@
             cell = [[OCKCareCardTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
                                                    reuseIdentifier:CellIdentifier];
         }
-        
-        cell.interventionEvents = events;
+
         cell.delegate = self;
-        
+        cell.interventionEvents = events;
         return cell;
     }
     
@@ -947,6 +946,19 @@
     }
 }
 
+- (nullable NSString*)careCardTableViewCell:(OCKCareCardTableViewCell *)cell selectedStateTextForInterventionActivity:(OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger)index {
+    if ([self.delegate respondsToSelector:@selector(careCardTableViewCell:selectedStateTextForInterventionActivity:atIndex:)]){
+        return [self.delegate careContentsViewController:self selectedStateTextForInterventionActivity:interventionActivity atButtonIndex:index];
+    }
+    return NULL;
+}
+
+- (nullable NSString*)careCardTableViewCell:(OCKCareCardTableViewCell *)cell deselectedStateTextForInterventionActivity:(OCKCarePlanEvent *)interventionActivity atIndex:(NSInteger)index {
+    if ([self.delegate respondsToSelector:@selector(careCardTableViewCell:deselectedStateTextForInterventionActivity:atIndex:)]){
+        return [self.delegate careContentsViewController:self deselectedStateTextForInterventionActivity:interventionActivity atButtonIndex:index];
+    }
+    return NULL;
+}
 
 #pragma mark - UIViewControllerPreviewingDelegate
 

--- a/Sample/OCKSample/RootViewController.swift
+++ b/Sample/OCKSample/RootViewController.swift
@@ -160,6 +160,14 @@ extension RootViewController: OCKCareContentsViewControllerDelegate {
             
             present(taskViewController, animated: true, completion: nil)
     }
+    
+    func careContentsViewController(_ viewController: OCKCareContentsViewController, selectedStateTextFor carePlanEvent: OCKCarePlanEvent, atButtonIndex index: Int) -> String? {
+        return "OK!"
+    }
+    
+    func careContentsViewController(_ viewController: OCKCareContentsViewController, deselectedStateTextFor carePlanEvent: OCKCarePlanEvent, atButtonIndex index: Int) -> String? {
+        return ["AM", "PM"][index % 2]
+    }
 }
 
 extension RootViewController: ORKTaskViewControllerDelegate {


### PR DESCRIPTION
This pull request probably needs some extra input before it's ready to merge. It's purpose is to add an optional label below `OCKCareCardButton`, but there is room for improvement in the way that data is passed to the cells. 

<img src="https://user-images.githubusercontent.com/22581112/35184628-a4e45666-fe3b-11e7-9676-ace5334b5b2d.png" width="450">

Currently I am passing the text in through `userInfo`, but this doesn't seem like a good way to make it a standard feature. If you have a preference for how to get the data to the button objects in a less hacky way, I'd be happy to update this PR.
