### PR TITLE
Fix documentation comment error

### DIFF
--- a/CareKit/CarePlan/OCKCarePlanEvent.h
+++ b/CareKit/CarePlan/OCKCarePlanEvent.h
@@ -52,7 +52,7 @@ typedef NS_ENUM(NSInteger, OCKCarePlanEventState) {
 
 /**
  An instance of `OCKCarePlanEvent` defines an occurrence of an activty.
- An activity is uniquely defined by two indices: numberOfDaysSinceStart and occurrenceIndexOfDay. 
+ An event is uniquely defined by two indices: numberOfDaysSinceStart and occurrenceIndexOfDay. 
  For example, the second event on day 1 is defined using numberOfDaysSinceStart = 0 and occurrenceIndexOfDay = 1.
  
  An `OCKCarePlanEvent` instance cannot be created directly.


### PR DESCRIPTION
Should be `event` instead of `activity`