### PR TITLE
More aesthetic arrangement for Care Card buttons

### DIFF
--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2017, Apple Inc. All rights reserved.
+ Copyright (c) 2018, Macro Yau. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -127,6 +128,16 @@ static const CGFloat ButtonViewSize = 40.0;
     _textLabel.text = _intervention.text;
 }
 
+- (int)optimizeButtonsPerRow:(int)max {
+    int buttonsInPartialRow = ([_frequencyButtons count] < max) ? 0 : [_frequencyButtons count] % max;
+    
+    if (buttonsInPartialRow == 0 || buttonsInPartialRow == max - 1) {
+        return max;
+    } else {
+        return [self optimizeButtonsPerRow:(max - 1)];
+    }
+}
+
 - (void)setUpConstraints {
     [NSLayoutConstraint deactivateConstraints:_constraints];
     
@@ -142,7 +153,8 @@ static const CGFloat ButtonViewSize = 40.0;
     CGFloat TrailingMargin = (self.separatorInset.right > 0) ? self.separatorInset.right : 25;
     
     CGFloat buttonsUsableWidth = [UIScreen mainScreen].bounds.size.width - (LeadingMargin + TrailingMargin);
-    int buttonsPerRow = buttonsUsableWidth / (ButtonViewSize + HorizontalMargin);
+    int maxButtonsPerRow = buttonsUsableWidth / (ButtonViewSize + HorizontalMargin);
+    int buttonsPerRow = [self optimizeButtonsPerRow:maxButtonsPerRow];
     
     [_constraints addObjectsFromArray:@[
                                         [NSLayoutConstraint constraintWithItem:_titleLabel

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -141,6 +141,9 @@ static const CGFloat ButtonViewSize = 40.0;
     CGFloat LeadingMargin = self.separatorInset.left;
     CGFloat TrailingMargin = (self.separatorInset.right > 0) ? self.separatorInset.right : 25;
     
+    CGFloat buttonsUsableWidth = [UIScreen mainScreen].bounds.size.width - (LeadingMargin + TrailingMargin);
+    int buttonsPerRow = buttonsUsableWidth / (ButtonViewSize + HorizontalMargin);
+    
     [_constraints addObjectsFromArray:@[
                                         [NSLayoutConstraint constraintWithItem:_titleLabel
                                                                      attribute:NSLayoutAttributeTop
@@ -232,7 +235,7 @@ static const CGFloat ButtonViewSize = 40.0;
                                                                             multiplier:1.0
                                                                               constant:VerticalMargin],
                                                 ]];
-        } else if (i == 7) {
+        } else if (i == buttonsPerRow) {
             [_constraints addObjectsFromArray:@[
                                                 [NSLayoutConstraint constraintWithItem:_frequencyButtons[i]
                                                                              attribute:NSLayoutAttributeLeading
@@ -286,7 +289,7 @@ static const CGFloat ButtonViewSize = 40.0;
                                             ]];
     }
     
-    int index = (_frequencyButtons.count <= 7) ? 0 : 7;
+    int index = (_frequencyButtons.count <= buttonsPerRow) ? 0 : buttonsPerRow;
     for (int i = index; i <_frequencyButtons.count; i++) {
         [_constraints addObjectsFromArray:@[
                                             [NSLayoutConstraint constraintWithItem:_frequencyButtons[i]

--- a/CareKit/CareCard/OCKCareCardTableViewCell.m
+++ b/CareKit/CareCard/OCKCareCardTableViewCell.m
@@ -153,7 +153,7 @@ static const CGFloat ButtonViewSize = 40.0;
     CGFloat TrailingMargin = (self.separatorInset.right > 0) ? self.separatorInset.right : 25;
     
     CGFloat buttonsUsableWidth = [UIScreen mainScreen].bounds.size.width - (LeadingMargin + TrailingMargin);
-    int maxButtonsPerRow = buttonsUsableWidth / (ButtonViewSize + HorizontalMargin);
+    int maxButtonsPerRow = (buttonsUsableWidth / ButtonViewSize) - 1;
     int buttonsPerRow = [self optimizeButtonsPerRow:maxButtonsPerRow];
     
     [_constraints addObjectsFromArray:@[

--- a/Sample/OCKSample.xcodeproj/project.pbxproj
+++ b/Sample/OCKSample.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		247E67881E53DCD30045D28B /* ResearchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 247E67871E53DCD30045D28B /* ResearchKit.framework */; };
 		247E67891E53DCD30045D28B /* ResearchKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 247E67871E53DCD30045D28B /* ResearchKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		24A69BBC1D779DE600BEAD84 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5C100991CB12E0C00FAD7E8 /* Assets.xcassets */; };
+		6C703DE82042C2B6002D12EA /* DrinkWater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C703DE72042C2B6002D12EA /* DrinkWater.swift */; };
 		B55565771CC82FCA00513644 /* CareKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55565711CC82F8D00513644 /* CareKit.framework */; };
 		B55565781CC82FCA00513644 /* CareKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B55565711CC82F8D00513644 /* CareKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B555759C1CB3DB8C0028DC37 /* NSCalendar+Dates.swift in Sources */ = {isa = PBXBuildFile; fileRef = B555759B1CB3DB8C0028DC37 /* NSCalendar+Dates.swift */; };
@@ -161,6 +162,7 @@
 		24026C661D6D244A007582F3 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		2436E42A1CD18BEC00ABE381 /* ResearchKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ResearchKit.xcodeproj; path = ../dependency/ResearchKit.xcodeproj; sourceTree = "<group>"; };
 		247E67871E53DCD30045D28B /* ResearchKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C703DE72042C2B6002D12EA /* DrinkWater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkWater.swift; sourceTree = "<group>"; };
 		B555759B1CB3DB8C0028DC37 /* NSCalendar+Dates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSCalendar+Dates.swift"; sourceTree = "<group>"; };
 		B555759D1CB3DBBE0028DC37 /* OCKInsightItem+EmptyMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OCKInsightItem+EmptyMessage.swift"; sourceTree = "<group>"; };
 		B56848B51CB5085E00D190EE /* InsightsBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsightsBuilder.swift; sourceTree = "<group>"; };
@@ -344,6 +346,7 @@
 			isa = PBXGroup;
 			children = (
 				B5C100E31CB27B5F00FAD7E8 /* Activity.swift */,
+				6C703DE72042C2B6002D12EA /* DrinkWater.swift */,
 				B58A3FB11CC81E89009CF1B9 /* OutdoorWalk.swift */,
 				B58A3FB31CC81EB8009CF1B9 /* HamstringStretch.swift */,
 				B58A3FB51CC81ED8009CF1B9 /* TakeMedication.swift */,
@@ -663,6 +666,7 @@
 				BA965B281DC6D3200066EAC6 /* Glyph.swift in Sources */,
 				B58A3FBD1CC81FF9009CF1B9 /* Mood.swift in Sources */,
 				1801613F1D4E778F0036E247 /* WatchConnectivityManager.swift in Sources */,
+				6C703DE82042C2B6002D12EA /* DrinkWater.swift in Sources */,
 				B5C01D521CB3BC2D000728D9 /* BuildInsightsOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sample/OCKSample/Activity.swift
+++ b/Sample/OCKSample/Activity.swift
@@ -48,6 +48,7 @@ enum ActivityType: String {
     case outdoorWalk
     case hamstringStretch
     case takeMedication
+    case drinkWater
     
     case backPain
     case mood

--- a/Sample/OCKSample/DrinkWater.swift
+++ b/Sample/OCKSample/DrinkWater.swift
@@ -1,9 +1,68 @@
-//
-//  DrinkWater.swift
-//  OCKSample
-//
-//  Created by Macro Yau on 25/2/2018.
-//  Copyright © 2018 Apple. All rights reserved.
-//
+/*
+ Copyright (c) 2017, Apple Inc. All rights reserved.
+ Copyright (c) 2018, Macro Yau. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
-import Foundation
+import CareKit
+
+/**
+ Struct that conforms to the `Activity` protocol to define an activity to take
+ medication.
+ */
+struct DrinkWater: Activity {
+    // MARK: Activity
+    
+    let activityType: ActivityType = .drinkWater
+    
+    func carePlanActivity() -> OCKCarePlanActivity {
+        // Create a weekly schedule.
+        let startDate = DateComponents(year: 2016, month: 01, day: 01)
+        let schedule = OCKCareSchedule.weeklySchedule(withStartDate: startDate as DateComponents, occurrencesOnEachDay: [8, 8, 8, 8, 8, 8, 8])
+        
+        // Get the localized strings to use for the activity.
+        let title = NSLocalizedString("Water", comment: "")
+        let summary = NSLocalizedString("250mL", comment: "")
+        let instructions = NSLocalizedString("Drink 8 glasses of water a day.", comment: "")
+        
+        let activity = OCKCarePlanActivity.intervention(
+            withIdentifier: activityType.rawValue,
+            groupIdentifier: "Medications",
+            title: title,
+            text: summary,
+            tintColor: Colors.lightBlue.color,
+            instructions: instructions,
+            imageURL: nil,
+            schedule: schedule,
+            userInfo: nil,
+            optional: true
+        )
+        
+        return activity
+    }
+}

--- a/Sample/OCKSample/DrinkWater.swift
+++ b/Sample/OCKSample/DrinkWater.swift
@@ -1,0 +1,9 @@
+//
+//  DrinkWater.swift
+//  OCKSample
+//
+//  Created by Macro Yau on 25/2/2018.
+//  Copyright © 2018 Apple. All rights reserved.
+//
+
+import Foundation

--- a/Sample/OCKSample/SampleData.swift
+++ b/Sample/OCKSample/SampleData.swift
@@ -40,6 +40,7 @@ class SampleData: NSObject {
         OutdoorWalk(),
         HamstringStretch(),
         TakeMedication(),
+        DrinkWater(),
         BackPain(),
         Mood(),
         BloodGlucose(),


### PR DESCRIPTION
Currently, each Care Card activity supports up to 14 buttons (intervention events), and the buttons layout is hard-coded to 7 per row, regardless of the screen size. Due to this hard-coded layout, arranging 8 to 12 buttons may look unbalanced.

This PR proposes changing the buttons layout as follows:

1. Maximum number of buttons per row is determined by screen width (e.g., 8 buttons a row is possible on iPhone 8 Plus); and
2. The actual number of buttons per row to be rendered is then calculated with respect to the number of buttons, so as to achieve a more aesthetic layout.

The newly introduced "Drink Water" activity in OCKSample app demonstrates both changes. With the "8 glasses of water a day" interventions, the current CareKit implementation renders the Care Card buttons like this:

> O O O O O O O O
> O

Now, with the screen width-based arrangement, the 8 buttons can be shown in a single row on larger screens. For smaller screens (e.g., iPhone 8 / SE), the buttons will be arranged in a more balanced fashion:

> O O O O
> O O O O