### PR TITLE
Allow custom header title in Care Contents

### DIFF
--- a/CareKit/CareCard/OCKCareCardViewController.h
+++ b/CareKit/CareCard/OCKCareCardViewController.h
@@ -187,7 +187,7 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, null_resettable) UIColor *glyphTintColor;
 
 /**
- The string that will be used as the Care Card header title.
+ The string that will be used as the Care Card header title. If you need to show the completion percentage in the customized title, include "%@" in the specified string.
  
  If the value is not specified, CareKit's default string ("Care Completion") is used.
  */

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -201,7 +201,7 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, null_resettable) UIColor *glyphTintColor;
 
 /**
- The string that will be used as the Care Contents header title.
+ The string that will be used as the Care Contents header title. If you need to show the completion percentage in the customized title, include "%@" in the specified string.
  
  If the value is not specified, CareKit's default string ("Your care overview is x% complete") is used.
  */

--- a/CareKit/CareContents/OCKCareContentsViewController.h
+++ b/CareKit/CareContents/OCKCareContentsViewController.h
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2017, Apple Inc. All rights reserved.
  Copyright (c) 2017, Erik Hornberger. All rights reserved.
+ Copyright (c) 2018, Macro Yau. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -199,6 +200,12 @@ OCK_CLASS_AVAILABLE
  */
 @property (nonatomic, null_resettable) UIColor *glyphTintColor;
 
+/**
+ The string that will be used as the Care Contents header title.
+ 
+ If the value is not specified, CareKit's default string ("Your care overview is x% complete") is used.
+ */
+@property (nonatomic, null_resettable) NSString *headerTitle;
 
 /**
  The glyph type for the header view (see OCKGlyphType).

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2017, Apple Inc. All rights reserved.
  Copyright (c) 2017, Erik Hornberger. All rights reserved.
+ Copyright (c) 2018, Macro Yau. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -189,7 +190,9 @@
         _headerView = [[OCKHeaderView alloc] initWithFrame:CGRectZero];
         [self.view addSubview:_headerView];
     }
-    
+    if ([_headerTitle length] > 0) {
+        _headerView.title = _headerTitle;
+    }
     _headerView.tintColor = self.glyphTintColor;
     if (self.glyphType == OCKGlyphTypeCustom) {
         UIImage *glyphImage = [self createCustomImageName:self.customGlyphImageName];
@@ -352,6 +355,13 @@
     _weekViewController.weekView.tintColor = _glyphTintColor;
     _headerView.tintColor = _glyphTintColor;
     self.navigationItem.rightBarButtonItem.tintColor = _glyphTintColor;
+}
+
+- (void)setHeaderTitle:(NSString *)headerTitle {
+    _headerTitle = headerTitle;
+    if ([_headerTitle length] > 0) {
+        _headerView.title = _headerTitle;
+    }
 }
 
 - (void)setDelegate:(id<OCKCareContentsViewControllerDelegate>)delegate

--- a/CareKit/Common/OCKHeaderView.m
+++ b/CareKit/Common/OCKHeaderView.m
@@ -102,7 +102,11 @@ static const CGFloat RingViewSize = 110.0;
 
 - (void)updateView {
     if (self.title.length > 0) {
-        _titleLabel.text = self.title;
+        if ([self.title containsString:@"%@"]) {
+            _titleLabel.text = [NSString stringWithFormat:self.title, [self valuePercentageString]];
+        } else {
+            _titleLabel.text = self.title;
+        }
     } else if (self.isCareCard) {
         _titleLabel.text = [NSString stringWithFormat:OCKLocalizedString(@"HEADER_TITLE_CARE_OVERVIEW", nil), [self valuePercentageString]];
     } else {

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.h
@@ -149,7 +149,7 @@ OCK_CLASS_AVAILABLE
 @property (nonatomic, null_resettable) UIColor *glyphTintColor;
 
 /**
- The string that will be used as the Symptom Tracker header title.
+ The string that will be used as the Symptom Tracker header title. If you need to show the completion percentage in the customized title, include "%@" in the specified string.
  
  If the value is not specified, CareKit's default string ("Activity Completion") is used.
  */


### PR DESCRIPTION
In addition to extending #141 to Care Contents, completion percentage can also be displayed in the customized title by including `%@` in the string provided.