### PR TITLE
Remove navigation bar tinting from framework

### DIFF
--- a/CareKit/CareCard/OCKCareCardViewController.m
+++ b/CareKit/CareCard/OCKCareCardViewController.m
@@ -104,7 +104,6 @@
                                                                               style:UIBarButtonItemStylePlain
                                                                              target:self
                                                                              action:@selector(showToday:)];
-    self.navigationItem.rightBarButtonItem.tintColor = self.glyphTintColor;
     
     _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
     _tableView.dataSource = self;
@@ -136,9 +135,6 @@
     _noActivitiesLabel.textAlignment = NSTextAlignmentCenter;
     _noActivitiesLabel.numberOfLines = 0;
     _tableView.backgroundView = _noActivitiesLabel;
-    
-    self.navigationController.navigationBar.translucent = NO;
-    [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -336,7 +332,6 @@
     }
     _weekViewController.weekView.tintColor = _glyphTintColor;
     _headerView.tintColor = _glyphTintColor;
-    self.navigationItem.rightBarButtonItem.tintColor = _glyphTintColor;
 }
 
 - (void)setHeaderTitle:(NSString *)headerTitle {

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -124,7 +124,6 @@
                                                                               style:UIBarButtonItemStylePlain
                                                                              target:self
                                                                              action:@selector(showToday:)];
-    self.navigationItem.rightBarButtonItem.tintColor = self.glyphTintColor;
 
     _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
     _tableView.dataSource = self;
@@ -154,10 +153,6 @@
     _noActivitiesLabel.numberOfLines = 0;
     _noActivitiesLabel.textAlignment = NSTextAlignmentCenter;
     _tableView.backgroundView = _noActivitiesLabel;
-    
-    self.navigationController.navigationBar.translucent = NO;
-    [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
-
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -351,7 +346,6 @@
     }
     _weekViewController.weekView.tintColor = _glyphTintColor;
     _headerView.tintColor = _glyphTintColor;
-    self.navigationItem.rightBarButtonItem.tintColor = _glyphTintColor;
 }
 
 - (void)setDelegate:(id<OCKCareContentsViewControllerDelegate>)delegate

--- a/CareKit/Connect/OCKConnectMessagesViewController.m
+++ b/CareKit/Connect/OCKConnectMessagesViewController.m
@@ -82,13 +82,6 @@ static NSString *EmptyString = @"";
     _isKeyboardVisible = NO;
 }
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    
-    self.navigationController.navigationBar.translucent = NO;
-    [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
-}
-
 - (void)prepareView {
     _placeholderString = OCKLocalizedString(@"CONNECT_MESSAGE_PLACEHOLDER", nil);
     self.title = OCKLocalizedString(@"CONNECT_INBOX_TITLE", nil);

--- a/CareKit/Connect/OCKConnectViewController.m
+++ b/CareKit/Connect/OCKConnectViewController.m
@@ -97,9 +97,6 @@
     _tableView.estimatedSectionHeaderHeight = 0;
     _tableView.estimatedSectionFooterHeight = 0;
     
-    self.navigationController.navigationBar.translucent = NO;
-    [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
-    
     [self createSectionedContacts];
     
     if ([self respondsToSelector:@selector(registerForPreviewingWithDelegate:sourceView:)]) {

--- a/CareKit/Insights/OCKInsightsViewController.m
+++ b/CareKit/Insights/OCKInsightsViewController.m
@@ -109,9 +109,6 @@
         [self.view addSubview:_tableView];
     }
     
-    self.navigationController.navigationBar.translucent = NO;
-    [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
-    
     [self setUpConstraints];
 }
 

--- a/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
+++ b/CareKit/SymptomTracker/OCKSymptomTrackerViewController.m
@@ -102,7 +102,6 @@
                                                                               style:UIBarButtonItemStylePlain
                                                                              target:self
                                                                              action:@selector(showToday:)];
-    self.navigationItem.rightBarButtonItem.tintColor = self.glyphTintColor;
     
     _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
     _tableView.dataSource = self;
@@ -134,9 +133,6 @@
     [_refreshControl addTarget:self action:@selector(didActivatePullToRefreshControl:) forControlEvents:UIControlEventValueChanged];
     _tableView.refreshControl = _refreshControl;
     [self updatePullToRefreshControl];
-    
-    self.navigationController.navigationBar.translucent = NO;
-    [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:245.0/255.0 green:244.0/255.0 blue:246.0/255.0 alpha:1.0]];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -335,7 +331,6 @@
     
     _weekViewController.weekView.tintColor = _glyphTintColor;
     _headerView.tintColor = _glyphTintColor;
-    self.navigationItem.rightBarButtonItem.tintColor = _glyphTintColor;
 }
 
 - (void)setHeaderTitle:(NSString *)headerTitle {

--- a/Sample/OCKSample/AppDelegate.swift
+++ b/Sample/OCKSample/AppDelegate.swift
@@ -38,6 +38,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         window?.tintColor = OCKColor.red
+        
+        let navigationBarAppearance = UINavigationBar.appearance()
+        navigationBarAppearance.barTintColor = UIColor(red: 245.0 / 255.0,
+                                                       green: 244.0 / 255.0,
+                                                       blue: 246.0 / 255.0,
+                                                       alpha: 1.0)
+        navigationBarAppearance.tintColor = OCKColor.red
+        navigationBarAppearance.isTranslucent = false
+        
         return true
     }
 }


### PR DESCRIPTION
This PR removes the CareKit view controllers' navigation bar tinting currently hard-coded or altered by `glyphTintColor`. Instead, a navigation bar style consistent throughout the app should be defined in `application(_:didFinishLaunchingWithOptions:)` (as reflected in `AppDelegate` of OCKSample).

For the "Today" button, I believe that it should be colored according to the navigation bar styling, rather than `glyphTintColor`, given the [recommendations in HIG](https://developer.apple.com/ios/human-interface-guidelines/visual-design/color/).