### PR TITLE
Fix typos and update code formatting

### DIFF
--- a/CareKit/CareKit/Lists/View/OCKHeaderBodyView.swift
+++ b/CareKit/CareKit/Lists/View/OCKHeaderBodyView.swift
@@ -70,7 +70,7 @@ internal class OCKHeaderBodyView: UIView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("Unsupported Initializer.")
+        fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: Methods

--- a/CareKit/CareKit/Lists/View/OCKListView.swift
+++ b/CareKit/CareKit/Lists/View/OCKListView.swift
@@ -66,18 +66,18 @@ internal class OCKListView: UIView {
         constrainSubviews()
     }
 
+    private func addSubviews() {
+        addSubview(scrollView)
+        scrollView.addSubview(contentView)
+        contentView.addSubview(stackView)
+    }
+
     private func styleSubviews() {
         preservesSuperviewLayoutMargins = true
         contentView.backgroundColor = OCKStyle.color.gray1
         scrollView.backgroundColor = contentView.backgroundColor
         stackView.spacing = directionalLayoutMargins.top * 3
         scrollView.alwaysBounceVertical = true
-    }
-
-    private func addSubviews() {
-        addSubview(scrollView)
-        scrollView.addSubview(contentView)
-        contentView.addSubview(stackView)
     }
 
     private func constrainSubviews() {

--- a/CareKitUI/CareKitUI/Common/Extensions/UIFont+Extensions.swift
+++ b/CareKitUI/CareKitUI/Common/Extensions/UIFont+Extensions.swift
@@ -54,7 +54,7 @@ internal extension UIFont {
             UIFontDescriptor.AttributeName.family: UIFont.systemFont(ofSize: size).familyName
         ])
 
-        // add the font weight too the descriptor
+        // Add the font weight to the descriptor
         let weightedFontDescriptor = fontDescriptor.addingAttributes([
             UIFontDescriptor.AttributeName.traits: [
                 UIFontDescriptor.TraitKey.weight: weight

--- a/CareKitUI/CareKitUI/Common/Views/OCKCollapsedView.swift
+++ b/CareKitUI/CareKitUI/Common/Views/OCKCollapsedView.swift
@@ -31,6 +31,8 @@
 import UIKit
 
 internal class OCKCollapsedView: UIView {
+	// MARK: Properties
+
     private enum Const {
         static let bundle = Bundle(for: OCKCollapserButton.self)
     }
@@ -45,6 +47,8 @@ internal class OCKCollapsedView: UIView {
         return imageView
     }()
 
+	// MARK: Life cycle
+
     init() {
         super.init(frame: .zero)
         setup()
@@ -54,6 +58,8 @@ internal class OCKCollapsedView: UIView {
         super.init(coder: aDecoder)
         setup()
     }
+
+	// MARK: Methods
 
     private func setup() {
         styleSubviews()

--- a/CareKitUI/CareKitUI/Common/Views/OCKSeparatorView.swift
+++ b/CareKitUI/CareKitUI/Common/Views/OCKSeparatorView.swift
@@ -33,6 +33,8 @@ import UIKit
 
 /// Separator view.
 open class OCKSeparatorView: UIView {
+	// MARK: Life cycle
+
     public init() {
         super.init(frame: .zero)
         setup()
@@ -42,6 +44,8 @@ open class OCKSeparatorView: UIView {
         super.init(coder: aDecoder)
         setup()
     }
+
+	// MARK: Methods
 
     private func setup() {
         styleSubviews()

--- a/CareKitUI/CareKitUI/Components/Task/Buttons/OCKLabeledCircleButton.swift
+++ b/CareKitUI/CareKitUI/Components/Task/Buttons/OCKLabeledCircleButton.swift
@@ -65,6 +65,14 @@ internal class OCKLabeledCircleButton: OCKButton {
         constrainSubviews()
     }
 
+    private func addSubviews() {
+        [_imageButton, _titleButton].forEach { addSubview($0) }
+    }
+
+    private func styleSubviews() {
+        preservesSuperviewLayoutMargins = true
+    }
+
     private func constrainSubviews() {
         [_titleButton, _imageButton].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
         NSLayoutConstraint.activate([
@@ -78,13 +86,5 @@ internal class OCKLabeledCircleButton: OCKButton {
             _titleButton.trailingAnchor.constraint(equalTo: trailingAnchor),
             bottomAnchor.constraint(equalTo: _titleButton.bottomAnchor)
         ])
-    }
-
-    private func addSubviews() {
-        [_imageButton, _titleButton].forEach { addSubview($0) }
-    }
-
-    private func styleSubviews() {
-        preservesSuperviewLayoutMargins = true
     }
 }

--- a/CareKitUI/CareKitUI/Components/Task/Buttons/OCKLogItemButton.swift
+++ b/CareKitUI/CareKitUI/Components/Task/Buttons/OCKLogItemButton.swift
@@ -31,7 +31,9 @@
 import UIKit
 
 internal class OCKLogItemButton: OCKButton {
-    private enum Constants {
+	// MARK: Properties
+
+	private enum Constants {
         static let bundle = Bundle(for: OCKChecklistItemButton.self)
         static let spacing: CGFloat = 2
     }

--- a/CareKitUI/CareKitUI/Components/Task/OCKChecklistTaskView.swift
+++ b/CareKitUI/CareKitUI/Components/Task/OCKChecklistTaskView.swift
@@ -168,20 +168,20 @@ open class OCKChecklistTaskView: UIView, OCKCardable, OCKCollapsible, OCKCollaps
         collapsedView.addGestureRecognizer(tapGesture)
     }
 
-    private func styleSubviews() {
-        preservesSuperviewLayoutMargins = true
-        enableCardStyling(true)
-        contentStackView.spacing = directionalLayoutMargins.top * 2
-        contentStackView.setCustomSpacing(0, after: instructionsLabel)
-        contentStackView.setCustomSpacing(0, after: spacerView)
-    }
-
     private func addSubviews() {
         addSubview(contentView)
         contentView.addSubview(contentStackView)
         [headerView, checklistItemsStackView, instructionsLabel, spacerView, collapsedView, collapserButton].forEach {
             contentStackView.addArrangedSubview($0)
         }
+    }
+
+    private func styleSubviews() {
+        preservesSuperviewLayoutMargins = true
+        enableCardStyling(true)
+        contentStackView.spacing = directionalLayoutMargins.top * 2
+        contentStackView.setCustomSpacing(0, after: instructionsLabel)
+        contentStackView.setCustomSpacing(0, after: spacerView)
     }
 
     private func constrainSubviews() {

--- a/CareKitUI/CareKitUI/Components/Task/OCKInstructionsTaskView.swift
+++ b/CareKitUI/CareKitUI/Components/Task/OCKInstructionsTaskView.swift
@@ -140,19 +140,19 @@ open class OCKInstructionsTaskView: UIView, OCKCardable, OCKCollapsible, OCKColl
         collapsedView.addGestureRecognizer(tapGesture)
     }
 
+    private func addSubviews() {
+        addSubview(contentView)
+        contentView.addSubview(contentStackView)
+        [headerView, instructionsLabel, completionButton,
+         spacerView, collapsedView, collapserButton].forEach { contentStackView.addArrangedSubview($0) }
+    }
+
     private func styleSubviews() {
         preservesSuperviewLayoutMargins = true
         enableCardStyling(true)
         contentStackView.spacing = directionalLayoutMargins.top * 2
         contentStackView.setCustomSpacing(0, after: completionButton)
         contentStackView.setCustomSpacing(0, after: spacerView)
-    }
-
-    private func addSubviews() {
-        addSubview(contentView)
-        contentView.addSubview(contentStackView)
-        [headerView, instructionsLabel, completionButton,
-         spacerView, collapsedView, collapserButton].forEach { contentStackView.addArrangedSubview($0) }
     }
 
     private func constrainSubviews() {

--- a/CareKitUI/CareKitUI/Components/Task/OCKSimpleLogTaskView.swift
+++ b/CareKitUI/CareKitUI/Components/Task/OCKSimpleLogTaskView.swift
@@ -135,17 +135,17 @@ open class OCKSimpleLogTaskView: UIView, OCKCardable {
         constrainSubviews()
     }
 
+    private func addSubviews() {
+        addSubview(contentStackView)
+        [headerView, instructionsLabel, logButton, logItemsStackView].forEach { contentStackView.addArrangedSubview($0) }
+    }
+
     private func styleSubviews() {
         preservesSuperviewLayoutMargins = true
         enableCardStyling(true)
         logItemsStackView.spacing = directionalLayoutMargins.top
         contentStackView.spacing = directionalLayoutMargins.top * 2
         setSpacingAfterLogButton(0, animated: false)
-    }
-
-    private func addSubviews() {
-        addSubview(contentStackView)
-        [headerView, instructionsLabel, logButton, logItemsStackView].forEach { contentStackView.addArrangedSubview($0) }
     }
 
     private func constrainSubviews() {

--- a/CareKitUI/CareKitUI/Components/Task/OCKSimpleTaskView.swift
+++ b/CareKitUI/CareKitUI/Components/Task/OCKSimpleTaskView.swift
@@ -74,13 +74,13 @@ open class OCKSimpleTaskView: UIView, OCKCardable, OCKCollapsible {
         constrainSubviews()
     }
 
+    private func addSubviews() {
+        [headerView, completionButton].forEach { addSubview($0) }
+    }
+
     private func styleSubviews() {
         preservesSuperviewLayoutMargins = true
         enableCardStyling(true)
-    }
-
-    private func addSubviews() {
-        [headerView, completionButton].forEach { addSubview($0) }
     }
 
     private func constrainSubviews() {

--- a/CareKitUI/CareKitUI/Detail View/OCKDetailView.swift
+++ b/CareKitUI/CareKitUI/Detail View/OCKDetailView.swift
@@ -30,7 +30,7 @@
 
 import UIKit
 
-/// A view with intended to display fine grained details. The view contains a configurable image, title, and instrucitons. To add
+/// A view intended to display fine grained details. The view contains a configurable image, title, and instructions. To add
 /// custom views, insert into the `contentStackView`.
 open class OCKDetailView: UIView {
     // MARK: Properties
@@ -50,14 +50,14 @@ open class OCKDetailView: UIView {
         return titleLabel
     }()
 
-    /// secondary multi-line label
+    /// Secondary multi-line label
     public let instructionsLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .subheadline, weight: .medium)
         label.numberOfLines = 0
         return label
     }()
 
-    /// The vertical stack view thta holds the main contentt for the view.
+    /// The vertical stack view that holds the main content for the view.
     public let contentStackView: OCKStackView = {
         let stackView = OCKStackView()
         stackView.axis = .vertical


### PR DESCRIPTION
Just wanted to contribute a few fixes and updates for issues I noticed:

- Reorders method declarations in custom `UIView`s to match their corresponding `setup()` methods. Matching the call order improves readability and makes parsing much quicker.
- Fixes numerous typos.
- Adds missing `MARK`s.
- Adds consistent messaging for `fatalError(...)` in `OCKHeaderBodyView`.