### PR TITLE
Integrate TravisCI for CareKit 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: swift 
+osx_image: xcode11
+xcode_workspace: CKWorkspace.xcworkspace
+xcode_scheme: CareKit
+xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11 Pro Max

--- a/CareKit/CareKit.xcodeproj/xcshareddata/xcschemes/CareKit.xcscheme
+++ b/CareKit/CareKit.xcodeproj/xcshareddata/xcschemes/CareKit.xcscheme
@@ -60,13 +60,6 @@
             BlueprintName = "CareKit"
             ReferencedContainer = "container:CareKit.xcodeproj">
          </BuildableReference>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "E784B8F72232EED600736CA5"
-            BuildableName = "CareKitCarePlanStore.framework"
-            BlueprintName = "CareKitCarePlanStore"
-            ReferencedContainer = "container:CareKitCarePlanStore/CareKitCarePlanStore.xcodeproj">
-         </BuildableReference>
       </CodeCoverageTargets>
       <Testables>
          <TestableReference
@@ -87,6 +80,26 @@
                BuildableName = "CareKitTests.xctest"
                BlueprintName = "CareKitTests"
                ReferencedContainer = "container:CareKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E784B9002232EED600736CA5"
+               BuildableName = "CareKitStoreTests.xctest"
+               BlueprintName = "CareKitStoreTests"
+               ReferencedContainer = "container:../CareKitStore/CareKitStore.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "512B012D22C2F82900ABCB1D"
+               BuildableName = "CareKitUITests.xctest"
+               BlueprintName = "CareKitUITests"
+               ReferencedContainer = "container:../CareKitUI/CareKitUI.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>

--- a/CareKitStore/CareKitStoreTests/Store/TestStore+Tasks.swift
+++ b/CareKitStore/CareKitStoreTests/Store/TestStore+Tasks.swift
@@ -261,14 +261,14 @@ class TestStoreTasks: XCTestCase {
         taskA.effectiveDate = dateA
         taskA = try store.addTaskAndWait(OCKTask(identifier: "A", title: "a", carePlanID: nil, schedule: schedule))
 
-        let dateB = Date().addingTimeInterval(100)
+        let dateB = dateA.addingTimeInterval(100)
         var taskB = OCKTask(identifier: "A", title: "b", carePlanID: nil, schedule: schedule)
         taskB.effectiveDate = dateB
         taskB = try store.updateTaskAndWait(taskB)
 
         let query = OCKTaskQuery(start: dateA.addingTimeInterval(10), end: dateB.addingTimeInterval(-10))
         let fetched = try store.fetchTasksAndWait(query: query)
-        XCTAssert(fetched.count == 1)
+        XCTAssert(fetched.count == 1, "Expected to get 1 task, but got \(fetched.count)")
         XCTAssert(fetched.first?.title == taskA.title)
     }
 


### PR DESCRIPTION
This PR enables TravisCI for CareKit 2.0
Note that running tests for CareKit now also runs tests for CareKitUI and CareKitStore.