### PR TITLE
Fix crash caused by updating a task without changing its effective date

### DIFF
--- a/CareKitStore/CareKitStore/CoreData/OCKCDOutcome.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKCDOutcome.swift
@@ -36,7 +36,7 @@ class OCKCDOutcome: OCKCDObject, OCKCDManageable {
     @NSManaged var taskOccurrenceIndex: Int
     @NSManaged var task: OCKCDTask?
     @NSManaged var values: Set<OCKCDOutcomeValue>
-    @NSManaged var date: Date?
+    @NSManaged var date: Date
 
     static var defaultSortDescriptors: [NSSortDescriptor] {
         return [NSSortDescriptor(keyPath: \OCKCDOutcome.createdDate, ascending: false)]

--- a/CareKitStore/CareKitStore/CoreData/OCKManagedObjectModel.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKManagedObjectModel.swift
@@ -52,7 +52,7 @@ import CoreData
 //
 
 private let secureUnarchiver = "NSSecureUnarchiveFromData"
-private let schemaVersion = OCKSemanticVersion(majorVersion: 2, minorVersion: 0, patchNumber: 0)
+private let schemaVersion = OCKSemanticVersion(majorVersion: 2, minorVersion: 0, patchNumber: 1)
 
 private func makeManagedObjectModel() -> NSManagedObjectModel {
     let managedObjectModel = NSManagedObjectModel()
@@ -801,7 +801,7 @@ private func makeOutcomeEntity() -> NSEntityDescription {
     let date = NSAttributeDescription()
     date.name = "date"
     date.attributeType = .dateAttributeType
-    date.isOptional = true
+    date.isOptional = false
 
     outcomeEntity.properties = makeObjectAttributes() + [index, date]
     return outcomeEntity

--- a/CareKitStore/CareKitStoreTests/CoreDataSchema/TestCoreDataSchema+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/CoreDataSchema/TestCoreDataSchema+Outcomes.swift
@@ -70,6 +70,7 @@ class TestCoreDataSchemaWithOutcomes: XCTestCase {
         outcome.taskOccurrenceIndex = 0
         outcome.values = Set([value1, value2, value3])
         outcome.task = task1
+        outcome.date = Date()
 
         XCTAssertNoThrow(try store.context.save())
         XCTAssert(outcome.values.count == 3)

--- a/CareKitStore/CareKitStoreTests/CoreDataSchema/TestCoreDataSchemaIntegration.swift
+++ b/CareKitStore/CareKitStoreTests/CoreDataSchema/TestCoreDataSchemaIntegration.swift
@@ -69,6 +69,7 @@ class TestCoreDataSchemaIntegration: XCTestCase {
         let outcome = OCKCDOutcome(context: store.context)
         outcome.taskOccurrenceIndex = 0
         outcome.task = task
+        outcome.date = Date()
 
         let value = OCKCDOutcomeValue(context: store.context)
         value.kind = "pulse"

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -83,13 +83,43 @@ class TestStoreOutcomes: XCTestCase {
         XCTAssert(outcome.taskID == taskID)
     }
 
-    func testTwoOutcomesWithoutSameTaskIDAndOccurenceIndexCannotBeAdded() throws {
+    func testTwoOutcomesWithoutSameTaskIDAndOccurrenceIndexCannotBeAdded() throws {
         var task = OCKTask(id: "task", title: "My Task", carePlanID: nil, schedule: .mealTimesEachDay(start: Date(), end: nil))
         task = try store.addTaskAndWait(task)
         let taskID = try task.getLocalID()
 
         let outcome = OCKOutcome(taskID: taskID, taskOccurrenceIndex: 2, values: [])
         XCTAssertThrowsError(try store.addOutcomesAndWait([outcome, outcome]))
+    }
+
+    func testCannotAddOutcomeToCoveredRegionOfPreviousTaskVersion() throws {
+        let thisMorning = Calendar.current.startOfDay(for: Date())
+        let schedule = OCKSchedule.mealTimesEachDay(start: thisMorning, end: nil)
+        let task = OCKTask(id: "meds", title: "Medications", carePlanID: nil, schedule: schedule)
+        let taskV1 = try store.addTaskAndWait(task)
+        let taskV2 = try store.updateTaskAndWait(task)
+        let value = OCKOutcomeValue(123)
+        let outcome = OCKOutcome(taskID: try taskV1.getLocalID(), taskOccurrenceIndex: 1, values: [value])
+        XCTAssert(taskV2.previousVersionID == taskV1.localDatabaseID)
+        XCTAssertThrowsError(try store.addOutcomeAndWait(outcome))
+    }
+
+    func testCannotUpdateOutcomeToCoveredRegionOfPreviousTaskVersion() throws {
+        let thisMorning = Calendar.current.startOfDay(for: Date())
+        let tomorrowMorning = Calendar.current.date(byAdding: .day, value: 1, to: thisMorning)!
+        let schedule = OCKSchedule.mealTimesEachDay(start: thisMorning, end: nil)
+
+        var task = OCKTask(id: "meds", title: "Medications", carePlanID: nil, schedule: schedule)
+        let taskV1 = try store.addTaskAndWait(task)
+
+        task.effectiveDate = tomorrowMorning
+        try store.updateTaskAndWait(task)
+
+        let value = OCKOutcomeValue(123)
+        var outcome = OCKOutcome(taskID: try taskV1.getLocalID(), taskOccurrenceIndex: 0, values: [value])
+        outcome = try store.addOutcomeAndWait(outcome)
+        outcome.taskOccurrenceIndex = 8
+        XCTAssertThrowsError(try store.updateOutcomeAndWait(outcome))
     }
 
     // MARK: Querying


### PR DESCRIPTION
These changes modify the behavior of versioned tasks and fix #349.

1. Avoid a hard crash if a later version of a task has an earlier `effectiveDate` than a previous version.

2. Assure that outcomes can't be added to "shadowed" areas of past versions of tasks.

Consider the following case.

```
|--------- Query Interval ------------|
     Task V1 -------------------------->
                   V2 ----------------->
              V3----------------------->
```

When querying for events in the given interval, we start from version three and gather all outcomes. We then move on to version 2 and gather all outcomes in the region before V3 begins. A crash would occur in this case because there the time between the start of V2 and V3 is negative.

**This was fixed by skipping over versions that are fully shadowed**. Unit tests have been added to prevent regression.

```
|--------- Query Interval ------------|
     Task V1 -------------------------->
                   V2 ----x------x----->
              V3----------------------->
```

Another possibly unexpected result could occur if there were outcomes saved to V2 when V3 was created. Before the creation of V3, queries would return outcomes from V2, but after the creation of V3, those outcomes would no longer be returned because V2 is shadowed by V3. 

**This was fixed by adding checks that make the transaction fail if updating a task or outcome would result in "shadowed" outcomes.** Unit tests have also been added to ensure the expected behavior in these cases as well.