### PR TITLE
Fix a bug that involved scheduling of all day tasks

### DIFF
--- a/CareKitStore/CareKitStore/Structs/OCKSchedule.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKSchedule.swift
@@ -94,7 +94,12 @@ public struct OCKSchedule: Codable, Equatable {
         for index in 0..<allEvents.count {
             allEvents[index] = allEvents[index].changing(occurrenceIndex: index)
         }
-        return allEvents.filter { $0.start + $0.element.duration.seconds >= start }
+        return allEvents.filter { event in
+            if event.element.duration == .allDay {
+                return event.start >= Calendar.current.startOfDay(for: start)
+            }
+            return event.start + event.element.duration.seconds >= start
+        }
     }
 
     /// Create a new schedule by shifting this schedule.

--- a/CareKitStore/CareKitStore/Structs/OCKScheduleElement.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKScheduleElement.swift
@@ -223,6 +223,13 @@ public struct OCKScheduleElement: Codable, Equatable, OCKObjectCompatible {
 
     /// Determines the last date at which an event could possibly occur
     private func determineStopDate(onOrBefore date: Date) -> Date {
+        if duration == .allDay {
+          let stopDay = end ?? date
+          let morningOfStopDay = Calendar.current.startOfDay(for: stopDay)
+          let endOfStopDay = Calendar.current.date(byAdding: .init(day: 1, second: -1), to: morningOfStopDay)!
+          return endOfStopDay
+        }
+        
         guard let endDate = end else { return date }
         return min(endDate, date)
     }

--- a/CareKitStore/CareKitStoreTests/Structs/TestSchedule.swift
+++ b/CareKitStore/CareKitStoreTests/Structs/TestSchedule.swift
@@ -57,6 +57,17 @@ class TestSchedule: XCTestCase {
         XCTAssert(events[2].occurrence == 2)
     }
 
+    func testAllDayEventsCapturedByEventsBetweenDates() {
+         let morning = Calendar.current.startOfDay(for: Date())
+         let breakfast = Calendar.current.date(byAdding: .hour, value: 7, to: morning)!
+         let lunch = Calendar.current.date(byAdding: .hour, value: 12, to: morning)!
+         let dinner = Calendar.current.date(byAdding: .hour, value: 18, to: morning)!
+         let allDay = OCKScheduleElement(start: breakfast, end: nil, interval: DateComponents(day: 1), text: "Daily", duration: .allDay)
+         let schedule = OCKSchedule(composing: [allDay])
+         let events = schedule.events(from: lunch, to: dinner)
+         XCTAssert(events.count == 1, "Expected 1 all day event, but got \(events.count)")
+     }
+
     func testWeeklySchedule() {
         let schedule = OCKSchedule.weeklyAtTime(weekday: 1, hours: 0, minutes: 0, start: Date(), end: nil, targetValues: [], text: nil)
         for index in 0..<5 {


### PR DESCRIPTION
This change addresses a bug in which tasks with a duration of `.allDay` were not properly captured by `OCKSchedule`'s `events(from:to:)` method.


```swift
let morning = Calendar.current.startOfDay(for: Date())
let breakfast = Calendar.current.date(byAdding: .hour, value: 7, to: morning)!
let lunch = Calendar.current.date(byAdding: .hour, value: 12, to: morning)!
let dinner = Calendar.current.date(byAdding: .hour, value: 18, to: morning)!
let allDay = OCKScheduleElement(start: breakfast, end: nil, interval: DateComponents(day: 1), text: "Daily", duration: .allDay)
let schedule = OCKSchedule(composing: [allDay])

// This should return 1 event. It was incorrectly returning 0.
let events = schedule.events(from: lunch, to: dinner)
```