### PR TITLE
Fix for a bug that prevented tasks with outcomes from being updated.

### DIFF
--- a/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
@@ -257,7 +257,10 @@ extension OCKCoreDataTaskStoreProtocol {
             guard let latestDate = allOutcomes.map({ $0.date }).max()
                 else { continue }
 
-            if task.effectiveDate <= latestDate {
+            guard let proposedUpdate = tasks.first(where: { $0.id == task.id })
+                else { fatalError("Fetched an OCKCDTask for which an update was not proposed.") }
+
+            if proposedUpdate.effectiveDate <= latestDate {
                 throw OCKStoreError.updateFailed(reason: """
                     Updating task \(task.id) failed. The new version of the task takes effect on \(task.effectiveDate), but an outcome for a
                     previous version of the task exists on \(latestDate). To prevent implicit data loss, you must explicitly delete all outcomes

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Tasks.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Tasks.swift
@@ -276,6 +276,15 @@ class TestStoreTasks: XCTestCase {
         XCTAssertThrowsError(try store.updateTaskAndWait(task))
     }
 
+    func testCanUpdateTaskWithOutcomesIfDoesNotCauseDataLoss() throws {
+        let schedule = OCKSchedule.mealTimesEachDay(start: Date(), end: nil)
+        var task = try store.addTaskAndWait(OCKTask(id: "meds", title: "Medication", carePlanID: nil, schedule: schedule))
+        let outcome = OCKOutcome(taskID: try task.getLocalID(), taskOccurrenceIndex: 0, values: [OCKOutcomeValue(1)])
+        try store.addOutcomesAndWait([outcome])
+        task.effectiveDate = task.schedule[5].start
+        XCTAssertNoThrow(try store.updateTaskAndWait(task))
+    }
+
     func testUpdateFailsForUnsavedTasks() {
         let task = OCKTask(id: "meds", title: "Medication", carePlanID: nil, schedule: .mealTimesEachDay(start: Date(), end: nil))
         XCTAssertThrowsError(try store.updateTaskAndWait(task))


### PR DESCRIPTION
This is a fix for the bug discovered in by #353.
There was a logical error in the pre-update validation for tasks.

A unit test has been added to cover this case.