### PR TITLE
Fix query by tag bug

### DIFF
--- a/CareKitStore/CareKitStore/CoreData/OCKStore+CarePlans.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+CarePlans.swift
@@ -54,7 +54,10 @@ extension OCKStore {
                     fetchRequest.sortDescriptors = self.buildSortDescriptors(from: query)
                 }
 
-                let plans = persistedPlans.map(self.makePlan)
+                let plans = persistedPlans
+                    .map(self.makePlan)
+                    .filter({ $0.matches(tags: query.tags) })
+
                 callbackQueue.async { completion(.success(plans)) }
             } catch {
                 self.context.rollback()
@@ -189,10 +192,6 @@ extension OCKStore {
 
         if !query.groupIdentifiers.isEmpty {
             predicate = predicate.including(groupIdentifiers: query.groupIdentifiers)
-        }
-
-        if !query.tags.isEmpty {
-            predicate = predicate.including(tags: query.tags)
         }
 
         return predicate

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Contacts.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Contacts.swift
@@ -43,7 +43,10 @@ extension OCKStore {
                     fetchRequest.sortDescriptors = self.buildSortDescriptors(for: query)
                 }
 
-                let contacts = persistedContacts.map(self.makeContact)
+                let contacts = persistedContacts
+                    .map(self.makeContact)
+                    .filter({ $0.matches(tags: query.tags) })
+
                 callbackQueue.async { completion(.success(contacts)) }
             } catch {
                 callbackQueue.async { completion(.failure(.fetchFailed(reason: "Failed to fetch contacts. Error: \(error.localizedDescription)"))) }
@@ -225,10 +228,6 @@ extension OCKStore {
 
         if !query.groupIdentifiers.isEmpty {
             predicate = predicate.including(groupIdentifiers: query.groupIdentifiers)
-        }
-
-        if !query.tags.isEmpty {
-            predicate = predicate.including(tags: query.tags)
         }
 
         return predicate

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Patients.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Patients.swift
@@ -43,7 +43,10 @@ extension OCKStore {
                     fetchRequest.sortDescriptors = self.buildSortDescriptors(from: query)
                 }
 
-                let patients = patientsObjects.map(self.makePatient)
+                let patients = patientsObjects
+                    .map(self.makePatient)
+                    .filter({ $0.matches(tags: query.tags) })
+
                 callbackQueue.async { completion(.success(patients)) }
             } catch {
                 self.context.rollback()
@@ -171,10 +174,6 @@ extension OCKStore {
 
         if !query.groupIdentifiers.isEmpty {
             predicate = predicate.including(groupIdentifiers: query.groupIdentifiers)
-        }
-
-        if !query.tags.isEmpty {
-            predicate = predicate.including(tags: query.tags)
         }
 
         return predicate

--- a/CareKitStore/CareKitStore/CoreData/OCKStore.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore.swift
@@ -95,9 +95,4 @@ internal extension NSPredicate {
         let groupPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.groupIdentifier), groupIdentifiers)
         return NSCompoundPredicate(andPredicateWithSubpredicates: [self, groupPredicate])
     }
-
-    func including(tags: [String]) -> NSPredicate {
-        let tagsPredicate = NSPredicate(format: "SOME %K IN %@", #keyPath(OCKCDObject.tags), tags)
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [self, tagsPredicate])
-    }
 }

--- a/CareKitStore/CareKitStore/Protocols/OCKObjectCompatible.swift
+++ b/CareKitStore/CareKitStore/Protocols/OCKObjectCompatible.swift
@@ -116,6 +116,11 @@ extension OCKObjectCompatible {
             return note
         }
     }
+
+    func matches(tags: [String]) -> Bool {
+        if tags.isEmpty { return true }
+        return !Set(self.tags ?? []).isDisjoint(with: tags)
+    }
 }
 
 extension OCKVersionedObjectCompatible {

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -203,6 +203,21 @@ class TestStoreOutcomes: XCTestCase {
         XCTAssert(fetched == outcome)
     }
 
+    func testQueryOutcomeByTag() throws {
+        var task = OCKTask(id: "A", title: nil, carePlanID: nil, schedule: .mealTimesEachDay(start: Date(), end: nil))
+        task = try store.addTaskAndWait(task)
+
+        var outcome = OCKOutcome(taskID: try task.getLocalID(), taskOccurrenceIndex: 0, values: [])
+        outcome.tags = ["123"]
+        outcome = try store.addOutcomeAndWait(outcome)
+
+        var query = OCKOutcomeQuery(for: Date())
+        query.tags = ["123"]
+
+        let fetched = try store.fetchOutcomesAndWait(query: query).first
+        XCTAssert(fetched == outcome)
+    }
+
     // MARK: Updating
 
     func testUpdateOutcomes() throws {


### PR DESCRIPTION
Close #356 

This commit fixes a problem in which queries against tags would work on .inMemory stores but not on .onDisk stores.

The underlying problem was that CoreData serializes arrays of tags to binary when they are saved to disk, and predicates do no evaluate properly against binary blobs. .inMemory stores do not serialize anything, so predicates do work as one would expect.

The solution was to perform filtering against tags at the CareKitStore level instead of the CoreData level. This solution is sub-optimal from a performance perspective, but will likely never manifest as a problem given the number of tasks in a typical CareKit app.

We considered addressing the root problem by changing the tags from an array of strings into a many-to-many relationship with its own table. However, this would require a complicated database migration and doesn't seem worth the effort or the risk. In the future, we may consider making this change if it can be batched with other changes into a single migration.