### PR TITLE
Fixed query regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift 
-osx_image: xcode11
+osx_image: xcode11.3
 xcode_workspace: CKWorkspace.xcworkspace
 xcode_scheme: CareKit
-xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11 Pro Max
+xcode_destination: platform=iOS Simulator,OS=13.3,name=iPhone 11 Pro Max

--- a/CareKitStore/CareKitStore/CoreData/OCKCDVersionedObject.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKCDVersionedObject.swift
@@ -75,7 +75,7 @@ class OCKCDVersionedObject: OCKCDObject, OCKCDManageable {
     static func headerPredicate() -> NSPredicate {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [
             notDeletedPredicate,
-            NSPredicate(format: "%K == nil", #keyPath(OCKCDVersionedObject.deletedDate))
+            NSPredicate(format: "%K == nil", #keyPath(OCKCDVersionedObject.next))
         ])
     }
 

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Contacts.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Contacts.swift
@@ -234,12 +234,33 @@ class TestStoreContacts: XCTestCase {
         XCTAssertThrowsError(try store.updateContactAndWait(patient))
     }
 
-    func testContactQueryOnlyReturnsLatestVersionOfAContact() throws {
-        let versionA = try store.addContactAndWait(OCKContact(id: "contact", givenName: "Amy", familyName: "Frost", carePlanID: nil))
-        let versionB = try store.updateContactAndWait(OCKContact(id: "contact", givenName: "Mariana", familyName: "Lin", carePlanID: nil))
-        let fetched = try store.fetchContactAndWait(id: versionA.id)
-        XCTAssert(fetched?.id == versionB.id)
-        XCTAssert(fetched?.name == versionB.name)
+    func testContactQueryByIDOnlyReturnsLatestVersionOfAContact() throws {
+        try store.addContactAndWait(OCKContact(id: "contact", givenName: "A", familyName: "", carePlanID: nil))
+        try store.updateContactAndWait(OCKContact(id: "contact", givenName: "B", familyName: "", carePlanID: nil))
+        try store.updateContactAndWait(OCKContact(id: "contact", givenName: "C", familyName: "", carePlanID: nil))
+        let versionD = try store.updateContactAndWait(OCKContact(id: "contact", givenName: "D", familyName: "", carePlanID: nil))
+        let fetched = try store.fetchContactAndWait(id: "contact")
+        XCTAssert(fetched?.id == versionD.id)
+        XCTAssert(fetched?.name == versionD.name)
+    }
+
+    func testContactQueryWithDateOnlyReturnsLatestVersionOfAContact() throws {
+        try store.addContactAndWait(OCKContact(id: "contact", givenName: "A", familyName: "", carePlanID: nil))
+        try store.updateContactAndWait(OCKContact(id: "contact", givenName: "B", familyName: "", carePlanID: nil))
+        try store.updateContactAndWait(OCKContact(id: "contact", givenName: "C", familyName: "", carePlanID: nil))
+        try store.updateContactAndWait(OCKContact(id: "contact", givenName: "D", familyName: "", carePlanID: nil))
+        let fetched = try store.fetchContactsAndWait(query: OCKContactQuery(for: Date()))
+        XCTAssert(fetched.count == 1)
+        XCTAssert(fetched.first?.name.givenName == "D")
+    }
+
+    func testContactQueryWithNoDateReturnsAllVersionsOfAContact() throws {
+        try store.addContactAndWait(OCKContact(id: "contact", givenName: "A", familyName: "", carePlanID: nil))
+        try store.updateContactAndWait(OCKContact(id: "contact", givenName: "B", familyName: "", carePlanID: nil))
+        try store.updateContactAndWait(OCKContact(id: "contact", givenName: "C", familyName: "", carePlanID: nil))
+        try store.updateContactAndWait(OCKContact(id: "contact", givenName: "D", familyName: "", carePlanID: nil))
+        let fetched = try store.fetchContactsAndWait(query: OCKContactQuery())
+        XCTAssert(fetched.count == 4)
     }
 
     func testContactQueryOnPastDateReturnsPastVersionOfAContact() throws {


### PR DESCRIPTION
The problem was that a previous commit (hash 72625cb92f3c58f86c48bbb7317296faf2c1f568) incorrectly modified the header predicate such that it was no longer checking if a "next" version exists.

The solution was to rectify the predicate.

Close #357.