### PR TITLE
Resolve task version chain bug

### DIFF
--- a/CareKit/CareKit/Synchronized View Controllers/Task/View Controllers/OCKTaskViewController.swift
+++ b/CareKit/CareKit/Synchronized View Controllers/Task/View Controllers/OCKTaskViewController.swift
@@ -112,7 +112,7 @@ UIViewController, OCKTaskViewDelegate {
 
     // Reset view state on a failure
     // Note: This is needed because the UI assumes user interactions (lke button taps) will be successful, and displays the corresponding
-    // state immedately. When the interaction is actually unsuccessful, we need to reset the UI.
+    // state immediately. When the interaction is actually unsuccessful, we need to reset the UI.
     func resetViewState() {
         controller.objectWillChange.value = controller.objectWillChange.value // triggers an update to the view
     }

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
@@ -175,7 +175,7 @@ public extension OCKReadOnlyEventStore where Task: OCKAnyVersionableTask, Outcom
                         // If there is a previous version, fetch the events for it that don't overlap with
                         // any of the versions we've already fetched events for.
                         let nextEndDate = task.effectiveDate
-                        let nextStartDate = max(query.dateInterval.start, previousVersion.effectiveDate)
+                        let nextStartDate = query.dateInterval.start
                         let nextInterval = DateInterval(start: nextStartDate, end: nextEndDate)
                         let nextQuery = OCKEventQuery(dateInterval: nextInterval)
                         self.fetchEvents(task: previousVersion, query: nextQuery, previousEvents: events,

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
@@ -127,11 +127,12 @@ public extension OCKReadOnlyEventStore where Task: OCKAnyVersionableTask, Outcom
                 let late = scheduleEvent.end.addingTimeInterval(1)
                 var query = OCKOutcomeQuery(dateInterval: DateInterval(start: early, end: late))
                 query.taskVersionIDs = [taskVersionID]
-                self.fetchOutcome(query: query, callbackQueue: callbackQueue, completion: { result in
+                self.fetchOutcomes(query: query, callbackQueue: callbackQueue, completion: { result in
                     switch result {
                     case .failure(let error): completion(.failure(.fetchFailed(reason: "Couldn't find outcome. \(error.localizedDescription)")))
-                    case .success(let outcome):
-                        let event = OCKEvent(task: task, outcome: outcome, scheduleEvent: scheduleEvent)
+                    case .success(let outcomes):
+                        let matchingOutcome = outcomes.first(where: { $0.taskOccurrenceIndex == occurrenceIndex })
+                        let event = OCKEvent(task: task, outcome: matchingOutcome, scheduleEvent: scheduleEvent)
                         completion(.success(event))
                     }
                 })

--- a/CareKitStore/CareKitStoreTests/TestStoreProtocolExtensions.swift
+++ b/CareKitStore/CareKitStoreTests/TestStoreProtocolExtensions.swift
@@ -231,6 +231,21 @@ class TestStoreProtocolExtensions: XCTestCase {
         XCTAssert(events.first?.task.title == "B")
     }
 
+    func testFetchEventsReturnsAnEventForEachVersionOfATaskWhenEventsAreAllDayDuration() throws {
+        let midnight = Calendar.current.startOfDay(for: Date())
+        let schedule = OCKSchedule.dailyAtTime(hour: 0, minutes: 0, start: midnight, end: nil, text: nil, duration: .allDay, targetValues: [])
+        let task = OCKTask(id: "A", title: "Original", carePlanID: nil, schedule: schedule)
+        try store.addTaskAndWait(task)
+        for i in 1...10 {
+            var update = task
+            update.effectiveDate = midnight.advanced(by: 10 * TimeInterval(i))
+            update.title = "Update \(i)"
+            try store.updateTaskAndWait(update)
+        }
+        let events = try store.fetchEventsAndWait(taskID: "A", query: .init(for: midnight))
+        XCTAssert(events.count == 11)
+    }
+
     // MARK: Adherence and Insights
 
     func testFetchAdherenceAggregatesEventsAcrossTasks() throws {

--- a/CareKitStore/CareKitStoreTests/TestStoreProtocolExtensions.swift
+++ b/CareKitStore/CareKitStoreTests/TestStoreProtocolExtensions.swift
@@ -246,6 +246,12 @@ class TestStoreProtocolExtensions: XCTestCase {
         XCTAssert(events.count == 11)
     }
 
+    func testFetchSingleEventSucceedsEvenIfThereIsNoOutcome() throws {
+        let schedule = OCKSchedule.mealTimesEachDay(start: Date(), end: nil)
+        let task = try store.addTaskAndWait(OCKTask(id: "A", title: "ABC", carePlanID: nil, schedule: schedule))
+        XCTAssertNoThrow(try store.fetchEventAndWait(forTask: task, occurrence: 0))
+    }
+
     // MARK: Adherence and Insights
 
     func testFetchAdherenceAggregatesEventsAcrossTasks() throws {


### PR DESCRIPTION
Close #367 

Resolves an issue in which the events for tasks with many versions were not correctly returned from queries.

- Address a logic error in the store's recursive event fetch method. When fetching events from old versions of a task, the query start date was being set to a date that was later than the query applied at the beginning of the recursion. This resulted in invalid date ranges when recursing back more than one task version.

- Ensure task view controllers update when their watched task changes

- Fix a problem in which `fetchEvent(task:occurrence:)` would fail if the outcome for the event was nil.