### PR TITLE
Propagate background color in `OCKListView`

### DIFF
--- a/CareKit/CareKit.xcodeproj/project.pbxproj
+++ b/CareKit/CareKit.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		51B714862367849100590A5A /* OCKButtonLogTaskView+Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B714852367849100590A5A /* OCKButtonLogTaskView+Updatable.swift */; };
 		51BEAD5A237E00C600B32D55 /* TestDailyTasksPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BEAD59237E00C600B32D55 /* TestDailyTasksPageViewController.swift */; };
 		51CF0A00235528EC00A343F9 /* OCKTaskControllerProtocol+Methods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CF09FF235528EC00A343F9 /* OCKTaskControllerProtocol+Methods.swift */; };
+		51D8E27F24115D7D0026C716 /* TestListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D8E27E24115D7D0026C716 /* TestListView.swift */; };
 		51E88828234CE61300763B97 /* OCKContactViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E88827234CE61300763B97 /* OCKContactViewController.swift */; };
 		51EF7E46234FAAB700B28C0A /* OCKSimpleTaskViewSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF7E45234FAAB700B28C0A /* OCKSimpleTaskViewSynchronizer.swift */; };
 		51EF7E48234FAB7A00B28C0A /* OCKInstructionsTaskViewSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF7E47234FAB7A00B28C0A /* OCKInstructionsTaskViewSynchronizer.swift */; };
@@ -232,6 +233,7 @@
 		51B714852367849100590A5A /* OCKButtonLogTaskView+Updatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKButtonLogTaskView+Updatable.swift"; sourceTree = "<group>"; };
 		51BEAD59237E00C600B32D55 /* TestDailyTasksPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDailyTasksPageViewController.swift; sourceTree = "<group>"; };
 		51CF09FF235528EC00A343F9 /* OCKTaskControllerProtocol+Methods.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKTaskControllerProtocol+Methods.swift"; sourceTree = "<group>"; };
+		51D8E27E24115D7D0026C716 /* TestListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestListView.swift; sourceTree = "<group>"; };
 		51E88827234CE61300763B97 /* OCKContactViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKContactViewController.swift; sourceTree = "<group>"; };
 		51EF7E45234FAAB700B28C0A /* OCKSimpleTaskViewSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKSimpleTaskViewSynchronizer.swift; sourceTree = "<group>"; };
 		51EF7E47234FAB7A00B28C0A /* OCKInstructionsTaskViewSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKInstructionsTaskViewSynchronizer.swift; sourceTree = "<group>"; };
@@ -484,6 +486,7 @@
 				51FF9B8C2373374200BAEDB2 /* Calendar */,
 				511372452374DFBD00831191 /* TestSynchronizedContext.swift */,
 				51BEAD59237E00C600B32D55 /* TestDailyTasksPageViewController.swift */,
+				51D8E27E24115D7D0026C716 /* TestListView.swift */,
 				5196C7FD226F8F8F00F1C2A2 /* Info.plist */,
 			);
 			path = CareKitTests;
@@ -871,6 +874,7 @@
 				511372442374CA2B00831191 /* TestCustomChartViewController.swift in Sources */,
 				511372422374CA1900831191 /* TestCartesianChartViewSynchronizer.swift in Sources */,
 				51FF9B8E2373377500BAEDB2 /* TestWeekCalendarViewSynchronizer.swift in Sources */,
+				51D8E27F24115D7D0026C716 /* TestListView.swift in Sources */,
 				511372462374DFBD00831191 /* TestSynchronizedContext.swift in Sources */,
 				51BEAD5A237E00C600B32D55 /* TestDailyTasksPageViewController.swift in Sources */,
 			);

--- a/CareKit/CareKit/Lists/View/OCKListView.swift
+++ b/CareKit/CareKit/Lists/View/OCKListView.swift
@@ -33,6 +33,13 @@ import UIKit
 /// A view enclosing a scrollable stack view.
 internal class OCKListView: OCKView {
 
+    override var backgroundColor: UIColor? {
+        didSet {
+            contentView.backgroundColor = backgroundColor
+            scrollView.backgroundColor = backgroundColor
+        }
+    }
+
     // MARK: Properties
 
     /// The stack view embedded inside the scroll view.
@@ -45,7 +52,7 @@ internal class OCKListView: OCKView {
     /// The scroll view that contains the stack view.
     let scrollView = UIScrollView()
 
-    private let contentView = UIView()
+    let contentView = UIView()
 
     // MARK: - Life Cycle
 
@@ -68,7 +75,6 @@ internal class OCKListView: OCKView {
     }
 
     private func styleSubviews() {
-        scrollView.backgroundColor = contentView.backgroundColor
         scrollView.alwaysBounceVertical = true
     }
 
@@ -97,7 +103,6 @@ internal class OCKListView: OCKView {
         let cachedStyle = style()
         contentView.directionalLayoutMargins = cachedStyle.dimension.directionalInsets1
         backgroundColor = cachedStyle.color.customGroupedBackground
-        contentView.backgroundColor = cachedStyle.color.customGroupedBackground
         stackView.spacing = cachedStyle.dimension.directionalInsets1.top
     }
 }

--- a/CareKit/CareKitTests/TestListView.swift
+++ b/CareKit/CareKitTests/TestListView.swift
@@ -1,0 +1,44 @@
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@testable import CareKit
+import Foundation
+import XCTest
+
+class TestListView: XCTestCase {
+
+    func testBackgroundColorPropagates() {
+        let view = OCKListView()
+        view.backgroundColor = .red
+        XCTAssertEqual(view.backgroundColor, .red)
+        XCTAssertEqual(view.backgroundColor, view.scrollView.backgroundColor)
+        XCTAssertEqual(view.contentView.backgroundColor, view.scrollView.backgroundColor)
+    }
+}


### PR DESCRIPTION
This fixes an issue where the background color in the `OCKListView` was not being set correctly from the view's style.