### PR TITLE
Fix bug in deserialization of OCKScheduleElement

### DIFF
--- a/CareKitStore/CareKitStore/Structs/OCKScheduleElement.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKScheduleElement.swift
@@ -78,9 +78,11 @@ public struct OCKScheduleElement: Codable, Equatable, OCKObjectCompatible {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             if try container.decodeIfPresent(Bool.self, forKey: .isAllDay) == true {
                 self = .allDay
+                return
             }
             if let seconds = try container.decodeIfPresent(Double.self, forKey: .seconds) {
                 self = .seconds(seconds)
+                return
             }
             throw DecodingError.dataCorruptedError(forKey: CodingKeys.seconds, in: container, debugDescription: "No seconds or allDay key was found!")
         }

--- a/CareKitStore/CareKitStoreTests/Structs/TestScheduleElement.swift
+++ b/CareKitStore/CareKitStoreTests/Structs/TestScheduleElement.swift
@@ -51,6 +51,13 @@ class TestScheduleElement: XCTestCase {
     var element: OCKScheduleElement {
         return OCKScheduleElement(start: date, end: nil, interval: interval, text: "Wedding Anniversary", targetValues: [])
     }
+    
+    func testSerialization() throws {
+        XCTAssertNoThrow(try JSONEncoder().encode(element))
+        let data = try JSONEncoder().encode(element)
+        let decoded = try JSONDecoder().decode(OCKScheduleElement.self, from: data)
+        XCTAssert(element == decoded)
+    }
 
     func testSubscript() {
         let event = element[0]


### PR DESCRIPTION
This fixes a bug that caused an error to be thrown when attempting to deserialize `OCKScheduleElement`s.