### PR TITLE
Add new addUpdateOrDelete tasks method onto OCKStore

### DIFF
--- a/CareKitStore/CareKitStore/Protocols/OCKStoreProtocol+Synchronous.swift
+++ b/CareKitStore/CareKitStore/Protocols/OCKStoreProtocol+Synchronous.swift
@@ -294,7 +294,21 @@ extension OCKReadOnlyEventStore {
 }
 
 extension OCKAnyTaskStore {
+    @discardableResult
     func addAnyTaskAndWait(_ task: OCKAnyTask) throws -> OCKAnyTask {
         try performSynchronously { addAnyTask(task, callbackQueue: backgroundQueue, completion: $0) }
+    }
+}
+
+extension OCKCoreDataTaskStoreProtocol {
+    @discardableResult
+    func addUpdateOrDeleteTasksAndWait(addOrUpdate tasksToAddOrUpdate: [Task],
+                                       delete tasksToDelete: [Task]) throws -> ([Task], [Task], [Task]) {
+        try performSynchronously {
+            addUpdateOrDeleteTasks(
+                addOrUpdate: tasksToAddOrUpdate,
+                delete: tasksToDelete,
+                callbackQueue: backgroundQueue, completion: $0)
+        }
     }
 }

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Tasks.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Tasks.swift
@@ -92,6 +92,24 @@ class TestStoreTasks: XCTestCase {
         guard let fetchedElement = task.schedule.elements.first else { XCTFail("Bad schedule"); return }
         XCTAssertTrue(fetchedElement.duration == .allDay)
     }
+    
+    func testAddUpdateOrDelete() throws {
+        let schedule = OCKSchedule.mealTimesEachDay(start: Date(), end: nil)
+        let taskC = OCKTask(id: "C", title: "OriginalC", carePlanID: nil, schedule: schedule)
+        try store.addTaskAndWait(OCKTask(id: "A", title: "OriginalA", carePlanID: nil, schedule: schedule))
+        try store.addTaskAndWait(taskC)
+        
+        let taskA = OCKTask(id: "A", title: "UpdatedA", carePlanID: nil, schedule: schedule)
+        let taskB = OCKTask(id: "B", title: "OriginalB", carePlanID: nil, schedule: schedule)
+        try store.addUpdateOrDeleteTasksAndWait(addOrUpdate: [taskA, taskB], delete: [taskC])
+        
+        let tasks = try store.fetchTasksAndWait(query: OCKTaskQuery())
+        let titles = tasks.map { $0.title }
+        XCTAssert(tasks.count == 3)
+        XCTAssert(titles.contains("OriginalA"))
+        XCTAssert(titles.contains("UpdatedA"))
+        XCTAssert(titles.contains("OriginalB"))
+    }
 
     // MARK: Querying
 
@@ -227,6 +245,7 @@ class TestStoreTasks: XCTestCase {
         let fetched = try store.fetchTasksAndWait(query: query).first
         XCTAssert(fetched == task)
     }
+    
     // MARK: Versioning
 
     func testUpdateTaskCreateNewVersion() throws {


### PR DESCRIPTION
This PR adds a new `addUpdateOrDeleteTasks` method onto `OCKStore`.
This new method is useful because it allows one to perform atomic batch operations.