### PR TITLE
Anchor action sheet in TaskViewController

### DIFF
--- a/CareKit/CareKit/Synchronized View Controllers/Task/View Controllers/OCKTaskViewController.swift
+++ b/CareKit/CareKit/Synchronized View Controllers/Task/View Controllers/OCKTaskViewController.swift
@@ -134,9 +134,9 @@ UIViewController, OCKTaskViewDelegate {
         do {
             let alert = try controller.initiateDeletionForOutcomeValue(atIndex: index, eventIndexPath: eventIndexPath,
                                                                        deletionCompletion: notifyDelegateAndResetViewOnError)
-            if let anchorPoint = sender as? UIView {
-                alert.popoverPresentationController?.sourceRect = anchorPoint.bounds
-                alert.popoverPresentationController?.sourceView = anchorPoint
+            if let anchor = sender as? UIView {
+                alert.popoverPresentationController?.sourceRect = anchor.bounds
+                alert.popoverPresentationController?.sourceView = anchor
                 alert.popoverPresentationController?.permittedArrowDirections = .any
             }
             present(alert, animated: true, completion: nil)

--- a/CareKit/CareKit/Synchronized View Controllers/Task/View Controllers/OCKTaskViewController.swift
+++ b/CareKit/CareKit/Synchronized View Controllers/Task/View Controllers/OCKTaskViewController.swift
@@ -134,6 +134,11 @@ UIViewController, OCKTaskViewDelegate {
         do {
             let alert = try controller.initiateDeletionForOutcomeValue(atIndex: index, eventIndexPath: eventIndexPath,
                                                                        deletionCompletion: notifyDelegateAndResetViewOnError)
+            if let anchorPoint = sender as? UIView {
+                alert.popoverPresentationController?.sourceRect = anchorPoint.bounds
+                alert.popoverPresentationController?.sourceView = anchorPoint
+                alert.popoverPresentationController?.permittedArrowDirections = .any
+            }
             present(alert, animated: true, completion: nil)
         } catch {
             delegate?.taskViewController(self, didEncounterError: error)


### PR DESCRIPTION
Fixes a crash on iPad and MacOS devices because the action sheet isn't anchored. The crash occurs when you use OCKButtonLogTaskViewController and you try to tap to delete an already saved outcome.

This addresses #358.

I know that @erik-apple mentioned that iPad isn't officially supported, but I wanted to provide this fix as it's the only bug I found on the iPad so far and everything else has been working when using CareKit in my iPad app.