### PR TITLE
Query by uuid for Outcome and expose deletedDate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift 
-osx_image: xcode11.4.1
+osx_image: xcode11.4
 xcode_workspace: CKWorkspace.xcworkspace
 xcode_scheme: CareKit
 xcode_destination: platform=iOS Simulator,OS=13.4.1,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: swift
 osx_image: xcode11.4
 xcode_workspace: CKWorkspace.xcworkspace
 xcode_scheme: CareKit
-xcode_destination: platform=iOS Simulator,OS=13.4,name=iPhone 11 Pro Max
+xcode_destination: platform=iOS Simulator,OS=13.4.1,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift 
-osx_image: xcode11.4
+osx_image: xcode11.3
 xcode_workspace: CKWorkspace.xcworkspace
 xcode_scheme: CareKit
-xcode_destination: platform=iOS Simulator,OS=13.4.1,name=iPhone 11 Pro Max
+xcode_destination: platform=iOS Simulator,OS=13.3,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift 
-osx_image: xcode11.3
+osx_image: xcode11.4
 xcode_workspace: CKWorkspace.xcworkspace
 xcode_scheme: CareKit
-xcode_destination: platform=iOS Simulator,OS=13.3,name=iPhone 11 Pro Max
+xcode_destination: platform=iOS Simulator,OS=13.4.1,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift 
-osx_image: xcode11.4
+osx_image: xcode11.4.1
 xcode_workspace: CKWorkspace.xcworkspace
 xcode_scheme: CareKit
 xcode_destination: platform=iOS Simulator,OS=13.4.1,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift 
-osx_image: xcode11.4
+osx_image: xcode11.3
 xcode_workspace: CKWorkspace.xcworkspace
 xcode_scheme: CareKit
 xcode_destination: platform=iOS Simulator,OS=13.4.1,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: swift
 osx_image: xcode11.3
 xcode_workspace: CKWorkspace.xcworkspace
 xcode_scheme: CareKit
-xcode_destination: platform=iOS Simulator,OS=13.4.1,name=iPhone 11 Pro Max
+xcode_destination: platform=iOS Simulator,OS=13.3,name=iPhone 11 Pro Max

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+CarePlans.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+CarePlans.swift
@@ -171,8 +171,8 @@ extension OCKStore {
         }
 
         if !query.uuids.isEmpty {
-            let versionPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDVersionedObject.uuid), query.uuids)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, versionPredicate])
+            let objectPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.uuid), query.uuids)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, objectPredicate])
         }
 
         if !query.remoteIDs.isEmpty {
@@ -186,8 +186,8 @@ extension OCKStore {
         }
 
         if !query.patientUUIDs.isEmpty {
-            let versionPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDCarePlan.patient), query.patientUUIDs)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, versionPredicate])
+            let objectPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDCarePlan.patient.uuid), query.patientUUIDs)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, objectPredicate])
         }
 
         if !query.patientRemoteIDs.isEmpty {

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Contacts.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Contacts.swift
@@ -208,8 +208,8 @@ extension OCKStore {
         }
 
         if !query.uuids.isEmpty {
-            let versionPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDVersionedObject.id), query.uuids)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, versionPredicate])
+            let objectPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.uuid), query.uuids)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, objectPredicate])
         }
 
         if !query.remoteIDs.isEmpty {
@@ -223,8 +223,8 @@ extension OCKStore {
         }
 
         if !query.carePlanUUIDs.isEmpty {
-            let versionPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDContact.carePlan.uuid), query.carePlanUUIDs)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, versionPredicate])
+            let objectPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDContact.carePlan.uuid), query.carePlanUUIDs)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, objectPredicate])
         }
 
         if !query.carePlanRemoteIDs.isEmpty {

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Outcomes.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Outcomes.swift
@@ -241,6 +241,11 @@ extension OCKStore {
             predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, afterPredicate, beforePredicate])
         }
 
+        if !query.uuids.isEmpty {
+            let versionPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.uuid), query.uuids)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, versionPredicate])
+        }
+     
         if !query.remoteIDs.isEmpty {
             let remotePredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDVersionedObject.remoteID), query.remoteIDs)
             predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, remotePredicate])

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Outcomes.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Outcomes.swift
@@ -242,8 +242,8 @@ extension OCKStore {
         }
 
         if !query.uuids.isEmpty {
-            let versionPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.uuid), query.uuids)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, versionPredicate])
+            let objectPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.uuid), query.uuids)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, objectPredicate])
         }
      
         if !query.remoteIDs.isEmpty {

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Patients.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Patients.swift
@@ -168,8 +168,8 @@ extension OCKStore {
         }
 
         if !query.uuids.isEmpty {
-            let versionPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDVersionedObject.uuid), query.uuids)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, versionPredicate])
+            let objectPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.uuid), query.uuids)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, objectPredicate])
         }
 
         if !query.remoteIDs.isEmpty {

--- a/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataStoreProtocol.swift
+++ b/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataStoreProtocol.swift
@@ -141,8 +141,8 @@ extension OCKCoreDataStoreProtocol {
     }
 
     func validateNew<T: OCKCDVersionedObject, U: OCKVersionedObjectCompatible>(_ type: T.Type, _ objects: [U]) throws {
-        let ids = objects.map(\.id)
-        let uuids = objects.map(\.uuid)
+        let ids = objects.map{$0.id}
+        let uuids = objects.map{$0.uuid}
 
         guard Set(ids).count == ids.count else {
             throw OCKStoreError.invalidValue(reason: "Identifiers contains duplicate values! \(ids)")

--- a/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
@@ -352,8 +352,8 @@ extension OCKCoreDataTaskStoreProtocol {
         }
 
         if !query.uuids.isEmpty {
-            let versionPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDVersionedObject.uuid), query.uuids)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, versionPredicate])
+            let objectPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.uuid), query.uuids)
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, objectPredicate])
         }
 
         if !query.remoteIDs.isEmpty {

--- a/CareKitStore/CareKitStore/Structs/OCKOutcome.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKOutcome.swift
@@ -44,10 +44,10 @@ public struct OCKOutcome: Codable, Equatable, Identifiable, OCKAnyOutcome, OCKOb
     public var values: [OCKOutcomeValue]
 
     // MARK: OCKObjectCompatible
-    internal var uuid: UUID?
+    public internal(set) var uuid: UUID?
     public internal(set) var createdDate: Date?
     public internal(set) var updatedDate: Date?
-    internal var deletedDate: Date?
+    public internal(set) var deletedDate: Date?
     public internal(set) var schemaVersion: OCKSemanticVersion?
     public var remoteID: String?
     public var groupIdentifier: String?

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKOutcomeQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKOutcomeQuery.swift
@@ -103,6 +103,7 @@ public struct OCKOutcomeQuery: OCKAnyOutcomeQuery, Equatable {
 
     // MARK: OCKAnyOutcomeQuery
     public var ids: [String] = []
+    public var uuids: [UUID] = []
     public var remoteIDs: [String] = []
     public var taskIDs: [String] = []
     public var dateInterval: DateInterval?

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+CarePlans.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+CarePlans.swift
@@ -148,6 +148,17 @@ class TestStoreCarePlans: XCTestCase {
         let fetched = try store.fetchCarePlansAndWait(query: query)
         XCTAssert(fetched.map { $0.title } == ["A", "B"])
     }
+    
+    func testCarePlaneQueryByPatientUUID() throws {
+        let patient = try store.addPatientAndWait(.init(id: "A", givenName: "B", familyName: "C"))
+        let plan = try store.addCarePlanAndWait(.init(id: "F", title: "G", patientUUID: try patient.getUUID()))
+
+        var query = OCKCarePlanQuery()
+        query.patientUUIDs = [try patient.getUUID()]
+
+        let fetched = try store.fetchCarePlansAndWait(query: query)
+        XCTAssert(fetched == [plan])
+    }
 
     // MARK: Versioning
 

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Contacts.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Contacts.swift
@@ -219,6 +219,15 @@ class TestStoreContacts: XCTestCase {
         let fetched = try store.fetchContactsAndWait(query: query).first
         XCTAssert(fetched == contact)
     }
+    
+    func testQueryContactByUUID() throws {
+        var contact = OCKContact(id: "A", givenName: "B", familyName: "C", carePlanUUID: nil)
+        contact = try store.addContactAndWait(contact)
+        var query = OCKContactQuery()
+        query.uuids = [try contact.getUUID()]
+        let fetched = try store.fetchContactsAndWait(query: query).first
+        XCTAssert(fetched == contact)
+    }
 
     // MARK: Versioning
 

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -223,7 +223,6 @@ class TestStoreOutcomes: XCTestCase {
         task = try store.addTaskAndWait(task)
 
         var outcome = OCKOutcome(taskUUID: try task.getUUID(), taskOccurrenceIndex: 0, values: [])
-        outcome.tags = ["123"]
         outcome = try store.addOutcomeAndWait(outcome)
 
         var query = OCKOutcomeQuery(for: Date())

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -217,6 +217,24 @@ class TestStoreOutcomes: XCTestCase {
         let fetched = try store.fetchOutcomesAndWait(query: query).first
         XCTAssert(fetched == outcome)
     }
+ 
+    func testQueryOutcomeByUUID() throws {
+        var task = OCKTask(id: "A", title: nil, carePlanUUID: nil, schedule: .mealTimesEachDay(start: Date(), end: nil))
+        task = try store.addTaskAndWait(task)
+
+        var outcome = OCKOutcome(taskUUID: try task.getUUID(), taskOccurrenceIndex: 0, values: [])
+        outcome.tags = ["123"]
+        outcome = try store.addOutcomeAndWait(outcome)
+
+        var query = OCKOutcomeQuery(for: Date())
+        query.tags = ["123"]
+
+        let fetched = try store.fetchOutcomesAndWait(query: query).first
+        var query2 = OCKOutcomeQuery(for: Date())
+        query2.uuids = [fetched!.uuid!]
+        let fetched2 = try store.fetchOutcomesAndWait(query: query2).first
+        XCTAssert(fetched2 == outcome)
+    }
 
     // MARK: Updating
 

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -227,14 +227,10 @@ class TestStoreOutcomes: XCTestCase {
         outcome = try store.addOutcomeAndWait(outcome)
 
         var query = OCKOutcomeQuery(for: Date())
-        query.tags = ["123"]
-
-        let fetched = try store.fetchOutcomesAndWait(query: query).first
-        var query2 = OCKOutcomeQuery(for: Date())
-        query2.uuids = [fetched!.uuid!]
+        query.uuids = [ outcome.uuid!]
         
-        let fetched2 = try store.fetchOutcomesAndWait(query: query2).first
-        XCTAssert(fetched2 == outcome)
+        let fetched = try store.fetchOutcomesAndWait(query: query).first
+        XCTAssert(fetched == outcome)
     }
 
     // MARK: Updating

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -232,6 +232,7 @@ class TestStoreOutcomes: XCTestCase {
         let fetched = try store.fetchOutcomesAndWait(query: query).first
         var query2 = OCKOutcomeQuery(for: Date())
         query2.uuids = [fetched!.uuid!]
+        
         let fetched2 = try store.fetchOutcomesAndWait(query: query2).first
         XCTAssert(fetched2 == outcome)
     }

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -227,7 +227,7 @@ class TestStoreOutcomes: XCTestCase {
         outcome = try store.addOutcomeAndWait(outcome)
 
         var query = OCKOutcomeQuery(for: Date())
-        query.uuids = [ outcome.uuid!]
+        query.uuids = [try outcome.getUUID()]
         
         let fetched = try store.fetchOutcomesAndWait(query: query).first
         XCTAssert(fetched == outcome)

--- a/CareKitStore/CareKitStoreTests/Utils.swift
+++ b/CareKitStore/CareKitStoreTests/Utils.swift
@@ -60,13 +60,6 @@ extension OCKSchedule {
     }
 }
 
-extension OCKVersionedObjectCompatible {
-    func getUUID() throws -> UUID {
-        guard let uuid = uuid else { throw OCKStoreError.invalidValue(reason: "Missing UUID") }
-        return uuid
-    }
-}
-
 extension OCKObjectCompatible {
     func getUUID() throws -> UUID {
         guard let uuid = uuid else { throw OCKStoreError.invalidValue(reason: "Missing UUID") }

--- a/CareKitStore/CareKitStoreTests/Utils.swift
+++ b/CareKitStore/CareKitStoreTests/Utils.swift
@@ -66,3 +66,10 @@ extension OCKVersionedObjectCompatible {
         return uuid
     }
 }
+
+extension OCKObjectCompatible {
+    func getUUID() throws -> UUID {
+        guard let uuid = uuid else { throw OCKStoreError.invalidValue(reason: "Missing UUID") }
+        return uuid
+    }
+}


### PR DESCRIPTION
- Fix #432 
- Fix #433
- Fix query by uuids for OCKContact
- Fix query by patient uuids for OCKCarePlan
- Slight change to mapping ids and uuids in OCKCoreDataStoreProtocol.swift so that CareKit can still compile on < Xcode 11.4.0
- Downgrade travis to xcode11.3 and iOS13.3 since xcode11.4 is having issues, see [this](https://github.com/carekit-apple/CareKit/pull/435#issuecomment-632079613) for details.