### PR TITLE
Allow queries that match against nil

### DIFF
--- a/CareKitStore/CareKitStore/CoreData/OCKStore+CarePlans.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+CarePlans.swift
@@ -176,8 +176,7 @@ extension OCKStore {
         }
 
         if !query.remoteIDs.isEmpty {
-            let remotePredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.remoteID), query.remoteIDs)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, remotePredicate])
+            predicate = predicate.including(query.remoteIDs, for: #keyPath(OCKCDObject.remoteID))
         }
 
         if !query.patientIDs.isEmpty {
@@ -196,7 +195,9 @@ extension OCKStore {
         }
 
         if !query.groupIdentifiers.isEmpty {
-            predicate = predicate.including(groupIdentifiers: query.groupIdentifiers)
+            predicate = predicate.including(
+                query.groupIdentifiers,
+                for: #keyPath(OCKCDObject.groupIdentifier))
         }
 
         return predicate

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Contacts.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Contacts.swift
@@ -213,8 +213,7 @@ extension OCKStore {
         }
 
         if !query.remoteIDs.isEmpty {
-            let remotePredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.remoteID), query.remoteIDs)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, remotePredicate])
+            predicate = predicate.including(query.remoteIDs, for: #keyPath(OCKCDObject.remoteID))
         }
 
         if !query.carePlanIDs.isEmpty {
@@ -233,7 +232,9 @@ extension OCKStore {
         }
 
         if !query.groupIdentifiers.isEmpty {
-            predicate = predicate.including(groupIdentifiers: query.groupIdentifiers)
+            predicate = predicate.including(
+                query.groupIdentifiers,
+                for: #keyPath(OCKCDObject.groupIdentifier))
         }
 
         return predicate

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Outcomes.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Outcomes.swift
@@ -247,8 +247,7 @@ extension OCKStore {
         }
      
         if !query.remoteIDs.isEmpty {
-            let remotePredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDVersionedObject.remoteID), query.remoteIDs)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, remotePredicate])
+            predicate = predicate.including(query.remoteIDs, for: #keyPath(OCKCDObject.remoteID))
         }
 
         if !query.taskIDs.isEmpty {
@@ -267,7 +266,9 @@ extension OCKStore {
         }
 
         if !query.groupIdentifiers.isEmpty {
-            predicate = predicate.including(groupIdentifiers: query.groupIdentifiers)
+            predicate = predicate.including(
+                query.groupIdentifiers,
+                for: #keyPath(OCKCDObject.groupIdentifier))
         }
 
         return predicate

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Patients.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Patients.swift
@@ -173,12 +173,13 @@ extension OCKStore {
         }
 
         if !query.remoteIDs.isEmpty {
-            let remotePredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.remoteID), query.remoteIDs)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, remotePredicate])
+            predicate = predicate.including(query.remoteIDs, for: #keyPath(OCKCDObject.remoteID))
         }
 
         if !query.groupIdentifiers.isEmpty {
-            predicate = predicate.including(groupIdentifiers: query.groupIdentifiers)
+            predicate = predicate.including(
+                query.groupIdentifiers,
+                for: #keyPath(OCKCDObject.groupIdentifier))
         }
 
         return predicate

--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Tasks.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Tasks.swift
@@ -29,7 +29,6 @@
  */
 
 import Foundation
-import HealthKit
 
 extension OCKStore: OCKCoreDataTaskStoreProtocol {
 

--- a/CareKitStore/CareKitStore/CoreData/OCKStore.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore.swift
@@ -159,8 +159,12 @@ open class OCKStore: OCKStoreProtocol, OCKCoreDataStoreProtocol, Equatable {
 }
 
 internal extension NSPredicate {
-    func including(groupIdentifiers: [String]) -> NSPredicate {
-        let groupPredicate = NSPredicate(format: "%K IN %@", #keyPath(OCKCDObject.groupIdentifier), groupIdentifiers)
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [self, groupPredicate])
+    func including(_ identifiers: [String?], for keyPath: String) -> NSPredicate {
+        let idPredicate = NSPredicate(format: "%K IN %@", keyPath, identifiers)
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [self, idPredicate])
+        let nilPredicate = NSPredicate(format: "%K == NIL", keyPath)
+        let andNilPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [self, nilPredicate])
+        let orNilPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [predicate, andNilPredicate])
+        return identifiers.contains(nil) ? orNilPredicate : predicate
     }
 }

--- a/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
@@ -357,8 +357,7 @@ extension OCKCoreDataTaskStoreProtocol {
         }
 
         if !query.remoteIDs.isEmpty {
-            let remotePredicate = NSPredicate(format: "%K in %@", #keyPath(OCKCDVersionedObject.remoteID), query.remoteIDs)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, remotePredicate])
+            predicate = predicate.including(query.remoteIDs, for: #keyPath(OCKCDObject.remoteID))
         }
 
         if !query.carePlanIDs.isEmpty {

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKCarePlanQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKCarePlanQuery.swift
@@ -99,7 +99,7 @@ public struct OCKCarePlanQuery: OCKAnyCarePlanQuery, Equatable {
     internal var extendedSortDescriptors: [SortDescriptor] = []
 
     /// An array of group identifiers to match against.
-    public var groupIdentifiers: [String] = []
+    public var groupIdentifiers: [String?] = []
 
     /// An array of tags to match against. If an object's tags contains one or more of entries, it will match the query.
     public var tags: [String] = []
@@ -108,7 +108,7 @@ public struct OCKCarePlanQuery: OCKAnyCarePlanQuery, Equatable {
     public var patientIDs: [String] = []
     public var dateInterval: DateInterval?
     public var ids: [String] = []
-    public var remoteIDs: [String] = []
+    public var remoteIDs: [String?] = []
     public var offset: Int = 0
     public var limit: Int?
 

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKContactQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKContactQuery.swift
@@ -103,14 +103,14 @@ public struct OCKContactQuery: OCKAnyContactQuery, Equatable {
     internal var extendedSortDescriptors: [SortDescriptor] = []
 
     /// An array of group identifiers to match against.
-    public var groupIdentifiers: [String] = []
+    public var groupIdentifiers: [String?] = []
 
     /// An array of tags to match against. If an object's tags contains one or more of entries, it will match the query.
     public var tags: [String] = []
 
     // MARK: OCKAnyContactQuery
     public var ids: [String] = []
-    public var remoteIDs: [String] = []
+    public var remoteIDs: [String?] = []
     public var carePlanIDs: [String] = []
     public var dateInterval: DateInterval?
     public var limit: Int?

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKEntityQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKEntityQuery.swift
@@ -38,10 +38,10 @@ public protocol OCKEntityQuery {
     var ids: [String] { get set }
 
     /// An array of remote IDs for entities that should match the query.
-    var remoteIDs: [String] { get set }
+    var remoteIDs: [String?] { get set }
 
     /// An array of group identifers that should match the query.
-    var groupIdentifiers: [String] { get set }
+    var groupIdentifiers: [String?] { get set }
 
     /// A date interval for entities that should match the query.
     var dateInterval: DateInterval? { get set }

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKOutcomeQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKOutcomeQuery.swift
@@ -86,7 +86,7 @@ public struct OCKOutcomeQuery: OCKAnyOutcomeQuery, Equatable {
     public var taskRemoteIDs: [String] = []
 
     /// An array of group identifiers to match against.
-    public var groupIdentifiers: [String] = []
+    public var groupIdentifiers: [String?] = []
 
     /// The order in which the results will be sorted when returned from the query.
     public var sortDescriptors: [OCKOutcomeSortDescriptor] {
@@ -104,7 +104,7 @@ public struct OCKOutcomeQuery: OCKAnyOutcomeQuery, Equatable {
     // MARK: OCKAnyOutcomeQuery
     public var ids: [String] = []
     public var uuids: [UUID] = []
-    public var remoteIDs: [String] = []
+    public var remoteIDs: [String?] = []
     public var taskIDs: [String] = []
     public var dateInterval: DateInterval?
     public var limit: Int?

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKPatientQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKPatientQuery.swift
@@ -94,14 +94,14 @@ public struct OCKPatientQuery: OCKAnyPatientQuery, Equatable {
     internal var extendedSortDescriptors: [SortDescriptor] = []
 
     /// An array of group identifiers to match against.
-    public var groupIdentifiers: [String] = []
+    public var groupIdentifiers: [String?] = []
 
     /// An array of tags to match against. If an object's tags contains one or more of entries, it will match the query.
     public var tags: [String] = []
 
     // MARK: OCKAnyPatientQuery
     public var ids: [String] = []
-    public var remoteIDs: [String] = []
+    public var remoteIDs: [String?] = []
     public var dateInterval: DateInterval?
     public var limit: Int?
     public var offset: Int = 0

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKTaskQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKTaskQuery.swift
@@ -104,7 +104,7 @@ public struct OCKTaskQuery: OCKAnyTaskQuery, Equatable {
     internal var extendedSortDescriptors: [SortDescriptor] = []
 
     /// An array of group identifiers to match against.
-    public var groupIdentifiers: [String] = []
+    public var groupIdentifiers: [String?] = []
 
     /// An array of tags to match against. If an object's tags contains one or more of entries, it will match the query.
     public var tags: [String] = []
@@ -112,7 +112,7 @@ public struct OCKTaskQuery: OCKAnyTaskQuery, Equatable {
     // MARK: OCKAnyTaskQuery
     public var ids: [String] = []
     public var uuids: [UUID] = []
-    public var remoteIDs: [String] = []
+    public var remoteIDs: [String?] = []
     public var carePlanIDs: [String] = []
     public var dateInterval: DateInterval?
     public var limit: Int?

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+CarePlans.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+CarePlans.swift
@@ -87,11 +87,32 @@ class TestStoreCarePlans: XCTestCase {
     func testCarePlanQueryGroupIdentifier() throws {
         var plan1 = OCKCarePlan(id: "id_1", title: "Diabetes Care Plan", patientUUID: nil)
         plan1.groupIdentifier = "1"
+
         var plan2 = OCKCarePlan(id: "id_2", title: "Obesity Care Plan", patientUUID: nil)
         plan2.groupIdentifier = "2"
+
         try store.addCarePlansAndWait([plan1, plan2])
+
         var query = OCKCarePlanQuery(for: Date())
         query.groupIdentifiers = ["1"]
+
+        let fetched = try store.fetchCarePlansAndWait(query: query)
+        XCTAssert(fetched.count == 1)
+        XCTAssert(fetched.first?.id == "id_1")
+    }
+
+    func testCarePlanQueryNilGroupIdentifier() throws {
+        var plan1 = OCKCarePlan(id: "id_1", title: "Diabetes Care Plan", patientUUID: nil)
+        plan1.groupIdentifier = nil
+
+        var plan2 = OCKCarePlan(id: "id_2", title: "Obesity Care Plan", patientUUID: nil)
+        plan2.groupIdentifier = "2"
+
+        try store.addCarePlansAndWait([plan1, plan2])
+
+        var query = OCKCarePlanQuery(for: Date())
+        query.groupIdentifiers = [nil]
+
         let fetched = try store.fetchCarePlansAndWait(query: query)
         XCTAssert(fetched.count == 1)
         XCTAssert(fetched.first?.id == "id_1")
@@ -158,6 +179,40 @@ class TestStoreCarePlans: XCTestCase {
 
         let fetched = try store.fetchCarePlansAndWait(query: query)
         XCTAssert(fetched == [plan])
+    }
+
+    func testCarePlanQueryByRemoteID() throws {
+        var plan1 = OCKCarePlan(id: "A", title: "A", patientUUID: nil)
+        plan1.remoteID = "abc"
+        plan1 = try store.addCarePlanAndWait(plan1)
+
+        var plan2 = OCKCarePlan(id: "B", title: "B", patientUUID: nil)
+        plan2.remoteID = "def"
+        plan2 = try store.addCarePlanAndWait(plan2)
+
+        var query = OCKCarePlanQuery()
+        query.remoteIDs = ["abc"]
+
+        let fetched = try store.fetchCarePlansAndWait(query: query)
+        XCTAssert(fetched.count == 1)
+        XCTAssert(fetched.first == plan1)
+    }
+
+    func testCarePlanQueryByNilRemoteID() throws {
+        var plan1 = OCKCarePlan(id: "A", title: "A", patientUUID: nil)
+        plan1.remoteID = nil
+        plan1 = try store.addCarePlanAndWait(plan1)
+
+        var plan2 = OCKCarePlan(id: "B", title: "B", patientUUID: nil)
+        plan2.remoteID = "abc"
+        plan2 = try store.addCarePlanAndWait(plan2)
+
+        var query = OCKCarePlanQuery()
+        query.remoteIDs = [nil]
+
+        let fetched = try store.fetchCarePlansAndWait(query: query)
+        XCTAssert(fetched.count == 1)
+        XCTAssert(fetched.first == plan1)
     }
 
     // MARK: Versioning

--- a/CareKitStore/CareKitStoreTests/Structs/TestCarePlanQuery.swift
+++ b/CareKitStore/CareKitStoreTests/Structs/TestCarePlanQuery.swift
@@ -35,8 +35,8 @@ import XCTest
 private struct MockQuery: OCKAnyCarePlanQuery {
 
     var ids: [String] = []
-    var remoteIDs: [String] = []
-    var groupIdentifiers: [String] = []
+    var remoteIDs: [String?] = []
+    var groupIdentifiers: [String?] = []
     var dateInterval: DateInterval?
     var limit: Int?
     var offset: Int = 0

--- a/CareKitStore/CareKitStoreTests/Structs/TestContactQuery.swift
+++ b/CareKitStore/CareKitStoreTests/Structs/TestContactQuery.swift
@@ -34,8 +34,8 @@ import XCTest
 
 private struct MockQuery: OCKAnyContactQuery {
     var ids: [String] = []
-    var remoteIDs: [String] = []
-    var groupIdentifiers: [String] = []
+    var remoteIDs: [String?] = []
+    var groupIdentifiers: [String?] = []
     var dateInterval: DateInterval?
     var limit: Int?
     var offset: Int = 0

--- a/CareKitStore/CareKitStoreTests/Structs/TestOutcomeQuery.swift
+++ b/CareKitStore/CareKitStoreTests/Structs/TestOutcomeQuery.swift
@@ -34,8 +34,8 @@ import XCTest
 
 private struct MockQuery: OCKAnyOutcomeQuery {
     var ids: [String] = []
-    var remoteIDs: [String] = []
-    var groupIdentifiers: [String] = []
+    var remoteIDs: [String?] = []
+    var groupIdentifiers: [String?] = []
     var dateInterval: DateInterval?
     var limit: Int?
     var offset: Int = 0

--- a/CareKitStore/CareKitStoreTests/Structs/TestPatientQuery.swift
+++ b/CareKitStore/CareKitStoreTests/Structs/TestPatientQuery.swift
@@ -34,8 +34,8 @@ import XCTest
 
 private struct MockQuery: OCKAnyPatientQuery {
     var ids: [String] = []
-    var remoteIDs: [String] = []
-    var groupIdentifiers: [String] = []
+    var remoteIDs: [String?] = []
+    var groupIdentifiers: [String?] = []
     var dateInterval: DateInterval?
     var limit: Int?
     var offset: Int = 0

--- a/CareKitStore/CareKitStoreTests/Structs/TestTaskQuery.swift
+++ b/CareKitStore/CareKitStoreTests/Structs/TestTaskQuery.swift
@@ -34,8 +34,8 @@ import XCTest
 
 private struct MockQuery: OCKAnyTaskQuery {
     var ids: [String] = []
-    var remoteIDs: [String] = []
-    var groupIdentifiers: [String] = []
+    var remoteIDs: [String?] = []
+    var groupIdentifiers: [String?] = []
     var dateInterval: DateInterval?
     var limit: Int?
     var offset: Int = 0


### PR DESCRIPTION
This PR makes it possible to query objects where properties are `nil`.

This is useful for returning, for example, all tasks that don't have a `groupIdentifier` or all outcomes for which the `remoteID` is not set.

This feature was proposed by @cbaker6 in #418.