### PR TITLE
Update OCKContactUtility.swift

### DIFF
--- a/CareKit/CareKit/Synchronized View Controllers/Utilities/OCKContactUtility.swift
+++ b/CareKit/CareKit/Synchronized View Controllers/Utilities/OCKContactUtility.swift
@@ -41,7 +41,7 @@ struct OCKContactUtility {
 
     private static let nameFormatter: PersonNameComponentsFormatter = {
         let nameFormatter = PersonNameComponentsFormatter()
-        nameFormatter.style = .medium
+        nameFormatter.style = .long
         return nameFormatter
     }()
 


### PR DESCRIPTION
The OCKContactUtility nameFormatter currently uses .medium for the formatter style, which displays given and family names only. Since it is very likely the contacts for Carekit include those in the medical field, i.e., Doctors, it would be more appropriate to use the formatter style .long so that the prefix (Dr.) is included in the formatted string that is displayed.