### PR TITLE
Fix bug in which the label was used as the value for phone numbers.

### DIFF
--- a/CareKit/CareKit/Extensions/OCKContact+Extensions.swift
+++ b/CareKit/CareKit/Extensions/OCKContact+Extensions.swift
@@ -34,7 +34,7 @@ import Foundation
 
 private extension OCKLabeledValue {
     func toLabeledString() -> CNLabeledValue<NSString> { CNLabeledValue(label: label, value: NSString(string: value)) }
-    func toLabeledPhoneNumber() -> CNLabeledValue<CNPhoneNumber> { CNLabeledValue(label: label, value: CNPhoneNumber(stringValue: label)) }
+    func toLabeledPhoneNumber() -> CNLabeledValue<CNPhoneNumber> { CNLabeledValue(label: label, value: CNPhoneNumber(stringValue: value)) }
 }
 
 private extension OCKPostalAddress {


### PR DESCRIPTION
This PR addresses a bug reported in #451.
The label was being used for both the label and the value.