### PR TITLE
CareKitFHIR

### DIFF
--- a/CKWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/CKWorkspace.xcworkspace/contents.xcworkspacedata
@@ -16,4 +16,7 @@
    <FileRef
       location = "group:OCKCatalog/OCKCatalog.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:CareKitFHIR/CareKitFHIR.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/CKWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CKWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "FHIRModels",
+        "repositoryURL": "git@github.com:apple/FHIRModels.git",
+        "state": {
+          "branch": null,
+          "revision": "31dc40c01ef43b89191be5d9719e1ddedb2c91b5",
+          "version": "0.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/CareKitFHIR/CareKitFHIR.xcodeproj/project.pbxproj
+++ b/CareKitFHIR/CareKitFHIR.xcodeproj/project.pbxproj
@@ -1,0 +1,636 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		031B455F247465BA0063E717 /* OCKFHIRResourceCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B455E247465BA0063E717 /* OCKFHIRResourceCoder.swift */; };
+		031B4561247499AA0063E717 /* OCKPatientConverterTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B4560247499AA0063E717 /* OCKPatientConverterTraits.swift */; };
+		031B456324749B5C0063E717 /* OCKTaskConverterTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B456224749B5C0063E717 /* OCKTaskConverterTraits.swift */; };
+		031B45652474A0C80063E717 /* OCKFHIRResourceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B45642474A0C80063E717 /* OCKFHIRResourceData.swift */; };
+		031B45672474A0F10063E717 /* OCKFHIRRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B45662474A0F10063E717 /* OCKFHIRRelease.swift */; };
+		031B45692474A1100063E717 /* OCKFHIRContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B45682474A1100063E717 /* OCKFHIRContentType.swift */; };
+		031B456B2474A1380063E717 /* OCKFHIRResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031B456A2474A1380063E717 /* OCKFHIRResource.swift */; };
+		031D4B662374E1D900199EFC /* FHIRModels+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031D4B652374E1D900199EFC /* FHIRModels+Extensions.swift */; };
+		0364BB6423C421E30047F952 /* CareKitStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0364BB6323C421E30047F952 /* CareKitStore.framework */; };
+		0396EF40233D187800C28FC0 /* CareKitFHIR.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0396EF36233D187800C28FC0 /* CareKitFHIR.framework */; };
+		03AFA92B233E697C0091DD45 /* OCKFHIRCodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFA92A233E697C0091DD45 /* OCKFHIRCodingError.swift */; };
+		03AFA930233E69830091DD45 /* OCKDSTU2PatientCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFA92D233E69830091DD45 /* OCKDSTU2PatientCoder.swift */; };
+		03AFA931233E69830091DD45 /* OCKR4PatientCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFA92E233E69830091DD45 /* OCKR4PatientCoder.swift */; };
+		03AFA93D233E74610091DD45 /* FHIRResourceDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFA93C233E74610091DD45 /* FHIRResourceDataTests.swift */; };
+		03AFA943233E80C40091DD45 /* DSTU2PatientConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFA942233E80C40091DD45 /* DSTU2PatientConverterTests.swift */; };
+		03C75C5724A50248009F1896 /* ModelsR4 in Frameworks */ = {isa = PBXBuildFile; productRef = 03C75C5624A50248009F1896 /* ModelsR4 */; };
+		03C75C5924A50248009F1896 /* ModelsDSTU2 in Frameworks */ = {isa = PBXBuildFile; productRef = 03C75C5824A50248009F1896 /* ModelsDSTU2 */; };
+		03C85E6E233D71EC002C5901 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C85E6D233D71EC002C5901 /* Utils.swift */; };
+		03C85E73233D7215002C5901 /* CareKitFHIRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C85E72233D7215002C5901 /* CareKitFHIRTests.swift */; };
+		03C85E76233D721F002C5901 /* R4PatientConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C85E75233D721F002C5901 /* R4PatientConverterTests.swift */; };
+		03E5929123736D0D00B6E9DE /* DSTU2TaskConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E5929023736D0D00B6E9DE /* DSTU2TaskConverterTests.swift */; };
+		E746B33A2378F55600278A95 /* OCKDSTU2ScheduleCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746B3392378F55600278A95 /* OCKDSTU2ScheduleCoder.swift */; };
+		E746B33E2378F6D500278A95 /* OCKDSTU2MedicationOrderCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746B33D2378F6D500278A95 /* OCKDSTU2MedicationOrderCoder.swift */; };
+		E746B3422378F95100278A95 /* DSTU2MedicationOrderConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746B3412378F95100278A95 /* DSTU2MedicationOrderConverterTests.swift */; };
+		E7B211552361579800AF5766 /* OCK+FHIRExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B211542361579800AF5766 /* OCK+FHIRExtensions.swift */; };
+		E7B2115A236160B800AF5766 /* OCKDSTU2CarePlanActivityCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B21159236160B800AF5766 /* OCKDSTU2CarePlanActivityCoder.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0396EF41233D187800C28FC0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0396EF2D233D187800C28FC0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0396EF35233D187800C28FC0;
+			remoteInfo = CareKitFHIR;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0318342423C6A2F3007CC3E2 /* CareKitFHIR.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = CareKitFHIR.xctestplan; path = CareKitFHIRTests/CareKitFHIR.xctestplan; sourceTree = "<group>"; };
+		031B455E247465BA0063E717 /* OCKFHIRResourceCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKFHIRResourceCoder.swift; sourceTree = "<group>"; };
+		031B4560247499AA0063E717 /* OCKPatientConverterTraits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKPatientConverterTraits.swift; sourceTree = "<group>"; };
+		031B456224749B5C0063E717 /* OCKTaskConverterTraits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKTaskConverterTraits.swift; sourceTree = "<group>"; };
+		031B45642474A0C80063E717 /* OCKFHIRResourceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKFHIRResourceData.swift; sourceTree = "<group>"; };
+		031B45662474A0F10063E717 /* OCKFHIRRelease.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKFHIRRelease.swift; sourceTree = "<group>"; };
+		031B45682474A1100063E717 /* OCKFHIRContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKFHIRContentType.swift; sourceTree = "<group>"; };
+		031B456A2474A1380063E717 /* OCKFHIRResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKFHIRResource.swift; sourceTree = "<group>"; };
+		031D4B652374E1D900199EFC /* FHIRModels+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FHIRModels+Extensions.swift"; sourceTree = "<group>"; };
+		0364BB6323C421E30047F952 /* CareKitStore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CareKitStore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0396EF36233D187800C28FC0 /* CareKitFHIR.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CareKitFHIR.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0396EF3A233D187800C28FC0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0396EF3F233D187800C28FC0 /* CareKitFHIRTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CareKitFHIRTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0396EF46233D187800C28FC0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		03AFA92A233E697C0091DD45 /* OCKFHIRCodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OCKFHIRCodingError.swift; sourceTree = "<group>"; };
+		03AFA92D233E69830091DD45 /* OCKDSTU2PatientCoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OCKDSTU2PatientCoder.swift; sourceTree = "<group>"; };
+		03AFA92E233E69830091DD45 /* OCKR4PatientCoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OCKR4PatientCoder.swift; sourceTree = "<group>"; };
+		03AFA93C233E74610091DD45 /* FHIRResourceDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FHIRResourceDataTests.swift; sourceTree = "<group>"; };
+		03AFA942233E80C40091DD45 /* DSTU2PatientConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSTU2PatientConverterTests.swift; sourceTree = "<group>"; };
+		03C85E6D233D71EC002C5901 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		03C85E72233D7215002C5901 /* CareKitFHIRTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CareKitFHIRTests.swift; sourceTree = "<group>"; };
+		03C85E75233D721F002C5901 /* R4PatientConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R4PatientConverterTests.swift; sourceTree = "<group>"; };
+		03E5929023736D0D00B6E9DE /* DSTU2TaskConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSTU2TaskConverterTests.swift; sourceTree = "<group>"; };
+		E746B3392378F55600278A95 /* OCKDSTU2ScheduleCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKDSTU2ScheduleCoder.swift; sourceTree = "<group>"; };
+		E746B33D2378F6D500278A95 /* OCKDSTU2MedicationOrderCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKDSTU2MedicationOrderCoder.swift; sourceTree = "<group>"; };
+		E746B3412378F95100278A95 /* DSTU2MedicationOrderConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSTU2MedicationOrderConverterTests.swift; sourceTree = "<group>"; };
+		E7B211542361579800AF5766 /* OCK+FHIRExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCK+FHIRExtensions.swift"; sourceTree = "<group>"; };
+		E7B21159236160B800AF5766 /* OCKDSTU2CarePlanActivityCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKDSTU2CarePlanActivityCoder.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0396EF33233D187800C28FC0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03C75C5924A50248009F1896 /* ModelsDSTU2 in Frameworks */,
+				03C75C5724A50248009F1896 /* ModelsR4 in Frameworks */,
+				0364BB6423C421E30047F952 /* CareKitStore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0396EF3C233D187800C28FC0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0396EF40233D187800C28FC0 /* CareKitFHIR.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0396EF2C233D187800C28FC0 = {
+			isa = PBXGroup;
+			children = (
+				0318342423C6A2F3007CC3E2 /* CareKitFHIR.xctestplan */,
+				0396EF38233D187800C28FC0 /* CareKitFHIR */,
+				0396EF43233D187800C28FC0 /* CareKitFHIRTests */,
+				0396EF37233D187800C28FC0 /* Products */,
+				03C67ADB23749D190072C715 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		0396EF37233D187800C28FC0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0396EF36233D187800C28FC0 /* CareKitFHIR.framework */,
+				0396EF3F233D187800C28FC0 /* CareKitFHIRTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0396EF38233D187800C28FC0 /* CareKitFHIR */ = {
+			isa = PBXGroup;
+			children = (
+				E7B2115623615FD300AF5766 /* Tasks */,
+				03AFA92C233E69830091DD45 /* Patients */,
+				031B45662474A0F10063E717 /* OCKFHIRRelease.swift */,
+				031B45682474A1100063E717 /* OCKFHIRContentType.swift */,
+				031B45642474A0C80063E717 /* OCKFHIRResourceData.swift */,
+				031B456A2474A1380063E717 /* OCKFHIRResource.swift */,
+				031B455E247465BA0063E717 /* OCKFHIRResourceCoder.swift */,
+				03AFA92A233E697C0091DD45 /* OCKFHIRCodingError.swift */,
+				E7B211542361579800AF5766 /* OCK+FHIRExtensions.swift */,
+				031D4B652374E1D900199EFC /* FHIRModels+Extensions.swift */,
+				0396EF3A233D187800C28FC0 /* Info.plist */,
+			);
+			path = CareKitFHIR;
+			sourceTree = "<group>";
+		};
+		0396EF43233D187800C28FC0 /* CareKitFHIRTests */ = {
+			isa = PBXGroup;
+			children = (
+				03C85E74233D721F002C5901 /* Unit Tests */,
+				03C85E71233D7215002C5901 /* Integration Tests */,
+				03C85E6D233D71EC002C5901 /* Utils.swift */,
+				0396EF46233D187800C28FC0 /* Info.plist */,
+			);
+			path = CareKitFHIRTests;
+			sourceTree = "<group>";
+		};
+		03AFA92C233E69830091DD45 /* Patients */ = {
+			isa = PBXGroup;
+			children = (
+				031B4560247499AA0063E717 /* OCKPatientConverterTraits.swift */,
+				03AFA92D233E69830091DD45 /* OCKDSTU2PatientCoder.swift */,
+				03AFA92E233E69830091DD45 /* OCKR4PatientCoder.swift */,
+			);
+			path = Patients;
+			sourceTree = "<group>";
+		};
+		03C67ADB23749D190072C715 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0364BB6323C421E30047F952 /* CareKitStore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		03C85E71233D7215002C5901 /* Integration Tests */ = {
+			isa = PBXGroup;
+			children = (
+				03C85E72233D7215002C5901 /* CareKitFHIRTests.swift */,
+			);
+			path = "Integration Tests";
+			sourceTree = "<group>";
+		};
+		03C85E74233D721F002C5901 /* Unit Tests */ = {
+			isa = PBXGroup;
+			children = (
+				03AFA93C233E74610091DD45 /* FHIRResourceDataTests.swift */,
+				03AFA942233E80C40091DD45 /* DSTU2PatientConverterTests.swift */,
+				03E5929023736D0D00B6E9DE /* DSTU2TaskConverterTests.swift */,
+				03C85E75233D721F002C5901 /* R4PatientConverterTests.swift */,
+				E746B3412378F95100278A95 /* DSTU2MedicationOrderConverterTests.swift */,
+			);
+			path = "Unit Tests";
+			sourceTree = "<group>";
+		};
+		E7B2115623615FD300AF5766 /* Tasks */ = {
+			isa = PBXGroup;
+			children = (
+				031B456224749B5C0063E717 /* OCKTaskConverterTraits.swift */,
+				E7B21159236160B800AF5766 /* OCKDSTU2CarePlanActivityCoder.swift */,
+				E746B3392378F55600278A95 /* OCKDSTU2ScheduleCoder.swift */,
+				E746B33D2378F6D500278A95 /* OCKDSTU2MedicationOrderCoder.swift */,
+			);
+			path = Tasks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0396EF31233D187800C28FC0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		0396EF35233D187800C28FC0 /* CareKitFHIR */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0396EF4A233D187800C28FC0 /* Build configuration list for PBXNativeTarget "CareKitFHIR" */;
+			buildPhases = (
+				0396EF31233D187800C28FC0 /* Headers */,
+				0396EF32233D187800C28FC0 /* Sources */,
+				0396EF33233D187800C28FC0 /* Frameworks */,
+				0396EF34233D187800C28FC0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CareKitFHIR;
+			packageProductDependencies = (
+				03C75C5624A50248009F1896 /* ModelsR4 */,
+				03C75C5824A50248009F1896 /* ModelsDSTU2 */,
+			);
+			productName = CareKitFHIR;
+			productReference = 0396EF36233D187800C28FC0 /* CareKitFHIR.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		0396EF3E233D187800C28FC0 /* CareKitFHIRTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0396EF4D233D187800C28FC0 /* Build configuration list for PBXNativeTarget "CareKitFHIRTests" */;
+			buildPhases = (
+				0396EF3B233D187800C28FC0 /* Sources */,
+				0396EF3C233D187800C28FC0 /* Frameworks */,
+				0396EF3D233D187800C28FC0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0396EF42233D187800C28FC0 /* PBXTargetDependency */,
+			);
+			name = CareKitFHIRTests;
+			productName = CareKitFHIRTests;
+			productReference = 0396EF3F233D187800C28FC0 /* CareKitFHIRTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0396EF2D233D187800C28FC0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1100;
+				LastUpgradeCheck = 1200;
+				ORGANIZATIONNAME = Apple;
+				TargetAttributes = {
+					0396EF35233D187800C28FC0 = {
+						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1100;
+					};
+					0396EF3E233D187800C28FC0 = {
+						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1100;
+					};
+				};
+			};
+			buildConfigurationList = 0396EF30233D187800C28FC0 /* Build configuration list for PBXProject "CareKitFHIR" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0396EF2C233D187800C28FC0;
+			packageReferences = (
+				03C75C5524A50248009F1896 /* XCRemoteSwiftPackageReference "FHIRModels" */,
+			);
+			productRefGroup = 0396EF37233D187800C28FC0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0396EF35233D187800C28FC0 /* CareKitFHIR */,
+				0396EF3E233D187800C28FC0 /* CareKitFHIRTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0396EF34233D187800C28FC0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0396EF3D233D187800C28FC0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0396EF32233D187800C28FC0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				031B45672474A0F10063E717 /* OCKFHIRRelease.swift in Sources */,
+				E7B2115A236160B800AF5766 /* OCKDSTU2CarePlanActivityCoder.swift in Sources */,
+				031B45692474A1100063E717 /* OCKFHIRContentType.swift in Sources */,
+				031B4561247499AA0063E717 /* OCKPatientConverterTraits.swift in Sources */,
+				E746B33E2378F6D500278A95 /* OCKDSTU2MedicationOrderCoder.swift in Sources */,
+				03AFA92B233E697C0091DD45 /* OCKFHIRCodingError.swift in Sources */,
+				031D4B662374E1D900199EFC /* FHIRModels+Extensions.swift in Sources */,
+				031B456324749B5C0063E717 /* OCKTaskConverterTraits.swift in Sources */,
+				031B45652474A0C80063E717 /* OCKFHIRResourceData.swift in Sources */,
+				031B455F247465BA0063E717 /* OCKFHIRResourceCoder.swift in Sources */,
+				E746B33A2378F55600278A95 /* OCKDSTU2ScheduleCoder.swift in Sources */,
+				03AFA930233E69830091DD45 /* OCKDSTU2PatientCoder.swift in Sources */,
+				E7B211552361579800AF5766 /* OCK+FHIRExtensions.swift in Sources */,
+				031B456B2474A1380063E717 /* OCKFHIRResource.swift in Sources */,
+				03AFA931233E69830091DD45 /* OCKR4PatientCoder.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0396EF3B233D187800C28FC0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03AFA93D233E74610091DD45 /* FHIRResourceDataTests.swift in Sources */,
+				03C85E73233D7215002C5901 /* CareKitFHIRTests.swift in Sources */,
+				03AFA943233E80C40091DD45 /* DSTU2PatientConverterTests.swift in Sources */,
+				03C85E76233D721F002C5901 /* R4PatientConverterTests.swift in Sources */,
+				E746B3422378F95100278A95 /* DSTU2MedicationOrderConverterTests.swift in Sources */,
+				03E5929123736D0D00B6E9DE /* DSTU2TaskConverterTests.swift in Sources */,
+				03C85E6E233D71EC002C5901 /* Utils.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0396EF42233D187800C28FC0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0396EF35233D187800C28FC0 /* CareKitFHIR */;
+			targetProxy = 0396EF41233D187800C28FC0 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0396EF48233D187800C28FC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		0396EF49233D187800C28FC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		0396EF4B233D187800C28FC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				INFOPLIST_FILE = CareKitFHIR/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.carekit.CareKitFHIR;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0396EF4C233D187800C28FC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				INFOPLIST_FILE = CareKitFHIR/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.carekit.CareKitFHIR;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		0396EF4E233D187800C28FC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = CareKitFHIRTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.Apple.com.CareKitFHIRTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0396EF4F233D187800C28FC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = CareKitFHIRTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.Apple.com.CareKitFHIRTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0396EF30233D187800C28FC0 /* Build configuration list for PBXProject "CareKitFHIR" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0396EF48233D187800C28FC0 /* Debug */,
+				0396EF49233D187800C28FC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0396EF4A233D187800C28FC0 /* Build configuration list for PBXNativeTarget "CareKitFHIR" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0396EF4B233D187800C28FC0 /* Debug */,
+				0396EF4C233D187800C28FC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0396EF4D233D187800C28FC0 /* Build configuration list for PBXNativeTarget "CareKitFHIRTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0396EF4E233D187800C28FC0 /* Debug */,
+				0396EF4F233D187800C28FC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		03C75C5524A50248009F1896 /* XCRemoteSwiftPackageReference "FHIRModels" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "git@github.com:apple/FHIRModels.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		03C75C5624A50248009F1896 /* ModelsR4 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03C75C5524A50248009F1896 /* XCRemoteSwiftPackageReference "FHIRModels" */;
+			productName = ModelsR4;
+		};
+		03C75C5824A50248009F1896 /* ModelsDSTU2 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03C75C5524A50248009F1896 /* XCRemoteSwiftPackageReference "FHIRModels" */;
+			productName = ModelsDSTU2;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 0396EF2D233D187800C28FC0 /* Project object */;
+}

--- a/CareKitFHIR/CareKitFHIR.xcodeproj/xcshareddata/xcschemes/CareKitFHIR.xcscheme
+++ b/CareKitFHIR/CareKitFHIR.xcodeproj/xcshareddata/xcschemes/CareKitFHIR.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0396EF35233D187800C28FC0"
+               BuildableName = "CareKitFHIR.framework"
+               BlueprintName = "CareKitFHIR"
+               ReferencedContainer = "container:CareKitFHIR.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0396EF3E233D187800C28FC0"
+               BuildableName = "CareKitFHIRTests.xctest"
+               BlueprintName = "CareKitFHIRTests"
+               ReferencedContainer = "container:CareKitFHIR.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0396EF35233D187800C28FC0"
+            BuildableName = "CareKitFHIR.framework"
+            BlueprintName = "CareKitFHIR"
+            ReferencedContainer = "container:CareKitFHIR.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CareKitFHIR/CareKitFHIR/FHIRModels+Extensions.swift
+++ b/CareKitFHIR/CareKitFHIR/FHIRModels+Extensions.swift
@@ -1,0 +1,69 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Foundation
+import ModelsDSTU2
+import ModelsR4
+
+extension ModelsDSTU2.DateTime {
+    var foundationDate: Date {
+        var components = DateComponents()
+
+        components.year = date.year
+        components.month = date.month.map { Int($0) }
+        components.day = date.day.map { Int($0) }
+
+        components.hour = time.map { $0.hour }.map { Int($0) }
+        components.minute = time.map { $0.minute }.map { Int($0) }
+        components.second = time.map { $0.second }.map { Int(truncating: $0 as NSNumber) }
+
+        components.timeZone = timeZone
+
+        return Calendar.current.date(from: components)!
+    }
+}
+
+extension ModelsR4.DateTime {
+    var foundationDate: Date {
+        var components = DateComponents()
+
+        components.year = date.year
+        components.month = date.month.map { Int($0) }
+        components.day = date.day.map { Int($0) }
+
+        components.hour = time.map { $0.hour }.map { Int($0) }
+        components.minute = time.map { $0.minute }.map { Int($0) }
+        components.second = time.map { $0.second }.map { Int(truncating: $0 as NSNumber) }
+
+        components.timeZone = timeZone
+
+        return Calendar.current.date(from: components)!
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/Info.plist
+++ b/CareKitFHIR/CareKitFHIR/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/CareKitFHIR/CareKitFHIR/OCK+FHIRExtensions.swift
+++ b/CareKitFHIR/CareKitFHIR/OCK+FHIRExtensions.swift
@@ -1,0 +1,86 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Foundation
+import ModelsDSTU2
+import ModelsR4
+
+extension String {
+    func fhirString<T: ExpressibleByStringLiteral>() -> T where T.StringLiteralType == String { T(stringLiteral: self) }
+}
+
+extension Calendar.Component {
+    var dstu2FHIRUnitString: ModelsDSTU2.FHIRPrimitive<ModelsDSTU2.FHIRString> {
+        switch self {
+        case .second: return "s"
+        case .minute: return "min"
+        case .hour: return "h"
+        case .day: return "d"
+        case .weekOfYear: return "wk"
+        case .month: return "mo"
+        default: fatalError("Calendar component \(self) is not supported by FHIR.")
+        }
+    }
+}
+
+extension Date {
+    var dstu2FHIRDateTime: ModelsDSTU2.DateTime {
+        let year = Calendar.current.component(.year, from: self)
+        let month = Calendar.current.component(.month, from: self)
+        let day = Calendar.current.component(.day, from: self)
+        let date = ModelsDSTU2.FHIRDate(year: year, month: UInt8(month), day: UInt8(day))
+
+        let hour = Calendar.current.component(.hour, from: self)
+        let minute = Calendar.current.component(.minute, from: self)
+        let second = Calendar.current.component(.second, from: self)
+        let time = ModelsDSTU2.FHIRTime(hour: UInt8(hour), minute: UInt8(minute), second: Decimal(second))
+
+        return DateTime(date: date, time: time, timezone: TimeZone.current)
+    }
+
+    var r4FHIRDateTime: ModelsR4.FHIRPrimitive<ModelsR4.DateTime> {
+        let year = Calendar.current.component(.year, from: self)
+        let month = Calendar.current.component(.month, from: self)
+        let day = Calendar.current.component(.day, from: self)
+        let date = ModelsR4.FHIRDate(year: year, month: UInt8(month), day: UInt8(day))
+
+        let hour = Calendar.current.component(.hour, from: self)
+        let minute = Calendar.current.component(.minute, from: self)
+        let second = Calendar.current.component(.second, from: self)
+        let time = ModelsR4.FHIRTime(hour: UInt8(hour), minute: UInt8(minute), second: Decimal(second))
+
+        return FHIRPrimitive(DateTime(date: date, time: time, timezone: TimeZone.current))
+    }
+
+    var truncatingNanoSeconds: Date {
+        let roundedDown = floor(timeIntervalSinceReferenceDate)
+        return Date(timeIntervalSinceReferenceDate: roundedDown)
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/OCKFHIRCodingError.swift
+++ b/CareKitFHIR/CareKitFHIR/OCKFHIRCodingError.swift
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2019, Apple Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder(s) nor the names of any contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission. No license is granted to the trademarks of
+the copyright holders even if such marks are included in this software.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A conversion error represents a problem converting one data format to another.
+public enum OCKFHIRCodingError: Error, Equatable {
+
+    /// Indicates that data is corrupt and cannot be read. Malformed JSON is one example.
+    case corruptData(String)
+
+    /// Indicates that conversion could not be completed because a required field was missing.
+    case missingRequiredField(String)
+
+    /// Indicates that the content encoding is not supported.
+    case unsupportedEncoding(String)
+
+    /// Indicates that the content of the source data format type could not be expressed in the target data format.
+    case unrepresentableContent(String)
+
+    /// Any other error encountered during conversion between two data formats.
+    case unknownError(String)
+
+    func prependMessage(_ message: String) -> OCKFHIRCodingError {
+        switch self {
+        case .corruptData: return .corruptData(message + " \(localizedDescription)")
+        case .missingRequiredField: return .missingRequiredField(message + " \(localizedDescription)")
+        case .unsupportedEncoding: return .unsupportedEncoding(message + " \(localizedDescription)")
+        case .unrepresentableContent: return .unrepresentableContent(message + " \(localizedDescription)")
+        case .unknownError: return .unknownError(message + " \(localizedDescription)")
+        }
+    }
+
+    public var localizedDescription: String {
+        switch self {
+        case .corruptData(let problem): return "Corrupt Data: \(problem)"
+        case .missingRequiredField(let field): return "Missing required field: \(field)"
+        case .unsupportedEncoding(let problem): return "Unsupported encoding: \(problem)"
+        case .unrepresentableContent(let problem): return "Unrepresentable content: \(problem)"
+        case .unknownError(let problem): return "Uknown error: \(problem)"
+        }
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/OCKFHIRContentType.swift
+++ b/CareKitFHIR/CareKitFHIR/OCKFHIRContentType.swift
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+public protocol FHIRContentType {}
+
+public struct JSON: FHIRContentType {}
+public struct XML: FHIRContentType {}
+public struct Turtle: FHIRContentType {}

--- a/CareKitFHIR/CareKitFHIR/OCKFHIRRelease.swift
+++ b/CareKitFHIR/CareKitFHIR/OCKFHIRRelease.swift
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+public protocol OCKFHIRRelease {}
+
+public struct DSTU2: OCKFHIRRelease {}
+public struct R4: OCKFHIRRelease {}

--- a/CareKitFHIR/CareKitFHIR/OCKFHIRResource.swift
+++ b/CareKitFHIR/CareKitFHIR/OCKFHIRResource.swift
@@ -1,0 +1,55 @@
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Foundation
+
+public protocol OCKFHIRResource: Codable {
+    associatedtype Release: OCKFHIRRelease
+}
+
+extension OCKFHIRResource {
+    static func decode<C: FHIRContentType>(data: Data, contentType: C.Type) throws -> Self {
+        if contentType is JSON.Type {
+            let encoder = JSONDecoder()
+            return try encoder.decode(Self.self, from: data)
+        }
+        throw OCKFHIRCodingError.unsupportedEncoding("\(C.self) is not supported!")
+    }
+
+    func encode(to contentType: FHIRContentType.Type) throws -> Data {
+        if contentType is JSON.Type {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(self)
+            return data
+        }
+
+        throw OCKFHIRCodingError.unsupportedEncoding("\(contentType) is not supported!")
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/OCKFHIRResourceCoder.swift
+++ b/CareKitFHIR/CareKitFHIR/OCKFHIRResourceCoder.swift
@@ -1,0 +1,170 @@
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import CareKitStore
+import Foundation
+import HealthKit
+import ModelsDSTU2
+
+/// Describes a type that is capable of encoding and decoding a CareKit entity
+/// to and from a specific FHIR resource for specific FHIR release.
+public protocol OCKFHIRResourceCoder {
+
+    /// The CareKit entity that this coder encodes and decodes to and from.
+    associatedtype Entity
+
+    /// The FHIR resource that this coder converts to and from a CareKit entity.
+    associatedtype Resource: OCKFHIRResource
+
+    /// Converts a CareKit entity into a  FHIR resource.
+    ///
+    /// Conversion may fail if the entity cannot be fully expressed in the FHIR format.
+    ///
+    /// - Parameter entity: The CareKit entity to be converted.
+    /// - Throws: `OCKFHIRCodingError`
+    func convert(entity: Entity) throws -> Resource
+
+    /// Converts a FHIR resource into a CareKit entity.
+    ///
+    /// Conversion may fail if the resource is missing fields that are required
+    /// to instantiate its CareKit counterpart.
+    ///
+    /// - Parameter resource: The FHIR resource to be converted.
+    /// - Throws: `OCKFHIRCodingError`
+    func convert(resource: Resource) throws -> Entity
+}
+
+public extension OCKFHIRResourceCoder {
+
+    /// Decode a CareKit entity from FHIR resource data.
+    ///
+    /// - Parameter resourceData: A FHIR resource from a specific release
+    /// - Returns: A CareKit entity
+    func decode<C: FHIRContentType>(_ resourceData: OCKFHIRResourceData<Resource.Release, C>) throws -> Entity {
+        do {
+            let resource = try Resource.decode(data: resourceData.data, contentType: C.self)
+            let entity = try convert(resource: resource)
+            return entity
+
+        } catch {
+            switch error {
+            case let conversionError as OCKFHIRCodingError:
+                throw conversionError.prependMessage("Failed to convert FHIR \(Resource.self) to \(Entity.self). Error:")
+            case is DecodingError:
+                throw OCKFHIRCodingError.corruptData("Failed to decode FHIR \(Resource.self) data. Error: \(error.localizedDescription)")
+            default:
+                throw OCKFHIRCodingError.unknownError(
+                    "Unknown error while converting FHIR FHIR \(Resource.self) to \(Entity.self). Error: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    /// Encode a CareKit entity in a FHIR compatible format.
+    ///
+    /// - Parameters:
+    ///   - entity: The CareKit entity to encode
+    ///   - format: The FHIR content type to encode it in (JSON, XML, or Turtle). Defaults to JSON.
+    /// - Returns: Binary data in a FHIR compatible format
+    func encode(_ entity: Entity, format: FHIRContentType.Type = JSON.self) throws -> Data {
+        let resource = try convert(entity: entity)
+        let data = try resource.encode(to: format)
+        return data
+    }
+}
+
+public extension OCKFHIRResourceCoder where Resource.Release == DSTU2 {
+
+    /// Decode and convert clinical health records from HealthKit into CareKit objects.
+    ///
+    /// - Parameters:
+    ///   - clinicalTypeIdentifier: An `HKClinicalTypeIdentifier`
+    ///   - store: A HealthKit store to query for medication orders.
+    ///   - completion: A closure that will be called upon completion. Always called on the main queue.
+    func decodeClinicalHealthRecords(
+        clinicalTypeIdentifier: HKClinicalTypeIdentifier,
+        from store: HKHealthStore,
+        completion: @escaping OCKResultClosure<[Entity]>) {
+
+        let clinicalType = HKObjectType.clinicalType(forIdentifier: clinicalTypeIdentifier)!
+
+        store.requestAuthorization(toShare: nil, read: [clinicalType]) { success, error in
+            guard success else {
+                let error = OCKStoreError.addFailed(reason: "Failed to request authorization for HealthKit's clinical records.")
+                DispatchQueue.main.async { completion(.failure(error)) }
+                return
+            }
+
+            // Success doesn't necessarily mean that we got permission to read. It just means the user answered yes or no.
+            // If the following queries return nothing, it could be either because the user did not grant us permission, or
+            // because there really isn't any data available. There is no way to tell which is the case. This is a privacy
+            // feature that is baked in HealthKit.
+            let clinicalQuery = HKSampleQuery(
+                sampleType: clinicalType,
+                predicate: nil,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: nil) { _, samples, error in
+
+                func fail(_ message: String) {
+                    let error = OCKStoreError.addFailed(reason: "Failed to fetch medications from HealthKit. \(message)")
+                    DispatchQueue.main.async { completion(.failure(error)) }
+                }
+
+                if let error = error {
+                    fail(error.localizedDescription)
+                    return
+                }
+
+                guard let fetchedSamples = samples else {
+                    fail("No samples found.")
+                    return
+                }
+
+                guard let clinicalSamples = fetchedSamples as? [HKClinicalRecord] else {
+                    fail("Samples were not clinical records.")
+                    return
+                }
+
+                do {
+                    let rawData = clinicalSamples.compactMap { $0.fhirResource?.data }
+                    let resources = rawData.map { OCKFHIRResourceData<DSTU2, JSON>(data: $0) }
+                    let tasks = try resources.map(self.decode)
+                    DispatchQueue.main.async {
+                        completion(.success(tasks))
+                    }
+                } catch {
+                    fail(error.localizedDescription)
+                }
+            }
+
+            store.execute(clinicalQuery)
+        }
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/OCKFHIRResourceData.swift
+++ b/CareKitFHIR/CareKitFHIR/OCKFHIRResourceData.swift
@@ -1,0 +1,65 @@
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Foundation
+
+/// Marks binary data with an explicit FHIR release and content type.
+public struct OCKFHIRResourceData<Release: OCKFHIRRelease, Content: FHIRContentType>: OCKFHIRResource {
+
+    /// The raw FHIR resource data.
+    public let data: Data
+
+    /// Initialize `OCKFHIRResourceData` by specifying the raw data, it's release, and content type.
+    /// 
+    /// - Parameter data: Binary data representing a FHIR resource.
+    public init(data: Data) {
+        self.data = data
+    }
+
+    /// Initialize `OCKFHIRResourceData` by specifying the raw data, it's release, and content type.
+    ///
+    /// - Parameter release: The release of the FHIR specification used.
+    /// - Parameter content: The encoding of the resource content.
+    /// - Parameter data: Binary data representing a FHIR resource.
+    public init(release: Release.Type, content: Content.Type, data: Data) {
+        self.data = data
+    }
+}
+
+public extension OCKFHIRResourceData where Content == JSON {
+
+    /// Initialize a JSON `OCKFHIRResourceData` by specifying the raw data and release.
+    ///
+    /// - Parameter release: The release of the FHIR specification used.
+    /// - Parameter data: Binary data representing a FHIR resource.
+    init(release: Release.Type, data: Data) {
+        self.data = data
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/Patients/OCKDSTU2PatientCoder.swift
+++ b/CareKitFHIR/CareKitFHIR/Patients/OCKDSTU2PatientCoder.swift
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2019, Apple Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder(s) nor the names of any contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission. No license is granted to the trademarks of
+the copyright holders even if such marks are included in this software.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import CareKitStore
+import Foundation
+import ModelsDSTU2
+
+extension ModelsDSTU2.Patient: OCKFHIRResource {
+    public typealias Release = DSTU2
+}
+
+/// Converts a FHIR DSTU2 `Patient` to an `OCKPatient`.
+///
+/// The mapping is predefined to use reasonable defaults, but it is possible to configure
+/// the behavior by setting properties on `OCKDSTU2PatientCoder`.
+public struct OCKDSTU2PatientCoder: OCKPatientConverterTraits {
+
+    public typealias Resource = ModelsDSTU2.Patient
+    public typealias Entity = OCKPatient
+
+    /// Initialize an `OCKDSTU2PatientCoder` that uses default mappings between FHIR and
+    /// CareKit patient models.
+    public init() {}
+
+    // MARK: Convert FHIR Patient to OCKPatient
+
+    public var getCareKitID: (Patient) throws -> String = {
+        guard let id = $0.id?.value?.string else {
+            throw OCKFHIRCodingError.missingRequiredField("id")
+        }
+        return id
+    }
+
+    public var getCareKitName: (Patient) throws -> PersonNameComponents = {
+        guard let fhirName = $0.name?.first else {
+            throw OCKFHIRCodingError.missingRequiredField("name")
+        }
+        var components = PersonNameComponents()
+        components.familyName = fhirName.family?.first?.value?.string
+        components.givenName = fhirName.given?.first?.value?.string
+        components.namePrefix = fhirName.prefix?.first?.value?.string
+        components.nameSuffix = fhirName.suffix?.first?.value?.string
+        return components
+    }
+
+    public var getCareKitSex: (Patient) throws -> OCKBiologicalSex? = {
+        switch $0.gender?.value {
+        case .male: return .male
+        case .female: return .female
+        case .other: return .other("other")
+        case .unknown: return nil
+        case .none: return nil
+        }
+    }
+
+    public var getCareKitBirthday: (Patient) throws -> Date? = {
+        guard
+            let birthday = $0.birthDate?.value,
+            let day = birthday.day,
+            let month = birthday.month
+        else { return nil }
+
+        var components = DateComponents()
+        components.year = birthday.year
+        components.month = Int(month)
+        components.day = Int(day)
+
+        return Calendar.current.date(from: components)
+    }
+
+    public var getCareKitAllergies: (Patient) throws -> [String]? = { _ in
+        nil
+    }
+
+    // MARK: Convert OCKPatient to FHIR Patient
+
+    public var setFHIRID: (String, Patient) throws -> Void = { id, patient in
+        patient.id = FHIRPrimitive(FHIRString(id))
+    }
+
+    public var setFHIRName: (PersonNameComponents, Patient) throws -> Void = { name, patient in
+        let humanName = HumanName()
+        humanName.family = name.familyName == nil ? [] : [name.familyName!.fhirString()]
+        humanName.given = name.givenName == nil ? [] : [name.givenName!.fhirString()]
+        humanName.prefix = name.namePrefix == nil ? [] : [name.namePrefix!.fhirString()]
+        humanName.suffix = name.nameSuffix == nil ? [] : [name.nameSuffix!.fhirString()]
+
+        patient.name = [humanName]
+    }
+
+    public var setFHIRSex: (OCKBiologicalSex, Patient) throws -> Void = { sex, patient in
+        patient.gender = sex.administrativeGender
+    }
+
+    public var setFHIRBirthday: (Date, Patient) throws -> Void = { birthday, patient in
+        patient.birthDate = FHIRPrimitive(birthday.dstu2FHIRDateTime.date)
+    }
+
+    public var setFHIRAllergies: ([String], Patient) throws -> Void = { allergies, patient in
+        // No-op
+    }
+
+    func newResource() -> Resource {
+        Patient()
+    }
+}
+
+private extension OCKBiologicalSex {
+    var administrativeGender: FHIRPrimitive<AdministrativeGender> {
+        switch self {
+        case .female: return FHIRPrimitive(.female)
+        case .male: return FHIRPrimitive(.male)
+        case let .other(value):
+            if value == AdministrativeGender.unknown.rawValue {
+                return FHIRPrimitive(.unknown)
+            } else {
+                return FHIRPrimitive(.other)
+            }
+        }
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/Patients/OCKDSTU2PatientConverter.swift
+++ b/CareKitFHIR/CareKitFHIR/Patients/OCKDSTU2PatientConverter.swift
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2019, Apple Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder(s) nor the names of any contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission. No license is granted to the trademarks of
+the copyright holders even if such marks are included in this software.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import CareKitStore
+import Foundation
+import ModelsDSTU2
+
+extension ModelsDSTU2.Patient: OCKFHIRResource {
+    public typealias Release = DSTU2
+}
+
+/// Converts a FHIR DSTU2 `Patient` to an `OCKPatient`.
+///
+/// The mapping is predefined to use reasonable defaults, but it is possible to configure
+/// the behavior by setting properties on `OCKDSTU2PatientCoder`.
+public struct OCKDSTU2PatientCoder: OCKPatientConverterTraits {
+
+    public typealias Resource = ModelsDSTU2.Patient
+    public typealias Release = Resource.Release
+    public typealias Entity = OCKPatient
+
+    /// Initialize an `OCKDSTU2PatientCoder` that uses default mappings between FHIR and
+    /// CareKit patient models.
+    public init() {}
+
+    // MARK: Convert FHIR Patient to OCKPatient
+
+    public var getId: (Patient) throws -> String = {
+        guard let id = $0.id?.string else {
+            throw OCKConversionError.missingRequiredField("id")
+        }
+        return id
+    }
+
+    public var getName: (Patient) throws -> PersonNameComponents = {
+        guard let fhirName = $0.name?.first else {
+            throw OCKConversionError.missingRequiredField("name")
+        }
+        var components = PersonNameComponents()
+        components.familyName = fhirName.family?.first?.string
+        components.givenName = fhirName.given?.first?.string
+        components.namePrefix = fhirName.prefix?.first?.string
+        components.nameSuffix = fhirName.suffix?.first?.string
+        return components
+    }
+
+    public var getSex: (Patient) throws -> OCKBiologicalSex? = {
+        switch $0.gender {
+        case .male: return .male
+        case .female: return .female
+        case .other: return .other("other")
+        case .unknown: return nil
+        case .none: return nil
+        }
+    }
+
+    public var getBirthday: (Patient) throws -> Date? = {
+        guard
+            let birthday = $0.birthDate,
+            let day = birthday.day,
+            let month = birthday.month
+        else { return nil }
+
+        var components = DateComponents()
+        components.year = birthday.year
+        components.month = Int(month)
+        components.day = Int(day)
+
+        return Calendar.current.date(from: components)
+    }
+
+    public var getAllergies: (Patient) throws -> [String]? = { _ in
+        nil
+    }
+
+    // MARK: Convert OCKPatient to FHIR Patient
+
+    func newResource() -> Resource {
+        Patient()
+    }
+
+    public var putId: (String, Patient) throws -> Void = { id, patient in
+        patient.id = FHIRString(id)
+    }
+
+    public var putName: (PersonNameComponents, Patient) throws -> Void = { name, patient in
+        let humanName = HumanName()
+        humanName.family = name.familyName == nil ? [] : [name.familyName!.fhirString()]
+        humanName.given = name.givenName == nil ? [] : [name.givenName!.fhirString()]
+        humanName.prefix = name.namePrefix == nil ? [] : [name.namePrefix!.fhirString()]
+        humanName.suffix = name.nameSuffix == nil ? [] : [name.nameSuffix!.fhirString()]
+
+        patient.name = [humanName]
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/Patients/OCKPatientConverterTraits.swift
+++ b/CareKitFHIR/CareKitFHIR/Patients/OCKPatientConverterTraits.swift
@@ -1,0 +1,100 @@
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import CareKitStore
+import Foundation
+
+protocol OCKPatientConverterTraits: OCKFHIRResourceCoder where Entity == OCKPatient {
+
+    // MARK: FHIR Patient to OCKPatient
+
+    /// A closure that defines how `OCKPatient`'s `id` property is mapped from a FHIR `Patient`.
+    var getCareKitID: (Resource) throws -> String { get }
+
+    /// A closure that defines how `OCKPatient`'s `name` property is mapped from a FHIR `Patient`.
+    var getCareKitName: (Resource) throws -> PersonNameComponents { get }
+
+    /// A closure that defines how `OCKPatient`'s `sex` property is mapped from a FHIR `Patient`.
+    var getCareKitSex: (Resource) throws -> OCKBiologicalSex? { get }
+
+    /// A closure that defines how `OCKPatient`'s `birthday` property is mapped from a FHIR `Patient``.
+    var getCareKitBirthday: (Resource) throws -> Date? { get }
+
+    /// A closure that defines how `OCKPatient`'s `allergies` property is mapped from a FHIR `Patient``.
+    var getCareKitAllergies: (Resource) throws -> [String]? { get }
+
+    // MARK: OCKPatient to FHIR Patient
+
+    /// A closure that sets a given id on a given patient.
+    var setFHIRID: (_ id: String, _ patient: Resource) throws -> Void { get }
+
+    /// A closure that sets a given name on a given patient.
+    var setFHIRName: (_ name: PersonNameComponents, _ patient: Resource) throws -> Void { get }
+
+    /// A closure that sets a given biological sex on a given patient.
+    var setFHIRSex: (_ sex: OCKBiologicalSex, _ patient: Resource) throws -> Void { get }
+
+    /// A closure that sets a given birthday on a given patient.
+    var setFHIRBirthday: (_ date: Date, _ patient: Resource) throws -> Void { get }
+
+    /// A closure that sets a given array of allergies on a given patient.
+    var setFHIRAllergies: (_ allergies: [String], _ patient: Resource) throws -> Void { get }
+
+    /// Create and return a new patient with all properties set to their default values.
+    /// - Note: This is basically a stand in for requiring the associated type to have a default init.
+    func newResource() -> Resource
+}
+
+extension OCKPatientConverterTraits {
+
+    /// Converts a CareKit `OCKPatient` into a FHIRModels object
+    /// - Parameter entity: An `OCKPatient`
+    /// - Throws: `OCKFHIRCodingError`
+    /// - Returns: A FHIRModels Patient
+    public func convert(entity: OCKPatient) throws -> Resource {
+        let fhirPatient = newResource()
+        try setFHIRID(entity.id, fhirPatient)
+        try setFHIRName(entity.name, fhirPatient)
+        return fhirPatient
+    }
+
+    /// Converts a FHIRModels object into a CareKit `OCKPatient`
+    /// - Parameter resource: A FHIRModels `Patient`
+    /// - Throws: `OCKFHIRCodingError`
+    /// - Returns: A CareKit `OCKPatient`
+    public func convert(resource: Resource) throws -> Entity {
+        var convertedPatient = OCKPatient(id: try getCareKitID(resource), name: try getCareKitName(resource))
+        convertedPatient.sex = try getCareKitSex(resource)
+        convertedPatient.birthday = try getCareKitBirthday(resource)
+        convertedPatient.allergies = try getCareKitAllergies(resource)
+        convertedPatient.source = "FHIR"
+        return convertedPatient
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/Patients/OCKR4PatientCoder.swift
+++ b/CareKitFHIR/CareKitFHIR/Patients/OCKR4PatientCoder.swift
@@ -1,0 +1,146 @@
+/*
+Copyright (c) 2019, Apple Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder(s) nor the names of any contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission. No license is granted to the trademarks of
+the copyright holders even if such marks are included in this software.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import CareKitStore
+import Foundation
+import ModelsR4
+
+extension ModelsR4.Patient: OCKFHIRResource {
+    public typealias Release = R4
+}
+
+/// Converts a FHIR R4 `Patient` to an `OCKPatient`.
+///
+/// The mapping is predefined to use reasonable defaults, but it is possible to configure
+/// the behavior by setting properties on `OCKR4PatientCoder`.
+public struct OCKR4PatientCoder: OCKPatientConverterTraits {
+
+    public typealias Resource = ModelsR4.Patient
+    public typealias Entity = OCKPatient
+
+    /// Initialize an `OCKR4PatientCoder` that uses default mappings between FHIR and
+    /// CareKit patient models.
+    public init() {}
+
+    // MARK: Convert FHIR Patient to OCKPatient
+
+    public var getCareKitID: (Patient) throws -> String = {
+        guard let id = $0.id?.value?.string else {
+            throw OCKFHIRCodingError.missingRequiredField("id")
+        }
+        return id
+    }
+
+    public var getCareKitName: (Patient) throws -> PersonNameComponents = {
+        guard let fhirName = $0.name?.first else {
+            throw OCKFHIRCodingError.missingRequiredField("name")
+        }
+        var components = PersonNameComponents()
+        components.familyName = fhirName.family?.value?.string
+        components.givenName = fhirName.given?.first?.value?.string
+        components.namePrefix = fhirName.prefix?.first?.value?.string
+        components.nameSuffix = fhirName.suffix?.first?.value?.string
+        return components
+    }
+
+    public var getCareKitSex: (Patient) throws -> OCKBiologicalSex? = {
+        switch $0.gender?.value {
+        case .male: return .male
+        case .female: return .female
+        case .other: return .other("other")
+        case .unknown: return nil
+        case .none: return nil
+        }
+    }
+
+    public var getCareKitBirthday: (Patient) throws -> Date? = {
+        guard
+            let birthday = $0.birthDate?.value,
+            let day = birthday.day,
+            let month = birthday.month
+        else { return nil }
+
+        var components = DateComponents()
+        components.year = birthday.year
+        components.month = Int(month)
+        components.day = Int(day)
+
+        return Calendar.current.date(from: components)
+    }
+
+    public var getCareKitAllergies: (Patient) throws -> [String]? = { _ in
+        nil
+    }
+
+    // MARK: Convert OCKPatient to FHIR Patient
+
+    public var setFHIRID: (String, Patient) throws -> Void = { id, patient in
+        patient.id = FHIRPrimitive(FHIRString(id))
+    }
+
+    public var setFHIRName: (PersonNameComponents, Patient) throws -> Void = { name, patient in
+        let humanName = HumanName()
+        humanName.family = name.familyName?.fhirString()
+        humanName.given = name.givenName == nil ? [] : [name.givenName!.fhirString()]
+        humanName.prefix = name.namePrefix == nil ? [] : [name.namePrefix!.fhirString()]
+        humanName.suffix = name.nameSuffix == nil ? [] : [name.nameSuffix!.fhirString()]
+
+        patient.name = [humanName]
+    }
+
+    public var setFHIRSex: (OCKBiologicalSex, Patient) throws -> Void = { sex, patient in
+        patient.gender = sex.administrativeGender
+    }
+
+    public var setFHIRBirthday: (Date, Patient) throws -> Void = { birthday, patient in
+        patient.birthDate = FHIRPrimitive(birthday.r4FHIRDateTime.value?.date)
+    }
+
+    public var setFHIRAllergies: ([String], Patient) throws -> Void = { allergies, patient in
+        // No-op
+    }
+
+    func newResource() -> Patient { Patient() }
+}
+
+private extension OCKBiologicalSex {
+    var administrativeGender: FHIRPrimitive<AdministrativeGender> {
+        switch self {
+        case .female: return FHIRPrimitive(.female)
+        case .male: return FHIRPrimitive(.male)
+        case let .other(value):
+            if value == AdministrativeGender.unknown.rawValue {
+                return FHIRPrimitive(.unknown)
+            } else {
+                return FHIRPrimitive(.other)
+            }
+        }
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/Tasks/OCKDSTU2CarePlanActivityCoder.swift
+++ b/CareKitFHIR/CareKitFHIR/Tasks/OCKDSTU2CarePlanActivityCoder.swift
@@ -1,0 +1,97 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import CareKitStore
+import Foundation
+import ModelsDSTU2
+
+extension ModelsDSTU2.CarePlanActivity: OCKFHIRResource {
+    public typealias Release = DSTU2
+}
+
+/// Converts a FHIR DSTU2 `CarePlanActivity` to an `OCKTask`.
+///
+/// The mapping is predefined to use reasonable defaults, but it is possible to configure
+/// the behavior by setting properties on `OCKDSTU2CarePlanActivityCoder`.
+public struct OCKDSTU2CarePlanActivityCoder: OCKTaskConverterTraits {
+
+    public typealias Resource = ModelsDSTU2.CarePlanActivity
+    public typealias Entity = OCKTask
+
+    // MARK: FHIR CarePlanActivity to OCKTask
+
+    public var getCareKitID: (Resource) throws -> String = { activity in
+        guard let id = activity.id?.value?.string else {
+            throw OCKFHIRCodingError.missingRequiredField("id")
+        }
+        return id
+    }
+
+    public var getCareKitSchedule: (Resource) throws -> OCKSchedule = { activity in
+
+        // There could be any of 3 kinds of schedules: Timing, Period, String.
+        // For now we're only considering the Timing case.
+        guard case let .timing(timing) = activity.detail?.scheduled else {
+            throw OCKFHIRCodingError.missingRequiredField("schedule")
+        }
+
+        return try OCKDSTU2ScheduleCoder().convert(resource: timing)
+    }
+
+    public var getCareKitTitle: (Resource) throws -> String? = { activity in
+        activity.detail?.description_fhir?.value?.string
+    }
+
+    public var getCareKitInstructions: (CarePlanActivity) throws -> String? = { activity in
+        nil
+    }
+
+    // MARK: OCKTask to FHIR CarePlanActivity
+
+    func newResource() -> Resource { CarePlanActivity() }
+
+    public var setFHIRID: (_ id: String, _ activity: Resource) throws -> Void = { id, activity in
+        activity.id = FHIRPrimitive(FHIRString(id))
+    }
+
+    public var setFHIRTitle: (_ title: String?, _ activity: Resource) throws -> Void = { title, activity in
+        guard let title = title else { return }
+        activity.detail = activity.detail ?? CarePlanActivityDetail(prohibited: false)
+        activity.detail?.description_fhir = FHIRPrimitive(FHIRString(title))
+    }
+
+    public var setFHIRSchedule: (OCKSchedule, CarePlanActivity) throws -> Void = { schedule, activity in
+        activity.detail = activity.detail ?? CarePlanActivityDetail(prohibited: false)
+        activity.detail?.scheduled = .timing(try OCKDSTU2ScheduleCoder().convert(entity: schedule))
+    }
+
+    public var setFHIRInstructions: (String?, CarePlanActivity) throws -> Void = { instructions, activity in
+        // no-op
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/Tasks/OCKDSTU2MedicationOrderCoder.swift
+++ b/CareKitFHIR/CareKitFHIR/Tasks/OCKDSTU2MedicationOrderCoder.swift
@@ -1,0 +1,113 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import CareKitStore
+import Foundation
+import ModelsDSTU2
+
+extension ModelsDSTU2.MedicationOrder: OCKFHIRResource {
+    public typealias Release = DSTU2
+}
+
+/// Converts a FHIR DSTU2 `MedicationOrder` to an `OCKTask`.
+///
+/// The mapping is predefined to use reasonable defaults, but it is possible to configure
+/// the behavior by setting properties on `OCKDSTU2MedicationOrderCoder`.
+public struct OCKDSTU2MedicationOrderCoder: OCKTaskConverterTraits {
+
+    public typealias Resource = ModelsDSTU2.MedicationOrder
+    public typealias Entity = OCKTask
+
+    public init() {}
+
+    // MARK: Convert FHIR MedicationOrder to OCKTask
+
+    public var getCareKitID: (Resource) throws -> String = { medicationOrder in
+        guard let id = medicationOrder.id?.value?.string else {
+            throw OCKFHIRCodingError.missingRequiredField("id")
+        }
+        return id
+    }
+
+    public var getCareKitTitle: (Resource) throws -> String? = { medicationOrder in
+        switch medicationOrder.medication {
+        case let .codeableConcept(concept):
+            return concept.text?.value?.string
+        case let .reference(reference):
+            return reference.id?.value?.string
+        }
+    }
+
+    public var getCareKitInstructions: (Resource) throws -> String? = { medicationOrder in
+        medicationOrder.dosageInstruction?.first?.text?.value?.string
+    }
+
+    public var getCareKitSchedule: (Resource) throws -> OCKSchedule = { medicationOrder in
+        guard let timing = medicationOrder.dosageInstruction?.first?.timing else {
+            throw OCKFHIRCodingError.missingRequiredField("schedule")
+        }
+        return try OCKDSTU2ScheduleCoder().convert(resource: timing)
+    }
+
+    // MARK: Convert OCKTask to FHIR MedicationOrder
+
+    public var setFHIRID: (String, Resource) throws -> Void = { id, medicationOrder in
+        medicationOrder.id = FHIRPrimitive(FHIRString(id))
+    }
+
+    public var setFHIRTitle: (String?, Resource) throws -> Void = { title, medicationOrder in
+        guard let title = title else { return }
+
+        if case let .codeableConcept(concept) = medicationOrder.medication {
+            concept.text = FHIRPrimitive(FHIRString(title))
+            medicationOrder.medication = .codeableConcept(concept)
+        } else {
+            let concept = CodeableConcept()
+            concept.text = FHIRPrimitive(FHIRString(title))
+            medicationOrder.medication = .codeableConcept(concept)
+        }
+    }
+
+    public var setFHIRInstructions: (String?, Resource) throws -> Void = { instructions, medicationOrder in
+        guard let instructions = instructions else { return }
+        // Arrays in FHIR are not allowed to be empty, so if it is non-nil, then it must have at least 1 element.
+        medicationOrder.dosageInstruction = medicationOrder.dosageInstruction ?? [MedicationOrderDosageInstruction()]
+        medicationOrder.dosageInstruction![0].text = instructions.fhirString()
+    }
+
+    public var setFHIRSchedule: (OCKSchedule, Resource) throws -> Void = { schedule, medicationOrder in
+        // Arrays in FHIR are not allowed to be empty, so if it is non-nil, then it must have at least 1 element.
+        medicationOrder.dosageInstruction = medicationOrder.dosageInstruction ?? [MedicationOrderDosageInstruction()]
+        medicationOrder.dosageInstruction![0].timing = try OCKDSTU2ScheduleCoder().convert(entity: schedule)
+    }
+
+    func newResource() -> Resource {
+        MedicationOrder(medication: .codeableConcept(CodeableConcept())) }
+}

--- a/CareKitFHIR/CareKitFHIR/Tasks/OCKDSTU2ScheduleCoder.swift
+++ b/CareKitFHIR/CareKitFHIR/Tasks/OCKDSTU2ScheduleCoder.swift
@@ -1,0 +1,188 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import CareKitStore
+import Foundation
+import ModelsDSTU2
+
+extension ModelsDSTU2.Timing: OCKFHIRResource {
+    public typealias Release = DSTU2
+}
+
+struct OCKDSTU2ScheduleCoder: OCKFHIRResourceCoder {
+
+    typealias Resource = Timing
+    typealias Entity = OCKSchedule
+
+    func convert(resource: Timing) throws -> OCKSchedule {
+        // There could be any of 3 kinds of schedules: Timing, Period, String.
+        // For now we're only considering the Timing case.
+        guard
+            let timing = resource.repeat,
+            let periodUnit = timing.periodUnits?.value,
+            let periodCount = timing.period.map({ Int(truncating: $0.value!.decimal as NSNumber) })
+        else { throw OCKFHIRCodingError.missingRequiredField("schedule") }
+
+        // Make sure the activity has a valid start date.
+
+        guard
+            case let .period(period) = timing.bounds,
+            let start = period.start?.value?.foundationDate else {
+            throw OCKFHIRCodingError.unrepresentableContent(
+                "A FHIR CarePlanActivity with no start date cannot be represented in CareKit.")
+        }
+
+        // A valid end date is not required in CareKit.
+        let end: Date? = period.end?.value?.foundationDate
+
+        let targets: [OCKOutcomeValue] = []
+        let text: String? = timing.when?.value?.string
+
+        let interval = try makeInterval(units: periodUnit, count: periodCount)
+        let duration = try makeDuration(units: timing.durationUnits?.value, count: timing.duration?.value)
+
+        let element = OCKScheduleElement(
+            start: start, end: end,
+            interval: interval, text: text,
+            targetValues: targets, duration: duration)
+
+        return OCKSchedule(composing: [element])
+    }
+
+    func convert(entity: OCKSchedule) throws -> Timing {
+
+        // Verify that the schedule can be represented in FHIR format.
+        // There must be only 1 schedule element and its interval must have only 1 component.
+        guard let element = entity.elements.first else {
+            throw OCKFHIRCodingError.corruptData("OCKSchedule didn't have any elements.")
+        }
+        guard entity.elements.count == 1 else {
+            throw OCKFHIRCodingError.unrepresentableContent("OCKSchedules with more than 1 element cannot be represented in FHIR.")
+        }
+
+        var nonZeroComponentCount = 0
+        let keypaths: [KeyPath<DateComponents, Int?>] = [\.second, \.minute, \.hour, \.day, \.weekOfYear, \.month, \.year]
+        for path in keypaths {
+            if element.interval[keyPath: path] != nil {
+                nonZeroComponentCount += 1
+            }
+        }
+
+        guard nonZeroComponentCount == 1 else {
+            throw OCKFHIRCodingError.unrepresentableContent("""
+            OCKScheduleElements with intervals containing more than 1 component cannot be represented in FHIR.
+            """)
+        }
+
+        // Reject components not support by FHIR.
+        if element.interval.year != nil {
+            throw OCKFHIRCodingError.unrepresentableContent("OCKScheduleElements with an interval in units of years are not supported in FHIR.")
+        }
+
+        // Build out the FHIR schedule
+        let repetition = TimingRepeat(element: element)
+        let start = FHIRPrimitive(entity.startDate().dstu2FHIRDateTime)
+        let end = FHIRPrimitive(entity.endDate()?.dstu2FHIRDateTime)
+        repetition.bounds = .period(Period(end: end, start: start))
+        repetition.frequency = FHIRPrimitive(1)
+
+        let timing = Timing()
+        timing.repeat = repetition
+
+        return timing
+    }
+
+    private func makeInterval(units: FHIRString, count: Int) throws -> DateComponents {
+        switch units {
+        case Calendar.Component.second.dstu2FHIRUnitString.value: return DateComponents(second: count)
+        case Calendar.Component.minute.dstu2FHIRUnitString.value: return DateComponents(minute: count)
+        case Calendar.Component.hour.dstu2FHIRUnitString.value: return DateComponents(hour: count)
+        case Calendar.Component.day.dstu2FHIRUnitString.value: return DateComponents(day: count)
+        case Calendar.Component.weekOfYear.dstu2FHIRUnitString.value: return DateComponents(weekOfYear: count)
+        case Calendar.Component.month.dstu2FHIRUnitString.value: return DateComponents(month: count)
+        default: throw OCKFHIRCodingError.corruptData("Unrecognized time units: \(units.string)")
+        }
+    }
+
+    private func makeDuration(units: FHIRString?, count: FHIRDecimal?) throws -> OCKScheduleElement.Duration {
+        guard let units = units, let count = count else { return .seconds(0) }
+        let doubleValue = Double(truncating: count.decimal as NSNumber)
+
+        // Treat units of days with duration of 1 as the special case `.allDay`.
+        if units == Calendar.Component.day.dstu2FHIRUnitString && count == FHIRDecimal(1) {
+            return .allDay
+        }
+
+        switch units {
+        case Calendar.Component.second.dstu2FHIRUnitString.value: return .seconds(doubleValue)
+        case Calendar.Component.minute.dstu2FHIRUnitString.value: return .minutes(doubleValue)
+        case Calendar.Component.hour.dstu2FHIRUnitString.value: return .hours(doubleValue)
+        default: throw OCKFHIRCodingError.corruptData("Unrecognized time unitss: \(units.string)")
+        }
+    }
+}
+
+private extension TimingRepeat {
+
+    convenience init(element: OCKScheduleElement) {
+        self.init()
+
+        switch element.duration {
+        case .allDay:
+            durationUnits = Calendar.Component.day.dstu2FHIRUnitString
+            duration = FHIRPrimitive(FHIRDecimal(Decimal(1)))
+        case .seconds(let secs):
+            durationUnits = Calendar.Component.second.dstu2FHIRUnitString
+            duration = FHIRPrimitive(FHIRDecimal(Decimal(secs)))
+        }
+
+        if let seconds = element.interval.second {
+            periodUnits = Calendar.Component.second.dstu2FHIRUnitString
+            period = FHIRPrimitive(FHIRDecimal(Decimal(seconds)))
+        } else if let minutes = element.interval.minute {
+            periodUnits = Calendar.Component.minute.dstu2FHIRUnitString
+            period = FHIRPrimitive(FHIRDecimal(Decimal(minutes)))
+        } else if let hours = element.interval.hour {
+            periodUnits = Calendar.Component.hour.dstu2FHIRUnitString
+            period = FHIRPrimitive(FHIRDecimal(Decimal(hours)))
+        } else if let days = element.interval.day {
+            periodUnits = Calendar.Component.day.dstu2FHIRUnitString
+            period = FHIRPrimitive(FHIRDecimal(Decimal(days)))
+        } else if let weeks = element.interval.weekOfYear {
+            periodUnits = Calendar.Component.weekOfYear.dstu2FHIRUnitString
+            period = FHIRPrimitive(FHIRDecimal(Decimal(weeks)))
+        } else if let months = element.interval.month {
+            periodUnits = Calendar.Component.month.dstu2FHIRUnitString
+            period = FHIRPrimitive(FHIRDecimal(Decimal(months)))
+        } else {
+            fatalError("Missing case")
+        }
+    }
+}

--- a/CareKitFHIR/CareKitFHIR/Tasks/OCKTaskConverterTraits.swift
+++ b/CareKitFHIR/CareKitFHIR/Tasks/OCKTaskConverterTraits.swift
@@ -1,0 +1,92 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import CareKitStore
+import Foundation
+
+protocol OCKTaskConverterTraits: OCKFHIRResourceCoder where Entity == OCKTask {
+
+    // MARK: FHIR CarePlanActivity to OCKTask
+
+    /// A closure that defines how `OCKTask`'s `id` property is mapped from a FHIR Resource.
+    var getCareKitID: (Resource) throws -> String { get }
+
+    /// A closure that defines how `OCKTask`'s `schedule` property is mapped from a FHIR Resource.
+    var getCareKitSchedule: (Resource) throws -> OCKSchedule { get }
+
+    /// A closure that defines how `OCKTask`'s `title` property is mapped from a FHIR Resource.
+    var getCareKitTitle: (Resource) throws -> String? { get }
+
+    /// A closure that defines how `OCKTasks`'s `instructions` property is mapped from a FHIR Resource.
+    var getCareKitInstructions: (Resource) throws -> String? { get }
+
+    // MARK: OCKTask to FHIR CarePlanResource
+
+    /// A closure that sets a given id on a given Resource.
+    var setFHIRID: (_ id: String, _ Resource: Resource) throws -> Void { get }
+
+    /// A closure that sets a given title on a given Resource.
+    var setFHIRTitle: (_ title: String?, _ Resource: Resource) throws -> Void { get }
+
+    /// A closure that sets a given schedule on a given Resource.
+    var setFHIRSchedule: (_ schedule: OCKSchedule, _ Resource: Resource) throws -> Void { get }
+
+    /// A closure that sets the given instructions on a given medication order.
+    var setFHIRInstructions: (String?, Resource) throws -> Void { get }
+
+    /// Create a new Resource with all properties set to the default value.
+    /// - Note: This is basically a stand in for requiring the associated type to have a default init.
+    func newResource() -> Resource
+}
+
+extension OCKTaskConverterTraits {
+
+    public func convert(resource: Resource) throws -> OCKTask {
+
+        var task = OCKTask(
+            id: try getCareKitID(resource),
+            title: try getCareKitTitle(resource),
+            carePlanUUID: nil,
+            schedule: try getCareKitSchedule(resource))
+
+        task.instructions = try getCareKitInstructions(resource)
+
+        return task
+    }
+
+    public func convert(entity: OCKTask) throws -> Resource {
+        let medicationOrder = newResource()
+        try setFHIRID(entity.id, medicationOrder)
+        try setFHIRTitle(entity.title, medicationOrder)
+        try setFHIRInstructions(entity.instructions, medicationOrder)
+        try setFHIRSchedule(entity.schedule, medicationOrder)
+        return medicationOrder
+    }
+}

--- a/CareKitFHIR/CareKitFHIRTests/CareKitFHIR.xctestplan
+++ b/CareKitFHIR/CareKitFHIRTests/CareKitFHIR.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "BF12B243-8B44-45E6-B20B-147E4E2A7D50",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:CareKitFHIR.xcodeproj",
+        "identifier" : "0396EF3E233D187800C28FC0",
+        "name" : "CareKitFHIRTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/CareKitFHIR/CareKitFHIRTests/Info.plist
+++ b/CareKitFHIR/CareKitFHIRTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/CareKitFHIR/CareKitFHIRTests/Integration Tests/CareKitFHIRTests.swift
+++ b/CareKitFHIR/CareKitFHIRTests/Integration Tests/CareKitFHIRTests.swift
@@ -1,0 +1,243 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@testable import CareKitFHIR
+import CareKitStore
+import XCTest
+
+class CareKitFHIRTests: XCTestCase {
+
+    func testParseFHIRPatient() throws {
+        let resource = OCKFHIRResourceData<R4, JSON>(data: samplePatientData)
+        let patient = try OCKR4PatientCoder().decode(resource)
+        XCTAssert(patient.id == "pat1")
+        XCTAssert(patient.name.familyName == "Donald")
+        XCTAssert(patient.name.givenName == "Duck")
+    }
+
+    func testParseFHIRCarePlanActivity() throws {
+        let resource = OCKFHIRResourceData<DSTU2, JSON>(data: sampleCarePlanActivityData)
+        let task = try OCKDSTU2CarePlanActivityCoder().decode(resource)
+        XCTAssert(task.id == "ABC")
+        XCTAssert(task.schedule.elements.first?.interval == DateComponents(day: 2))
+        XCTAssert(task.schedule.elements.first?.duration == .hours(1))
+    }
+
+    func testParseFHIRMedicationOrder() throws {
+        let resource = OCKFHIRResourceData<DSTU2, JSON>(data: sampleMedicationOrderData)
+        var coder = OCKDSTU2MedicationOrderCoder()
+        coder.getCareKitSchedule = { _ in OCKSchedule.dailyAtTime(hour: 0, minutes: 0, start: Date(), end: nil, text: nil, duration: .allDay) }
+        let task = try coder.decode(resource)
+        XCTAssert(task.id == "24")
+        XCTAssert(task.instructions == "2 puffs every 2-4 hours")
+        XCTAssert(task.schedule.elements.first?.interval == DateComponents(day: 1))
+    }
+
+    func testParseFailsWhenDataIsCorrupt() {
+        let corruptData = "{badJson: missingQuotes}".data(using: .utf8)!
+        let resource = OCKFHIRResourceData(release: R4.self, content: JSON.self, data: corruptData)
+        let coder = OCKR4PatientCoder()
+
+        let errorMessage = "Failed to decode FHIR Patient data. Error: The data couldn’t be read because it isn’t in the correct format."
+        let expectedError = OCKFHIRCodingError.corruptData(errorMessage)
+        XCTAssertThrowsError(try coder.decode(resource), matching: expectedError)
+    }
+
+    func testParseFailsWhenUnsupportedXMLContentTypeIsUsed() {
+        let resource = OCKFHIRResourceData(release: R4.self, content: XML.self, data: samplePatientData)
+        let errorMessage = "Failed to convert FHIR Patient to OCKPatient. Error: Unsupported encoding: XML is not supported!"
+        let expectedError = OCKFHIRCodingError.unsupportedEncoding(errorMessage)
+        XCTAssertThrowsError(try OCKR4PatientCoder().decode(resource), matching: expectedError)
+    }
+
+    func testEncodeCareKitPatientToR4() throws {
+        let patient = OCKPatient(id: "abc", givenName: "A", familyName: "B")
+        let coder = OCKR4PatientCoder()
+        let data = try coder.encode(patient, format: JSON.self)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssert(json.contains("\"id\":\"abc\""))
+        XCTAssert(json.contains("\"given\":[\"A\"]"))
+        XCTAssert(json.contains("\"family\":\"B\""))
+    }
+
+    func testEncodeCareKitPatientToDSTU2() throws {
+        let patient = OCKPatient(id: "abc", givenName: "A", familyName: "B")
+        let coder = OCKDSTU2PatientCoder()
+        let data = try coder.encode(patient, format: JSON.self)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssert(json.contains("\"id\":\"abc\""))
+        XCTAssert(json.contains("\"given\":[\"A\"]"))
+        XCTAssert(json.contains("\"family\":[\"B\"]"))
+    }
+
+    func testEncodeCareKitTaskToDSTU2MedicationOrder() throws {
+        let schedule = OCKSchedule.dailyAtTime(hour: 12, minutes: 0, start: Date(), end: nil, text: nil)
+        let task = OCKTask(id: "tylenol", title: "Take Tylenol", carePlanUUID: nil, schedule: schedule)
+        let coder = OCKDSTU2MedicationOrderCoder()
+        let data = try coder.encode(task, format: JSON.self)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssert(json.contains("\"id\":\"tylenol\""))
+        XCTAssert(json.contains("\"text\":\"Take Tylenol\""))
+        XCTAssert(json.contains("12:00:00"))
+    }
+
+    func testEncodeCareKitTaskToDSTU2CarePlanActivity() throws {
+        let schedule = OCKSchedule.dailyAtTime(hour: 12, minutes: 0, start: Date(), end: nil, text: nil)
+        let task = OCKTask(id: "tylenol", title: "Take Tylenol", carePlanUUID: nil, schedule: schedule)
+        let coder = OCKDSTU2CarePlanActivityCoder()
+        let data = try coder.encode(task, format: JSON.self)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssert(json.contains("\"id\":\"tylenol\""))
+        XCTAssert(json.contains("\"description\":\"Take Tylenol\""))
+        XCTAssert(json.contains("12:00:00"))
+    }
+}
+
+/// Sample data based on JSON borrowed from https://www.hl7.org/fhir/patient-example-a.json.html
+private let samplePatientData = """
+{
+  "resourceType": "Patient",
+  "id": "pat1",
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR"
+          }
+        ]
+      },
+      "system": "urn:oid:0.1.2.3.4.5.6.7",
+      "value": "654321"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "family": "Donald",
+      "given": [
+        "Duck"
+      ]
+    }
+  ],
+  "gender": "male",
+  "contact": [
+    {
+      "relationship": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0131",
+              "code": "E"
+            }
+          ]
+        }
+      ],
+      "organization": {
+        "reference": "Organization/1",
+        "display": "Walt Disney Corporation"
+      }
+    }
+  ],
+  "managingOrganization": {
+    "reference": "Organization/1",
+    "display": "ACME Healthcare, Inc"
+  },
+  "link": [
+    {
+      "other": {
+        "reference": "Patient/pat2"
+      },
+      "type": "seealso"
+    }
+  ]
+}
+""".data(using: .utf8)!
+
+private let sampleCarePlanActivityData = """
+{
+  "id":"ABC",
+  "detail":{
+    "prohibited":false,
+    "scheduledTiming":{
+      "resourceType":"Timing",
+      "event":[
+
+      ],
+      "repeat":{
+        "boundsPeriod": {
+          "start": "2019-11-07T16:49:57-08:00",
+          "end": "2021-11-07T16:49:57-08:00"
+        },
+        "duration":3600,
+        "durationUnits":"s",
+        "frequency":1,
+        "period":2,
+        "periodUnits":"d"
+      }
+    }
+  }
+}
+""".data(using: .utf8)!
+
+private let sampleMedicationOrderData = """
+{
+  "status":"active",
+  "note":"Please let me know if you need to use this more than three times per day",
+  "id":"24",
+  "medicationCodeableConcept":{
+    "text":"Albuterol HFA 90 mcg",
+    "coding":[
+      {
+        "system":"http://www.nlm.nih.gov/research/umls/rxnorm/",
+        "code":"329498"
+      }
+    ]
+  },
+  "patient":{
+    "display":"Candace Salinas",
+    "reference":"Patient/1"
+  },
+  "prescriber":{
+    "display":"Daren Estrada",
+    "reference":"Practitioner/20"
+  },
+  "dateWritten":"1985-10-11",
+  "resourceType":"MedicationOrder",
+  "dosageInstruction":[
+    {
+      "text":"2 puffs every 2-4 hours"
+    }
+  ]
+}
+""".data(using: .utf8)!

--- a/CareKitFHIR/CareKitFHIRTests/Unit Tests/DSTU2MedicationOrderConverterTests.swift
+++ b/CareKitFHIR/CareKitFHIRTests/Unit Tests/DSTU2MedicationOrderConverterTests.swift
@@ -1,0 +1,91 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@testable import CareKitFHIR
+import CareKitStore
+import Foundation
+import ModelsDSTU2
+import XCTest
+
+class DSTU2MedicationOrderConverterTest: XCTestCase {
+
+    func testConvertFHIRMedicationOrderToCareKitTask() throws {
+
+        let repetition = TimingRepeat()
+        repetition.bounds = .period(Period(start: FHIRPrimitive(Date().dstu2FHIRDateTime)))
+        repetition.period = FHIRPrimitive(FHIRDecimal(Decimal(1)))
+        repetition.periodUnits = "d"
+        repetition.frequency = FHIRPrimitive(1)
+
+        let concept = CodeableConcept()
+        concept.text = "Title"
+
+        let instructions = MedicationOrderDosageInstruction()
+        instructions.timing = Timing(code: concept)
+        instructions.timing?.repeat = repetition
+        instructions.text = "Instructions"
+
+        let medicationOrder = MedicationOrder(medication: .codeableConcept(concept))
+        medicationOrder.id = "ABC"
+        medicationOrder.dosageInstruction = [instructions]
+
+        let task = try OCKDSTU2MedicationOrderCoder().convert(resource: medicationOrder)
+        XCTAssert(task.id == "ABC")
+        XCTAssert(task.title == "Title")
+        XCTAssert(task.instructions == "Instructions")
+        XCTAssert(task.schedule.elements.first?.interval == DateComponents(day: 1))
+    }
+
+    func testConvertCareKitTaskToFHIRMedicationOrder() throws {
+        let startDate = Date().truncatingNanoSeconds
+        let endDate = Calendar.current.date(byAdding: .day, value: 10, to: startDate)!.truncatingNanoSeconds
+
+        let element = OCKScheduleElement(start: startDate, end: endDate, interval: DateComponents(day: 1), duration: .seconds(10))
+        let schedule = OCKSchedule(composing: [element])
+        var medication = OCKTask(id: "ABC", title: "Ibuprofen", carePlanUUID: nil, schedule: schedule)
+        medication.instructions = "Instructions"
+
+        let medicationOrder = try OCKDSTU2MedicationOrderCoder().convert(entity: medication)
+
+        guard case let .period(period) = medicationOrder.dosageInstruction?.first?.timing?.repeat?.bounds else {
+            XCTFail("Expected a period")
+            return
+        }
+
+        XCTAssert(medicationOrder.id?.value?.string == "ABC")
+        XCTAssert(medicationOrder.dosageInstruction?.first?.text == "Instructions")
+        XCTAssert(medicationOrder.dosageInstruction?.first?.timing?.repeat?.periodUnits == "d")
+        XCTAssert(medicationOrder.dosageInstruction?.first?.timing?.repeat?.period == FHIRPrimitive(FHIRDecimal(1)))
+        XCTAssert(medicationOrder.dosageInstruction?.first?.timing?.repeat?.durationUnits == "s")
+        XCTAssert(medicationOrder.dosageInstruction?.first?.timing?.repeat?.duration == FHIRPrimitive(FHIRDecimal(10)))
+        XCTAssert(period.start?.value?.foundationDate == startDate)
+        XCTAssert(period.end?.value?.foundationDate == endDate)
+    }
+}

--- a/CareKitFHIR/CareKitFHIRTests/Unit Tests/DSTU2PatientConverterTests.swift
+++ b/CareKitFHIR/CareKitFHIRTests/Unit Tests/DSTU2PatientConverterTests.swift
@@ -1,0 +1,140 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@testable import CareKitFHIR
+import CareKitStore
+import ModelsDSTU2
+import XCTest
+
+class DSTU2PatientConverterTests: XCTestCase {
+
+    // MARK: Convert FHIR Patient to OCKPatient
+
+    func testConvertFHIRPatientFailsWhenMissingID() {
+        let patient = Patient()
+        let converter = OCKDSTU2PatientCoder()
+        let expectedError: OCKFHIRCodingError = .missingRequiredField("id")
+        XCTAssertThrowsError(try converter.convert(resource: patient), matching: expectedError)
+    }
+
+    func testConvertFHIRPatientSucceedsForDefaultIDGetter() throws {
+        let patient = Patient()
+        patient.name = [HumanName()]
+        patient.id = "abc"
+
+        let converter = OCKDSTU2PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.id == "abc")
+    }
+
+    func testConvertFHIRPatientSetsPatientSourceToFHIR() throws {
+        let patient = Patient()
+        patient.name = [HumanName()]
+        patient.id = "abc"
+
+        let converter = OCKDSTU2PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.source == "FHIR")
+    }
+
+    func testConvertFHIRPatientSucceedsForCustomIDGetter() throws {
+        let identifier = Identifier()
+        identifier.value = "abc"
+
+        let patient = Patient()
+        patient.identifier = [identifier]
+        patient.name = [HumanName()]
+
+        var converter = OCKDSTU2PatientCoder()
+        converter.getCareKitID = { $0.identifier!.first!.value!.value!.string }
+
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.id == "abc")
+    }
+
+    func testConvertFHIRPatientSucceedsForDefaultNameGetter() throws {
+        let patient = Patient()
+        patient.id = "abc"
+        patient.name = [HumanName(family: ["Bill"], given: ["Bob"])]
+
+        let converter = OCKDSTU2PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.name.familyName == "Bill")
+        XCTAssert(converted.name.givenName == "Bob")
+    }
+
+    func testConvertFHIRPatientSucceedsForDefaultSexGetter() throws {
+        let patient = Patient()
+        patient.id = "abc"
+        patient.name = [HumanName()]
+        patient.gender = FHIRPrimitive(AdministrativeGender.other)
+
+        let converter = OCKDSTU2PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.sex == .other("other"))
+    }
+
+    func testConvertFHIRPatientSucceedsForDefaultBirthdayGetter() throws {
+        let components = Calendar.current.dateComponents(Set([.year, .month, .day]), from: Date())
+        let birthday = Calendar.current.date(from: components)!
+
+        let patient = Patient()
+        patient.id = "abc"
+        patient.name = [HumanName()]
+        patient.birthDate = FHIRPrimitive(FHIRDate(
+            year: Calendar.current.component(.year, from: birthday),
+            month: UInt8(Calendar.current.component(.month, from: birthday)),
+            day: UInt8(Calendar.current.component(.day, from: birthday))
+        ))
+
+        let converter = OCKDSTU2PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.birthday == birthday)
+    }
+
+    // MARK: Convert OCKPatient to FHIR Patient
+
+    func testConvertCareKitPatientSucceedsForDefaultSetters() throws {
+        var name = PersonNameComponents()
+        name.familyName = "A"
+        name.givenName = "B"
+        name.namePrefix = "C"
+        name.nameSuffix = "D"
+
+        let careKitPatient = OCKPatient(id: "123", name: name)
+        let converter = OCKDSTU2PatientCoder()
+        let fhirPatient = try converter.convert(entity: careKitPatient)
+
+        XCTAssert(fhirPatient.name?.first?.family == ["A"])
+        XCTAssert(fhirPatient.name?.first?.given == ["B"])
+        XCTAssert(fhirPatient.name?.first?.prefix == ["C"])
+        XCTAssert(fhirPatient.name?.first?.suffix == ["D"])
+    }
+}

--- a/CareKitFHIR/CareKitFHIRTests/Unit Tests/DSTU2TaskConverterTests.swift
+++ b/CareKitFHIR/CareKitFHIRTests/Unit Tests/DSTU2TaskConverterTests.swift
@@ -1,0 +1,252 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@testable import CareKitFHIR
+import CareKitStore
+import ModelsDSTU2
+import XCTest
+
+class DSTU2TaskConverterTests: XCTestCase {
+
+    // MARK: Convert FHIR Activity to OCKTask
+
+    func testConvertFHIRActivityFailsWhenMissingID() {
+        let activity = CarePlanActivity()
+        let converter = OCKDSTU2CarePlanActivityCoder()
+        let expectedError: OCKFHIRCodingError = .missingRequiredField("id")
+        XCTAssertThrowsError(try converter.convert(resource: activity), matching: expectedError)
+    }
+
+    func testConvertFHIRActivityFailsWhenMissingSchedule() {
+        let activity = CarePlanActivity()
+        activity.id = "abc"
+        let converter = OCKDSTU2CarePlanActivityCoder()
+        let expectedError: OCKFHIRCodingError = .missingRequiredField("schedule")
+        XCTAssertThrowsError(try converter.convert(resource: activity), matching: expectedError)
+    }
+
+    func testConvertFHIRTaskSucceedsForDefaultIDGetter() throws {
+        let activity = CarePlanActivity()
+        activity.id = "abc"
+
+        let repetition = TimingRepeat()
+        repetition.bounds = .period(Period(start: FHIRPrimitive(Date().dstu2FHIRDateTime)))
+        repetition.period = FHIRPrimitive(FHIRDecimal(Decimal(1)))
+        repetition.periodUnits = "d"
+        repetition.frequency = FHIRPrimitive(1)
+
+        let timing = Timing()
+        timing.repeat = repetition
+
+        activity.detail = CarePlanActivityDetail(prohibited: false, scheduled: .timing(timing))
+
+        let converter = OCKDSTU2CarePlanActivityCoder()
+        let task = try converter.convert(resource: activity)
+        XCTAssert(task.id == "abc")
+    }
+
+    func testConvertFHIRTaskSucceedsForCustomIDGetter() throws {
+        let activity = CarePlanActivity()
+
+        let repetition = TimingRepeat()
+        repetition.bounds = .period(Period(start: FHIRPrimitive(Date().dstu2FHIRDateTime)))
+        repetition.period = FHIRPrimitive(FHIRDecimal(Decimal(1)))
+        repetition.periodUnits = "d"
+        repetition.frequency = FHIRPrimitive(1)
+
+        let timing = Timing()
+        timing.repeat = repetition
+        activity.detail = CarePlanActivityDetail(prohibited: false, scheduled: .timing(timing))
+        activity.detail?.description_fhir = "abc"
+
+        var converter = OCKDSTU2CarePlanActivityCoder()
+        converter.getCareKitID = { $0.detail!.description_fhir!.value!.string }
+
+        let task = try converter.convert(resource: activity)
+        XCTAssert(task.id == "abc")
+    }
+
+    func testConvertFHIRTaskSucceedsForDefaultTitleGetter() throws {
+        let activity = CarePlanActivity()
+        activity.id = "abc"
+
+        let repetition = TimingRepeat()
+        repetition.bounds = .period(Period(start: FHIRPrimitive(Date().dstu2FHIRDateTime)))
+        repetition.period = FHIRPrimitive(FHIRDecimal(Decimal(1)))
+        repetition.periodUnits = "d"
+        repetition.frequency = FHIRPrimitive(1)
+
+        let timing = Timing()
+        timing.repeat = repetition
+
+        activity.detail = CarePlanActivityDetail(prohibited: false, scheduled: .timing(timing))
+        activity.detail?.description_fhir = "title"
+
+        let converter = OCKDSTU2CarePlanActivityCoder()
+        let task = try converter.convert(resource: activity)
+        XCTAssert(task.title == "title")
+    }
+
+    func testConvertFHIRTaskSucceedsForDefaultScheduleGetter() throws {
+        let activity = CarePlanActivity()
+        activity.id = "abc"
+
+        let repetition = TimingRepeat()
+        repetition.bounds = .period(Period(start: FHIRPrimitive(Date().dstu2FHIRDateTime)))
+        repetition.periodUnits = "d"
+        repetition.period = FHIRPrimitive(FHIRDecimal(Decimal(1)))
+        repetition.frequency = FHIRPrimitive(1)
+        repetition.durationUnits = "h"
+        repetition.duration = FHIRPrimitive(FHIRDecimal(2))
+
+        let timing = Timing()
+        timing.repeat = repetition
+
+        activity.detail = CarePlanActivityDetail(prohibited: false, scheduled: .timing(timing))
+        activity.detail?.description_fhir = "title"
+
+        let converter = OCKDSTU2CarePlanActivityCoder()
+        let task = try converter.convert(resource: activity)
+        XCTAssert(task.schedule.elements.count == 1)
+        XCTAssert(task.schedule.elements.first?.interval == DateComponents(day: 1))
+        XCTAssert(task.schedule.elements.first?.duration == .hours(2))
+    }
+
+    func testConvertFHIRTaskSucceedsForAllDayScheduleElement() throws {
+        let activity = CarePlanActivity()
+        activity.id = "abc"
+
+        let repetition = TimingRepeat()
+        repetition.bounds = .period(Period(start: FHIRPrimitive(Date().dstu2FHIRDateTime)))
+        repetition.periodUnits = "d"
+        repetition.period = FHIRPrimitive(FHIRDecimal(Decimal(1)))
+        repetition.frequency = FHIRPrimitive(1)
+        repetition.durationUnits = "d"
+        repetition.duration = FHIRPrimitive(FHIRDecimal(1))
+
+        let timing = Timing()
+        timing.repeat = repetition
+
+        activity.detail = CarePlanActivityDetail(prohibited: false, scheduled: .timing(timing))
+        activity.detail?.description_fhir = "title"
+
+        let converter = OCKDSTU2CarePlanActivityCoder()
+        let task = try converter.convert(resource: activity)
+        XCTAssert(task.schedule.elements.count == 1)
+        XCTAssert(task.schedule.elements.first?.interval == DateComponents(day: 1))
+        XCTAssert(task.schedule.elements.first?.duration == .allDay)
+    }
+
+    // MARK: Convert OCKTask to FHIR Care Plan Activity
+
+    func testConvertCareKitTaskToFHIRCarePlanActivitySucceedsForDefaultSetters() throws {
+        let element = OCKScheduleElement(start: Date(), end: nil, interval: DateComponents(day: 2), duration: .hours(1))
+        let schedule = OCKSchedule(composing: [element])
+        let task = OCKTask(id: "abc", title: "title", carePlanUUID: nil, schedule: schedule)
+        let converter = OCKDSTU2CarePlanActivityCoder()
+        let activity = try converter.convert(entity: task)
+
+        guard case let .timing(timing) = activity.detail?.scheduled else {
+            XCTFail("Expected the schedule to be a timing")
+            return
+        }
+
+        XCTAssert(activity.id == "abc")
+        XCTAssert(activity.detail?.description_fhir == "title")
+        XCTAssert(timing.repeat?.periodUnits == "d")
+        XCTAssert(timing.repeat?.period == FHIRPrimitive(FHIRDecimal(2)))
+        XCTAssert(timing.repeat?.frequency == FHIRPrimitive(1))
+        XCTAssert(timing.repeat?.durationUnits == "s")
+        XCTAssert(timing.repeat?.duration == FHIRPrimitive(FHIRDecimal(3_600)))
+    }
+
+    func testConvertCareKitTaskToFHIRCarePlanActivityConvertsAllDayElementsCorrectly() throws {
+        let startDate = Date().truncatingNanoSeconds
+        let endDate = Calendar.current.date(byAdding: .year, value: 2, to: startDate)
+        let element = OCKScheduleElement(start: startDate, end: endDate, interval: DateComponents(day: 2), duration: .hours(2))
+        let schedule = OCKSchedule(composing: [element])
+        let task = OCKTask(id: "abc", title: "title", carePlanUUID: nil, schedule: schedule)
+        let converter = OCKDSTU2CarePlanActivityCoder()
+        let activity = try converter.convert(entity: task)
+
+        guard
+            case let .timing(timing) = activity.detail?.scheduled,
+            case let .period(period) = timing.repeat?.bounds
+        else {
+            XCTFail("Expected the schedule to be a timing")
+            return
+        }
+
+        XCTAssert(activity.id == "abc")
+        XCTAssert(activity.detail?.description_fhir == "title")
+        XCTAssert(timing.repeat?.periodUnits == "d")
+        XCTAssert(timing.repeat?.period == FHIRPrimitive(FHIRDecimal(2)))
+        XCTAssert(timing.repeat?.durationUnits == "s")
+        XCTAssert(timing.repeat?.duration == FHIRPrimitive(FHIRDecimal(7_200)))
+        XCTAssert(period.start?.value?.foundationDate == startDate)
+        XCTAssert(period.end?.value?.foundationDate == endDate)
+
+    }
+
+    func testConvertCareKitTaskToFHIRCarePlanActivityFailsIfScheduleHasMoreThanOneElement() {
+        let element1 = OCKScheduleElement(start: Date(), end: nil, interval: DateComponents(day: 2))
+        let element2 = OCKScheduleElement(start: Date(), end: nil, interval: DateComponents(hour: 50))
+        let schedule = OCKSchedule(composing: [element1, element2])
+        let task = OCKTask(id: "abc", title: "title", carePlanUUID: nil, schedule: schedule)
+        let converter = OCKDSTU2CarePlanActivityCoder()
+
+        let errorMessage = "OCKSchedules with more than 1 element cannot be represented in FHIR."
+        let expectedError = OCKFHIRCodingError.unrepresentableContent(errorMessage)
+        XCTAssertThrowsError(try converter.convert(entity: task), matching: expectedError)
+    }
+
+    func testConvertCareKitTaskToFHIRCarePlanActivityFailsIfIntervalHasMultipleComponents() {
+        let interval = DateComponents(day: 1, hour: 12)
+        let element = OCKScheduleElement(start: Date(), end: nil, interval: interval)
+        let schedule = OCKSchedule(composing: [element])
+        let task = OCKTask(id: "abc", title: "title", carePlanUUID: nil, schedule: schedule)
+        let converter = OCKDSTU2CarePlanActivityCoder()
+
+        let errorMessage = "OCKScheduleElements with intervals containing more than 1 component cannot be represented in FHIR."
+        let expectedError = OCKFHIRCodingError.unrepresentableContent(errorMessage)
+        XCTAssertThrowsError(try converter.convert(entity: task), matching: expectedError)
+    }
+
+    func testConvertCareKitTaskToFHIRCarePlanActivityFailsIfIntervalHasYearComponent() {
+        let element = OCKScheduleElement(start: Date(), end: nil, interval: DateComponents(year: 2))
+        let schedule = OCKSchedule(composing: [element])
+        let task = OCKTask(id: "abc", title: "title", carePlanUUID: nil, schedule: schedule)
+        let converter = OCKDSTU2CarePlanActivityCoder()
+
+        let errorMessage = "OCKScheduleElements with an interval in units of years are not supported in FHIR."
+        let expectedError = OCKFHIRCodingError.unrepresentableContent(errorMessage)
+        XCTAssertThrowsError(try converter.convert(entity: task), matching: expectedError)
+    }
+}

--- a/CareKitFHIR/CareKitFHIRTests/Unit Tests/FHIRResourceDataTests.swift
+++ b/CareKitFHIR/CareKitFHIRTests/Unit Tests/FHIRResourceDataTests.swift
@@ -1,0 +1,47 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@testable import CareKitFHIR
+import XCTest
+
+class FHIRResourceDataTests: XCTestCase {
+
+    func testInitializer() {
+        let rawData = "abc".data(using: .utf8)!
+        let resource = OCKFHIRResourceData<DSTU2, Turtle>(data: rawData)
+        XCTAssert(resource.data == rawData)
+    }
+
+    func testDateConversion() {
+        let now = Date().truncatingNanoSeconds
+        let converted = now.dstu2FHIRDateTime.foundationDate
+        XCTAssert(now == converted)
+    }
+}

--- a/CareKitFHIR/CareKitFHIRTests/Unit Tests/R4PatientConverterTests.swift
+++ b/CareKitFHIR/CareKitFHIRTests/Unit Tests/R4PatientConverterTests.swift
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2019, Apple Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder(s) nor the names of any contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission. No license is granted to the trademarks of
+the copyright holders even if such marks are included in this software.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+@testable import CareKitFHIR
+import CareKitStore
+import ModelsR4
+import XCTest
+
+class R4PatientConverterTests: XCTestCase {
+
+    // MARK: Convert FHIR Patient to OCKPatient
+
+    func testConvertFHIRPatientFailsWhenMissingID() {
+        let patient = Patient()
+        let converter = OCKR4PatientCoder()
+        let expectedError: OCKFHIRCodingError = .missingRequiredField("id")
+        XCTAssertThrowsError(try converter.convert(resource: patient), matching: expectedError)
+    }
+
+    func testConvertFHIRPatientSucceedsForDefaultIDGetter() throws {
+        let patient = Patient()
+        patient.name = [HumanName()]
+        patient.id = "abc"
+
+        let converter = OCKR4PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.id == "abc")
+    }
+
+    func testConvertFHIRPatientSetsPatientSourceToFHIR() throws {
+        let patient = Patient()
+        patient.name = [HumanName()]
+        patient.id = "abc"
+
+        let converter = OCKR4PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.source == "FHIR")
+    }
+
+    func testConvertFHIRPatientSucceedsForCustomIDGetter() throws {
+        let identifier = Identifier()
+        identifier.value = "abc"
+
+        let patient = Patient()
+        patient.identifier = [identifier]
+        patient.name = [HumanName()]
+
+        var converter = OCKR4PatientCoder()
+        converter.getCareKitID = { $0.identifier!.first!.value!.value!.string }
+
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.id == "abc")
+    }
+
+    func testConvertFHIRPatientSucceedsForDefaultNameGetter() throws {
+        let patient = Patient()
+        patient.id = "abc"
+        patient.name = [HumanName(family: "Bill", given: ["Bob"])]
+
+        let converter = OCKR4PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.name.familyName == "Bill")
+        XCTAssert(converted.name.givenName == "Bob")
+    }
+
+    func testConvertFHIRPatientSucceedsForDefaultSexGetter() throws {
+        let patient = Patient()
+        patient.id = "abc"
+        patient.name = [HumanName()]
+        patient.gender = FHIRPrimitive(AdministrativeGender.other)
+
+        let converter = OCKR4PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.sex == .other("other"))
+    }
+
+    func testConvertFHIRPatientSucceedsForDefaultBirthdayGetter() throws {
+        let components = Calendar.current.dateComponents(Set([.year, .month, .day]), from: Date())
+        let birthday = Calendar.current.date(from: components)!
+
+        let patient = Patient()
+        patient.id = "abc"
+        patient.name = [HumanName()]
+        patient.birthDate = FHIRPrimitive(FHIRDate(
+            year: Calendar.current.component(.year, from: birthday),
+            month: UInt8(Calendar.current.component(.month, from: birthday)),
+            day: UInt8(Calendar.current.component(.day, from: birthday))
+        ))
+
+        let converter = OCKR4PatientCoder()
+        let converted = try converter.convert(resource: patient)
+        XCTAssert(converted.birthday == birthday)
+    }
+
+    // MARK: Convert OCKPatient to FHIR Patient
+
+    func testConvertCareKitPatientSucceedsForDefaultIDSetter() throws {
+        var name = PersonNameComponents()
+        name.familyName = "A"
+        name.givenName = "B"
+        name.namePrefix = "C"
+        name.nameSuffix = "D"
+
+        let careKitPatient = OCKPatient(id: "123", name: name)
+        let converter = OCKR4PatientCoder()
+        let fhirPatient = try converter.convert(entity: careKitPatient)
+
+        XCTAssert(fhirPatient.name?.first?.family == "A")
+        XCTAssert(fhirPatient.name?.first?.given == ["B"])
+        XCTAssert(fhirPatient.name?.first?.prefix == ["C"])
+        XCTAssert(fhirPatient.name?.first?.suffix == ["D"])
+    }
+}

--- a/CareKitFHIR/CareKitFHIRTests/Utils.swift
+++ b/CareKitFHIR/CareKitFHIRTests/Utils.swift
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2019, Apple Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder(s) nor the names of any contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission. No license is granted to the trademarks of
+the copyright holders even if such marks are included in this software.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import XCTest
+
+func XCTAssertThrowsError<T, E: Error>(_ expression: @autoclosure () throws -> T, matching expectedError: E,
+                                       file: StaticString = #file, line: UInt = #line) where E: Equatable {
+    do {
+        _ = try expression()
+        XCTFail("Expected to throw error, but did not!", file: file, line: line)
+    } catch {
+        guard let error = error as? E else {
+            XCTFail("An error was thrown, but it was not the right type!", file: file, line: line)
+            return
+        }
+
+        XCTAssertEqual(expectedError, error, file: file, line: line)
+    }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "FHIRModels",
+        "repositoryURL": "git@github.com:apple/FHIRModels.git",
+        "state": {
+          "branch": null,
+          "revision": "31dc40c01ef43b89191be5d9719e1ddedb2c91b5",
+          "version": "0.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,13 @@ let package = Package(
         .library(
             name: "CareKitStore",
             targets: ["CareKitStore"]),
+
+        .library(
+            name: "CareKitFHIR",
+            targets: ["CareKitFHIR"])
+    ],
+    dependencies: [
+        .package(url: "git@github.com:apple/FHIRModels.git", from: "0.1.0")
     ],
     targets: [
         .target(
@@ -31,10 +38,20 @@ let package = Package(
             name: "CareKitStore",
             path: "CareKitStore/CareKitStore"),
 
+        .target(
+            name: "CareKitFHIR",
+            dependencies: ["CareKitStore", "ModelsR4", "ModelsDSTU2"],
+            path: "CareKitFHIR/CareKitFHIR"),
+
         .testTarget(
             name: "CareKitStoreTests",
             dependencies: ["CareKitStore"],
             path: "CareKitStore/CareKitStoreTests"),
+
+        .testTarget(
+            name: "CareKitFHIRTests",
+            dependencies: ["CareKitFHIR"],
+            path: "CareKitFHIR/CareKitFHIRTests"),
 
         .testTarget(
             name: "CareKitTests",


### PR DESCRIPTION
This PR adds a new package to the CareKit workspace, `CareKitFHIR`. 

CareKitFHIR provides a suite of coders than translate back and forth between native CareKit entities and FHIR data.