### PR TITLE
Update travis to xcode12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: swift 
 osx_image: xcode12
+before_script:
+  - for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
 script:
-  set -o pipefail && xcodebuild -workspace CKWorkspace.xcworkspace -scheme CareKit -resolvePackageDependencies -destination platform\=iOS\ Simulator,OS\=14.0,name\=iPhone\ 11\ Pro\ Max build test | xcpretty
+  - set -o pipefail && xcodebuild -workspace CKWorkspace.xcworkspace -scheme CareKit -resolvePackageDependencies -destination platform\=iOS\ Simulator,OS\=14.0,name\=iPhone\ 11\ Pro\ Max build test | xcpretty
 
 #xcode_workspace: CKWorkspace.xcworkspace
 #xcode_scheme: CareKit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: swift 
 osx_image: xcode12
 xcode_workspace: CKWorkspace.xcworkspace
-matrix:
+jobs:
   include:
     - xcode_scheme: CareKit iOS
       xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: swift 
 osx_image: xcode12
-#before_script:
-  #- for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
-#script:
-#  - set -o pipefail && xcodebuild -workspace CKWorkspace.xcworkspace -scheme CareKit -resolvePackageDependencies -destination platform\=iOS\ Simulator,OS\=14.0,name\=iPhone\ 11\ Pro\ Max build test | xcpretty
 xcode_workspace: CKWorkspace.xcworkspace
-xcode_scheme: CareKit
+xcode_scheme: CareKit iOS
 xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,14 @@ matrix:
   include:
     - xcode_scheme: CareKit iOS
       xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
-    - xcode_scheme: CareKit Watch
-      xcode_destination: platform=watchOS Simulator,OS=7.0,name=Apple Watch Series 5 - 44mm
     - xcode_scheme: CareKitFHIR
       xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
     - xcode_scheme: CareKitStore iOS
       xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
-    - xcode_scheme: CareKitStore Watch
-      xcode_destination: platform=watchOS Simulator,OS=7.0,name=Apple Watch Series 5 - 44mm
     - xcode_scheme: CareKitUI iOS
       xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
-    - xcode_scheme: CareKitUI Watch
-      xcode_destination: platform=watchOS Simulator,OS=7.0,name=Apple Watch Series 5 - 44mm
     - xcode_scheme: OCKCatalog
       xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
     - xcode_scheme: OCKSample
       xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
-    - xcode_scheme: OCKWatchCatalog
-      xcode_destination: platform=watchOS Simulator,OS=7.0,name=Apple Watch Series 5 - 44mm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,26 @@
 language: swift 
 osx_image: xcode12
 xcode_workspace: CKWorkspace.xcworkspace
-xcode_scheme: CareKit iOS
-xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
+matrix:
+  include:
+    - xcode_scheme: CareKit iOS
+      xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
+    - xcode_scheme: CareKit Watch
+      xcode_destination: platform=watchOS Simulator,OS=7.0,name=Apple Watch Series 5 - 44mm
+    - xcode_scheme: CareKitFHIR
+      xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
+    - xcode_scheme: CareKitStore iOS
+      xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
+    - xcode_scheme: CareKitStore Watch
+      xcode_destination: platform=watchOS Simulator,OS=7.0,name=Apple Watch Series 5 - 44mm
+    - xcode_scheme: CareKitUI iOS
+      xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
+    - xcode_scheme: CareKitUI Watch
+      xcode_destination: platform=watchOS Simulator,OS=7.0,name=Apple Watch Series 5 - 44mm
+    - xcode_scheme: OCKCatalog
+      xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
+    - xcode_scheme: OCKSample
+      xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
+    - xcode_scheme: OCKWatchCatalog
+      xcode_destination: platform=watchOS Simulator,OS=7.0,name=Apple Watch Series 5 - 44mm
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: swift 
 osx_image: xcode12
-before_script:
-  - ssh-keyscan github.com >> ~/.ssh/known_hosts
+#before_script:
   #- for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
 #script:
 #  - set -o pipefail && xcodebuild -workspace CKWorkspace.xcworkspace -scheme CareKit -resolvePackageDependencies -destination platform\=iOS\ Simulator,OS\=14.0,name\=iPhone\ 11\ Pro\ Max build test | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift 
-osx_image: xcode11.3
+osx_image: xcode12
 xcode_workspace: CKWorkspace.xcworkspace
 xcode_scheme: CareKit
-xcode_destination: platform=iOS Simulator,OS=13.3,name=iPhone 11 Pro Max
+xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: swift 
 osx_image: xcode12
 before_script:
-  - rm ~/.ssh/id_rsa
-  - for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
+  - ssh-keyscan github.com >> ~/.ssh/known_hosts
+  #- for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
 #script:
 #  - set -o pipefail && xcodebuild -workspace CKWorkspace.xcworkspace -scheme CareKit -resolvePackageDependencies -destination platform\=iOS\ Simulator,OS\=14.0,name\=iPhone\ 11\ Pro\ Max build test | xcpretty
 xcode_workspace: CKWorkspace.xcworkspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: swift 
 osx_image: xcode12
-xcode_workspace: CKWorkspace.xcworkspace
-xcode_scheme: CareKit
-xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
+script:
+  set -o pipefail && xcodebuild -workspace CKWorkspace.xcworkspace -scheme CareKit -resolvePackageDependencies -destination platform\=iOS\ Simulator,OS\=14.0,name\=iPhone\ 11\ Pro\ Max build test | xcpretty
+
+#xcode_workspace: CKWorkspace.xcworkspace
+#xcode_scheme: CareKit
+#xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: swift 
 osx_image: xcode12
 before_script:
+  - rm ~/.ssh/id_rsa
   - for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
-script:
-  - set -o pipefail && xcodebuild -workspace CKWorkspace.xcworkspace -scheme CareKit -resolvePackageDependencies -destination platform\=iOS\ Simulator,OS\=14.0,name\=iPhone\ 11\ Pro\ Max build test | xcpretty
-
-#xcode_workspace: CKWorkspace.xcworkspace
-#xcode_scheme: CareKit
-#xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max
+#script:
+#  - set -o pipefail && xcodebuild -workspace CKWorkspace.xcworkspace -scheme CareKit -resolvePackageDependencies -destination platform\=iOS\ Simulator,OS\=14.0,name\=iPhone\ 11\ Pro\ Max build test | xcpretty
+xcode_workspace: CKWorkspace.xcworkspace
+xcode_scheme: CareKit
+xcode_destination: platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro Max

--- a/CKWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CKWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "FHIRModels",
-        "repositoryURL": "git@github.com:apple/FHIRModels.git",
+        "repositoryURL": "https://github.com/apple/FHIRModels.git",
         "state": {
           "branch": null,
           "revision": "31dc40c01ef43b89191be5d9719e1ddedb2c91b5",

--- a/CareKit/CareKitTests/Task/TestTaskController.swift
+++ b/CareKit/CareKitTests/Task/TestTaskController.swift
@@ -278,7 +278,7 @@ class TestTaskController: XCTestCase {
         let expectations = try setupDeletedTaskNotificationTest(controller: controller)
 
         controller.fetchAndObserveEvents(forTaskIDs: ["doxylamine"], eventQuery: .init(for: Date()))
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 3)
     }
 
     func testFetchWithTaskQueryReceivesDeletedTaskNotifications() throws {

--- a/CareKit/CareKitTests/Task/TestTaskController.swift
+++ b/CareKit/CareKitTests/Task/TestTaskController.swift
@@ -278,7 +278,7 @@ class TestTaskController: XCTestCase {
         let expectations = try setupDeletedTaskNotificationTest(controller: controller)
 
         controller.fetchAndObserveEvents(forTaskIDs: ["doxylamine"], eventQuery: .init(for: Date()))
-        wait(for: expectations, timeout: 3)
+        wait(for: expectations, timeout: 2)
     }
 
     func testFetchWithTaskQueryReceivesDeletedTaskNotifications() throws {

--- a/CareKitFHIR/CareKitFHIR.xcodeproj/project.pbxproj
+++ b/CareKitFHIR/CareKitFHIR.xcodeproj/project.pbxproj
@@ -22,12 +22,13 @@
 		03AFA931233E69830091DD45 /* OCKR4PatientCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFA92E233E69830091DD45 /* OCKR4PatientCoder.swift */; };
 		03AFA93D233E74610091DD45 /* FHIRResourceDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFA93C233E74610091DD45 /* FHIRResourceDataTests.swift */; };
 		03AFA943233E80C40091DD45 /* DSTU2PatientConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AFA942233E80C40091DD45 /* DSTU2PatientConverterTests.swift */; };
-		03C75C5724A50248009F1896 /* ModelsR4 in Frameworks */ = {isa = PBXBuildFile; productRef = 03C75C5624A50248009F1896 /* ModelsR4 */; };
-		03C75C5924A50248009F1896 /* ModelsDSTU2 in Frameworks */ = {isa = PBXBuildFile; productRef = 03C75C5824A50248009F1896 /* ModelsDSTU2 */; };
 		03C85E6E233D71EC002C5901 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C85E6D233D71EC002C5901 /* Utils.swift */; };
 		03C85E73233D7215002C5901 /* CareKitFHIRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C85E72233D7215002C5901 /* CareKitFHIRTests.swift */; };
 		03C85E76233D721F002C5901 /* R4PatientConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C85E75233D721F002C5901 /* R4PatientConverterTests.swift */; };
 		03E5929123736D0D00B6E9DE /* DSTU2TaskConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E5929023736D0D00B6E9DE /* DSTU2TaskConverterTests.swift */; };
+		915266B424A7C95E009CB68A /* ModelsDSTU2 in Frameworks */ = {isa = PBXBuildFile; productRef = 915266B324A7C95E009CB68A /* ModelsDSTU2 */; };
+		915266B624A7C95E009CB68A /* ModelsR4 in Frameworks */ = {isa = PBXBuildFile; productRef = 915266B524A7C95E009CB68A /* ModelsR4 */; };
+		915266B824A7C95E009CB68A /* ModelsBuild in Frameworks */ = {isa = PBXBuildFile; productRef = 915266B724A7C95E009CB68A /* ModelsBuild */; };
 		E746B33A2378F55600278A95 /* OCKDSTU2ScheduleCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746B3392378F55600278A95 /* OCKDSTU2ScheduleCoder.swift */; };
 		E746B33E2378F6D500278A95 /* OCKDSTU2MedicationOrderCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746B33D2378F6D500278A95 /* OCKDSTU2MedicationOrderCoder.swift */; };
 		E746B3422378F95100278A95 /* DSTU2MedicationOrderConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746B3412378F95100278A95 /* DSTU2MedicationOrderConverterTests.swift */; };
@@ -81,9 +82,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				03C75C5924A50248009F1896 /* ModelsDSTU2 in Frameworks */,
-				03C75C5724A50248009F1896 /* ModelsR4 in Frameworks */,
 				0364BB6423C421E30047F952 /* CareKitStore.framework in Frameworks */,
+				915266B624A7C95E009CB68A /* ModelsR4 in Frameworks */,
+				915266B424A7C95E009CB68A /* ModelsDSTU2 in Frameworks */,
+				915266B824A7C95E009CB68A /* ModelsBuild in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -224,8 +226,9 @@
 			);
 			name = CareKitFHIR;
 			packageProductDependencies = (
-				03C75C5624A50248009F1896 /* ModelsR4 */,
-				03C75C5824A50248009F1896 /* ModelsDSTU2 */,
+				915266B324A7C95E009CB68A /* ModelsDSTU2 */,
+				915266B524A7C95E009CB68A /* ModelsR4 */,
+				915266B724A7C95E009CB68A /* ModelsBuild */,
 			);
 			productName = CareKitFHIR;
 			productReference = 0396EF36233D187800C28FC0 /* CareKitFHIR.framework */;
@@ -279,7 +282,7 @@
 			);
 			mainGroup = 0396EF2C233D187800C28FC0;
 			packageReferences = (
-				03C75C5524A50248009F1896 /* XCRemoteSwiftPackageReference "FHIRModels" */,
+				915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */,
 			);
 			productRefGroup = 0396EF37233D187800C28FC0 /* Products */;
 			projectDirPath = "";
@@ -609,9 +612,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		03C75C5524A50248009F1896 /* XCRemoteSwiftPackageReference "FHIRModels" */ = {
+		915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "git@github.com:apple/FHIRModels.git";
+			repositoryURL = "https://github.com/apple/FHIRModels.git";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.1.0;
@@ -620,15 +623,20 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		03C75C5624A50248009F1896 /* ModelsR4 */ = {
+		915266B324A7C95E009CB68A /* ModelsDSTU2 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 03C75C5524A50248009F1896 /* XCRemoteSwiftPackageReference "FHIRModels" */;
+			package = 915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */;
+			productName = ModelsDSTU2;
+		};
+		915266B524A7C95E009CB68A /* ModelsR4 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */;
 			productName = ModelsR4;
 		};
-		03C75C5824A50248009F1896 /* ModelsDSTU2 */ = {
+		915266B724A7C95E009CB68A /* ModelsBuild */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 03C75C5524A50248009F1896 /* XCRemoteSwiftPackageReference "FHIRModels" */;
-			productName = ModelsDSTU2;
+			package = 915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */;
+			productName = ModelsBuild;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/CareKitFHIR/CareKitFHIR.xcodeproj/project.pbxproj
+++ b/CareKitFHIR/CareKitFHIR.xcodeproj/project.pbxproj
@@ -26,9 +26,8 @@
 		03C85E73233D7215002C5901 /* CareKitFHIRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C85E72233D7215002C5901 /* CareKitFHIRTests.swift */; };
 		03C85E76233D721F002C5901 /* R4PatientConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C85E75233D721F002C5901 /* R4PatientConverterTests.swift */; };
 		03E5929123736D0D00B6E9DE /* DSTU2TaskConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E5929023736D0D00B6E9DE /* DSTU2TaskConverterTests.swift */; };
-		915266B424A7C95E009CB68A /* ModelsDSTU2 in Frameworks */ = {isa = PBXBuildFile; productRef = 915266B324A7C95E009CB68A /* ModelsDSTU2 */; };
-		915266B624A7C95E009CB68A /* ModelsR4 in Frameworks */ = {isa = PBXBuildFile; productRef = 915266B524A7C95E009CB68A /* ModelsR4 */; };
-		915266B824A7C95E009CB68A /* ModelsBuild in Frameworks */ = {isa = PBXBuildFile; productRef = 915266B724A7C95E009CB68A /* ModelsBuild */; };
+		911F09AF24AA4D2100764C86 /* ModelsR4 in Frameworks */ = {isa = PBXBuildFile; productRef = 911F09AE24AA4D2100764C86 /* ModelsR4 */; };
+		911F09B124AA4D2100764C86 /* ModelsDSTU2 in Frameworks */ = {isa = PBXBuildFile; productRef = 911F09B024AA4D2100764C86 /* ModelsDSTU2 */; };
 		E746B33A2378F55600278A95 /* OCKDSTU2ScheduleCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746B3392378F55600278A95 /* OCKDSTU2ScheduleCoder.swift */; };
 		E746B33E2378F6D500278A95 /* OCKDSTU2MedicationOrderCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746B33D2378F6D500278A95 /* OCKDSTU2MedicationOrderCoder.swift */; };
 		E746B3422378F95100278A95 /* DSTU2MedicationOrderConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746B3412378F95100278A95 /* DSTU2MedicationOrderConverterTests.swift */; };
@@ -82,10 +81,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				911F09B124AA4D2100764C86 /* ModelsDSTU2 in Frameworks */,
+				911F09AF24AA4D2100764C86 /* ModelsR4 in Frameworks */,
 				0364BB6423C421E30047F952 /* CareKitStore.framework in Frameworks */,
-				915266B624A7C95E009CB68A /* ModelsR4 in Frameworks */,
-				915266B424A7C95E009CB68A /* ModelsDSTU2 in Frameworks */,
-				915266B824A7C95E009CB68A /* ModelsBuild in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -226,9 +224,8 @@
 			);
 			name = CareKitFHIR;
 			packageProductDependencies = (
-				915266B324A7C95E009CB68A /* ModelsDSTU2 */,
-				915266B524A7C95E009CB68A /* ModelsR4 */,
-				915266B724A7C95E009CB68A /* ModelsBuild */,
+				911F09AE24AA4D2100764C86 /* ModelsR4 */,
+				911F09B024AA4D2100764C86 /* ModelsDSTU2 */,
 			);
 			productName = CareKitFHIR;
 			productReference = 0396EF36233D187800C28FC0 /* CareKitFHIR.framework */;
@@ -282,7 +279,7 @@
 			);
 			mainGroup = 0396EF2C233D187800C28FC0;
 			packageReferences = (
-				915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */,
+				911F09AD24AA4D2100764C86 /* XCRemoteSwiftPackageReference "FHIRModels" */,
 			);
 			productRefGroup = 0396EF37233D187800C28FC0 /* Products */;
 			projectDirPath = "";
@@ -612,7 +609,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */ = {
+		911F09AD24AA4D2100764C86 /* XCRemoteSwiftPackageReference "FHIRModels" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/FHIRModels.git";
 			requirement = {
@@ -623,20 +620,15 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		915266B324A7C95E009CB68A /* ModelsDSTU2 */ = {
+		911F09AE24AA4D2100764C86 /* ModelsR4 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */;
-			productName = ModelsDSTU2;
-		};
-		915266B524A7C95E009CB68A /* ModelsR4 */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */;
+			package = 911F09AD24AA4D2100764C86 /* XCRemoteSwiftPackageReference "FHIRModels" */;
 			productName = ModelsR4;
 		};
-		915266B724A7C95E009CB68A /* ModelsBuild */ = {
+		911F09B024AA4D2100764C86 /* ModelsDSTU2 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 915266B224A7C95E009CB68A /* XCRemoteSwiftPackageReference "FHIRModels" */;
-			productName = ModelsBuild;
+			package = 911F09AD24AA4D2100764C86 /* XCRemoteSwiftPackageReference "FHIRModels" */;
+			productName = ModelsDSTU2;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/OCKCatalog/OCKCatalog.xcodeproj/xcshareddata/xcschemes/OCKWatchCatalog.xcscheme
+++ b/OCKCatalog/OCKCatalog.xcodeproj/xcshareddata/xcschemes/OCKWatchCatalog.xcscheme
@@ -54,8 +54,10 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/OCKCatalog">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "515327EA2447951800EEB862"
@@ -63,7 +65,7 @@
             BlueprintName = "OCKWatchCatalog"
             ReferencedContainer = "container:OCKCatalog.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -71,8 +73,10 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/OCKCatalog">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "515327EA2447951800EEB862"
@@ -80,7 +84,16 @@
             BlueprintName = "OCKWatchCatalog"
             ReferencedContainer = "container:OCKCatalog.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "515327EA2447951800EEB862"
+            BuildableName = "OCKWatchCatalog.app"
+            BlueprintName = "OCKWatchCatalog"
+            ReferencedContainer = "container:OCKCatalog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/OCKCatalog/OCKCatalog.xcodeproj/xcshareddata/xcschemes/OCKWatchCatalog.xcscheme
+++ b/OCKCatalog/OCKCatalog.xcodeproj/xcshareddata/xcschemes/OCKWatchCatalog.xcscheme
@@ -54,10 +54,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/OCKCatalog">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "515327EA2447951800EEB862"
@@ -65,7 +63,7 @@
             BlueprintName = "OCKWatchCatalog"
             ReferencedContainer = "container:OCKCatalog.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,10 +71,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/OCKCatalog">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "515327EA2447951800EEB862"
@@ -84,16 +80,7 @@
             BlueprintName = "OCKWatchCatalog"
             ReferencedContainer = "container:OCKCatalog.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "515327EA2447951800EEB862"
-            BuildableName = "OCKWatchCatalog.app"
-            BlueprintName = "OCKWatchCatalog"
-            ReferencedContainer = "container:OCKCatalog.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "FHIRModels",
-        "repositoryURL": "git@github.com:apple/FHIRModels.git",
+        "repositoryURL": "https://github.com/apple/FHIRModels.git",
         "state": {
           "branch": null,
           "revision": "31dc40c01ef43b89191be5d9719e1ddedb2c91b5",

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             targets: ["CareKitFHIR"])
     ],
     dependencies: [
-        .package(url: "git@github.com:apple/FHIRModels.git", from: "0.1.0")
+        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.1.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
It looks like there will be random timeouts from time-to-time due to the resources on travis and probably the time of day. If any of the timeouts become consistent, you can probably increase the wait time on the respective test.

I bumped  `testFetchWithTaskIDsReceivesDeletedTaskNotifications` by a second because it failed once, but I don't think this is a consistent failure. I did it to re-trigger the test.

It should run 5/6 of these concurrently, it's possible the travis settings for the repo is limiting the concurrent builds to 2 (or travis limits the builds for Xcode 12). Since there are more schemes in the updated version, setting the "build latest commit" setting can help canceling builds with updates to PRs