### PR TITLE
Fixed the issue with UILabel's autosizing in high levels of text sizes.

### DIFF
--- a/CareKitUI/CareKitUI/Common/Labels/OCKLabel.swift
+++ b/CareKitUI/CareKitUI/Common/Labels/OCKLabel.swift
@@ -120,4 +120,10 @@ open class OCKLabel: UILabel, OCKStylable {
     }
 
     open func styleDidChange() {}
+
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+
+        preferredMaxLayoutWidth = frame.size.width
+    }
 }


### PR DESCRIPTION
The issue:

1) Go to settings -> accessibility -> display & text size -> larger text on -> set the size to the second largest or third largest.
2) Run CareKit Catalog target
3) Select Task -> Simple

You'll see a broken layout. This PR fixes this bug.

EDIT: added screenshots.

BEFORE:
<img width="584" alt="Screenshot 2020-06-26 15 02 43" src="https://user-images.githubusercontent.com/1864402/86472253-2afc7980-bd3f-11ea-8c06-a7e7b9e55ffe.png">

AFTER:
<img width="584" alt="Screenshot 2020-07-03 15 08 56" src="https://user-images.githubusercontent.com/1864402/86472249-29cb4c80-bd3f-11ea-9171-63acffa9fb53.png">
