### PR TITLE
Fix title label wrapping in OCKSimpleTaskView

### DIFF
--- a/CareKitUI/CareKitUI/iOS/Contact/OCKAddressButton.swift
+++ b/CareKitUI/CareKitUI/iOS/Contact/OCKAddressButton.swift
@@ -66,6 +66,7 @@ open class OCKAddressButton: OCKAnimatedButton<OCKStackView> {
     public let titleLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .footnote, weight: .semibold)
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         label.text = loc("ADDRESS")
         return label
     }()
@@ -74,6 +75,7 @@ open class OCKAddressButton: OCKAnimatedButton<OCKStackView> {
     public let detailLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .footnote, weight: .regular)
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
 

--- a/CareKitUI/CareKitUI/iOS/Contact/OCKDetailedContactView.swift
+++ b/CareKitUI/CareKitUI/iOS/Contact/OCKDetailedContactView.swift
@@ -83,6 +83,7 @@ open class OCKDetailedContactView: OCKView, OCKContactDisplayable {
     public let instructionsLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .subheadline, weight: .medium)
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
 

--- a/CareKitUI/CareKitUI/iOS/Controls/OCKLabeledButton.swift
+++ b/CareKitUI/CareKitUI/iOS/Controls/OCKLabeledButton.swift
@@ -48,6 +48,7 @@ open class OCKLabeledButton: OCKAnimatedButton<OCKLabel> {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
 

--- a/CareKitUI/CareKitUI/iOS/Task/OCKButtonLogTaskView.swift
+++ b/CareKitUI/CareKitUI/iOS/Task/OCKButtonLogTaskView.swift
@@ -88,6 +88,7 @@ open class OCKButtonLogTaskView: OCKLogTaskView, UICollectionViewDelegate, UICol
     public let instructionsLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .subheadline, weight: .medium)
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
 

--- a/CareKitUI/CareKitUI/iOS/Task/OCKChecklistTaskView.swift
+++ b/CareKitUI/CareKitUI/iOS/Task/OCKChecklistTaskView.swift
@@ -104,6 +104,7 @@ open class OCKChecklistTaskView: OCKView, OCKTaskDisplayable {
     public let instructionsLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .caption1, weight: .regular)
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
 

--- a/CareKitUI/CareKitUI/iOS/Task/OCKGridTaskView.swift
+++ b/CareKitUI/CareKitUI/iOS/Task/OCKGridTaskView.swift
@@ -100,6 +100,7 @@ open class OCKGridTaskView: OCKView, OCKTaskDisplayable, UICollectionViewDelegat
     public let instructionsLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .caption1, weight: .regular)
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
 

--- a/CareKitUI/CareKitUI/iOS/Task/OCKInstructionsTaskView.swift
+++ b/CareKitUI/CareKitUI/iOS/Task/OCKInstructionsTaskView.swift
@@ -87,6 +87,7 @@ open class OCKInstructionsTaskView: OCKView, OCKTaskDisplayable {
     public let instructionsLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .subheadline, weight: .medium)
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
 

--- a/CareKitUI/CareKitUI/iOS/Task/OCKSimpleTaskView.swift
+++ b/CareKitUI/CareKitUI/iOS/Task/OCKSimpleTaskView.swift
@@ -101,7 +101,8 @@ open class OCKSimpleTaskView: OCKView, OCKTaskDisplayable {
 
     private func constrainSubviews() {
         [contentView, backgroundButton, horizontalContentStackView].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
-        completionButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        completionButton.setContentHuggingPriority(.required, for: .horizontal)
+        completionButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         NSLayoutConstraint.activate(
             contentView.constraints(equalTo: self) +
             backgroundButton.constraints(equalTo: contentView) +

--- a/CareKitUI/CareKitUI/iOS/Views/OCKHeaderView.swift
+++ b/CareKitUI/CareKitUI/iOS/Views/OCKHeaderView.swift
@@ -79,6 +79,7 @@ open class OCKHeaderView: OCKView {
     public let titleLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .headline, weight: .bold)
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         label.animatesTextChanges = true
         return label
     }()
@@ -87,6 +88,7 @@ open class OCKHeaderView: OCKView {
     public let detailLabel: OCKLabel = {
         let label = OCKLabel(textStyle: .caption1, weight: .medium)
         label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         label.animatesTextChanges = true
         return label
     }()


### PR DESCRIPTION
This fixes an issue that caused long strings in the title label of the OCKSimpleTaskView to get cutoff.