### PR TITLE
Only display current version of contacts

### DIFF
--- a/CareKit/CareKit/iOS/Higher Order/ViewController/OCKContactsListViewController.swift
+++ b/CareKit/CareKit/iOS/Higher Order/ViewController/OCKContactsListViewController.swift
@@ -100,7 +100,7 @@ open class OCKContactsListViewController: OCKListViewController {
     /// `fetchContacts` asynchronously retrieves an array of contacts stored in a `Result`
     /// and makes corresponding `OCKDetailedContactViewController`s.
     private func fetchContacts() {
-        storeManager.store.fetchAnyContacts(query: OCKContactQuery(), callbackQueue: .main) { [weak self] result in
+        storeManager.store.fetchAnyContacts(query: OCKContactQuery(for: Date()), callbackQueue: .main) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .failure(let error):


### PR DESCRIPTION
Currently, the `OCKContactsListViewController` queries and shows all versions (even deleted ones) of contacts. Passing in date makes it only show active versions.

This is related to [version section](https://github.com/carekit-apple/CareKit#store-) of the README.

This bug was discovered by a @ChrisGambrell, an undergraduate in my iOS App Development course.

Fix #523 