### PR TITLE
Fix a bug where all day schedule elements returned the wrong events

### DIFF
--- a/CareKitStore/CareKitStore/Structs/OCKScheduleElement.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKScheduleElement.swift
@@ -191,7 +191,9 @@ public struct OCKScheduleElement: Codable, Equatable {
         }
         let events = dates.enumerated().map { index, date in makeScheduleEvent(on: date, for: index) }
         return events.filter { event in
-            if duration == .allDay { return true }
+            if duration == .allDay {
+                return event.end > start
+            }
             return event.start + duration.seconds >= start
         }
     }

--- a/CareKitStore/CareKitStoreTests/Structs/TestScheduleElement.swift
+++ b/CareKitStore/CareKitStoreTests/Structs/TestScheduleElement.swift
@@ -73,6 +73,16 @@ class TestScheduleElement: XCTestCase {
         XCTAssert(events.isEmpty)
     }
 
+    func testNoEventsBeforeStartDateForAllDayEvents() {
+        let thisMorning = Calendar.current.startOfDay(for: Date())
+        let tonight = Calendar.current.date(byAdding: DateComponents(day: 1, second: -1), to: thisMorning)!
+        let aWeekAgo = Calendar.current.date(byAdding: .weekOfYear, value: -1, to: thisMorning)!
+        let element = OCKScheduleElement(start: aWeekAgo, end: nil, interval: DateComponents(day: 1),
+                                         text: nil, targetValues: [], duration: .allDay)
+        let events = element.events(from: thisMorning, to: tonight)
+        XCTAssert(events.count == 1)
+    }
+
     func testEventOccursExactlyOnStartDate() {
         let justAfter = Calendar.current.date(byAdding: .second, value: 1, to: element.start)!
         let events = element.events(from: date, to: justAfter)


### PR DESCRIPTION
This fixes a bug (#537) that would occur when generating events for an all day schedule element. If generating events for a date range that started several days after the schedule element's start date, and if the schedule element were an all day event, then events would be incorrectly returned starting from the the element's start date up to the query's start date.