### PR TITLE
Update Package.swift file

### DIFF
--- a/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataStoreProtocol.swift
+++ b/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataStoreProtocol.swift
@@ -74,11 +74,11 @@ internal protocol OCKCoreDataStoreProtocol: AnyObject {
 // per app invocation, so we load it here and reuse
 // the shared MoM each time a store is instantiated.
 let sharedManagedObjectModel: NSManagedObjectModel = {
-    #if SWIFT_PACKAGE
-    let bundle = Bundle.module // Use the SPM package's module
-    #else
+    //#if SWIFT_PACKAGE
+    //let bundle = Bundle.module // Use the SPM package's module
+    //#else
     let bundle = Bundle(for: OCKStore.self)
-    #endif
+    //#endif
     let modelUrl = bundle.url(forResource: "CareKitStore", withExtension: "momd")!
     let mom = NSManagedObjectModel(contentsOf: modelUrl)!
     return mom

--- a/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataStoreProtocol.swift
+++ b/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataStoreProtocol.swift
@@ -74,11 +74,11 @@ internal protocol OCKCoreDataStoreProtocol: AnyObject {
 // per app invocation, so we load it here and reuse
 // the shared MoM each time a store is instantiated.
 let sharedManagedObjectModel: NSManagedObjectModel = {
-    //#if SWIFT_PACKAGE
-    //let bundle = Bundle.module // Use the SPM package's module
-    //#else
+    #if SWIFT_PACKAGE
+    let bundle = Bundle.module // Use the SPM package's module
+    #else
     let bundle = Bundle(for: OCKStore.self)
-    //#endif
+    #endif
     let modelUrl = bundle.url(forResource: "CareKitStore", withExtension: "momd")!
     let mom = NSManagedObjectModel(contentsOf: modelUrl)!
     return mom

--- a/Package.swift
+++ b/Package.swift
@@ -29,34 +29,52 @@ let package = Package(
         .target(
             name: "CareKit",
             dependencies: ["CareKitUI", "CareKitStore"],
-            path: "CareKit/CareKit"),
+            path: "CareKit/CareKit",
+            exclude: ["Info.plist"]),
 
         .target(
             name: "CareKitUI",
-            path: "CareKitUI/CareKitUI"),
+            path: "CareKitUI/CareKitUI",
+            exclude: ["Info.plist"]),
 
         .target(
             name: "CareKitStore",
-            path: "CareKitStore/CareKitStore"),
+            path: "CareKitStore/CareKitStore",
+            exclude: ["Info.plist"],
+            resources: [
+                .process("CoreData/Migrations/2.0_to_2.1/2.0_2.1_Mapping.xcmappingmodel")
+            ]),
 
         .target(
             name: "CareKitFHIR",
-            dependencies: ["CareKitStore", .product(name: "ModelsR4", package: "FHIRModels"), .product(name: "ModelsDSTU2", package: "FHIRModels")],
-            path: "CareKitFHIR/CareKitFHIR"),
+            dependencies: [
+                "CareKitStore",
+                .product(name: "ModelsR4", package: "FHIRModels"),
+                .product(name: "ModelsDSTU2", package: "FHIRModels")
+            ],
+            path: "CareKitFHIR/CareKitFHIR",
+            exclude: ["Info.plist"]),
 
         .testTarget(
             name: "CareKitStoreTests",
             dependencies: ["CareKitStore"],
-            path: "CareKitStore/CareKitStoreTests"),
+            path: "CareKitStore/CareKitStoreTests",
+            exclude: ["Info.plist", "CareKitStore.xctestplan"],
+            resources: [
+                .process("CoreDataSchema/Migrations")
+            ]),
 
         .testTarget(
             name: "CareKitFHIRTests",
             dependencies: ["CareKitFHIR"],
-            path: "CareKitFHIR/CareKitFHIRTests"),
+            path: "CareKitFHIR/CareKitFHIRTests",
+            exclude: ["Info.plist", "CareKitFHIR.xctestplan"]),
 
         .testTarget(
             name: "CareKitTests",
             dependencies: ["CareKit"],
-            path: "CareKit/CareKitTests")
+            path: "CareKit/CareKitTests",
+            exclude: ["Info.plist"])
     ]
 )
+

--- a/Package.swift
+++ b/Package.swift
@@ -37,8 +37,7 @@ let package = Package(
 
         .target(
             name: "CareKitStore",
-            path: "CareKitStore/CareKitStore",
-            resources: [.process("CoreData/CareKitStore.xcdatamodel")]),
+            path: "CareKitStore/CareKitStore"),
 
         .target(
             name: "CareKitFHIR",

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,9 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
     name: "CareKit",
+    defaultLocalization: "en",
     platforms: [.iOS(.v13), .watchOS(.v6)],
     products: [
         .library(
@@ -36,11 +37,12 @@ let package = Package(
 
         .target(
             name: "CareKitStore",
-            path: "CareKitStore/CareKitStore"),
+            path: "CareKitStore/CareKitStore",
+            resources: [.copy("CoreData/CareKitStore.xcdatamodel")]),
 
         .target(
             name: "CareKitFHIR",
-            dependencies: ["CareKitStore", "ModelsR4", "ModelsDSTU2"],
+            dependencies: ["CareKitStore", .product(name: "ModelsR4", package: "FHIRModels"), .product(name: "ModelsDSTU2", package: "FHIRModels")],
             path: "CareKitFHIR/CareKitFHIR"),
 
         .testTarget(


### PR DESCRIPTION
This makes it work when importing using a Package.swift file below:

```swift
// swift-tools-version:5.3
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "ParseCareKit",
    platforms: [.iOS(.v13), .watchOS(.v6), .macOS(.v10_13), .tvOS(.v11)],
    products: [
        .library(
            name: "ParseCareKit",
            targets: ["ParseCareKit"])
    ],
    dependencies: [
        // Dependencies declare other packages that this package depends on.
        .package(name: "CareKit", url: "https://github.com/cbaker6/CareKit.git",
                 .revision("d4fca9a3a61d8d3fb693329254a138613dbb9837")),
        .package(name: "ParseSwift", url: "https://github.com/parse-community/Parse-Swift", from: "1.1.2")
    ],
    targets: [
        .target(
            name: "ParseCareKit",
            dependencies: ["ParseSwift", .product(name: "CareKitStore", package: "CareKit")]),
        .testTarget(
            name: "ParseCareKitTests",
            dependencies: ["ParseCareKit"])
    ]
)
```

Still doesn't work through Xcode though, `File > Swift Packages > Add Package Dependency`...

Note there are some warnings from the 5.3 tools for explicitly including other resource files. Fix #542 