### PR TITLE
Add a new task that has a start date of tomorrow

### DIFF
--- a/OCKSample/OCKSample/AppDelegate.swift
+++ b/OCKSample/OCKSample/AppDelegate.swift
@@ -72,6 +72,9 @@ private extension OCKStore {
         let aFewDaysAgo = Calendar.current.date(byAdding: .day, value: -4, to: thisMorning)!
         let beforeBreakfast = Calendar.current.date(byAdding: .hour, value: 8, to: aFewDaysAgo)!
         let afterLunch = Calendar.current.date(byAdding: .hour, value: 14, to: aFewDaysAgo)!
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: thisMorning)!
+        let tomorrowBeforeBreakfast = Calendar.current.date(byAdding: .hour, value: 8, to: tomorrow)!
+        let tomorrowAfterLunch = Calendar.current.date(byAdding: .hour, value: 14, to: tomorrow)!
 
         let schedule = OCKSchedule(composing: [
             OCKScheduleElement(start: beforeBreakfast, end: nil,
@@ -85,6 +88,18 @@ private extension OCKStore {
                                  carePlanUUID: nil, schedule: schedule)
         doxylamine.instructions = "Take 25mg of doxylamine when you experience nausea."
 
+        let asprinSchedule = OCKSchedule(composing: [
+            OCKScheduleElement(start: tomorrowBeforeBreakfast, end: nil,
+                               interval: DateComponents(day: 1)),
+            
+            OCKScheduleElement(start: tomorrowAfterLunch, end: nil,
+                               interval: DateComponents(day: 2))
+        ])
+        
+        var asprin = OCKTask(id: "asprin", title: "Take Baby Asprin",
+                                 carePlanUUID: nil, schedule: asprinSchedule)
+        asprin.instructions = "Take 25mg of baby asprin twice a day."
+        
         let nauseaSchedule = OCKSchedule(composing: [
             OCKScheduleElement(start: beforeBreakfast, end: nil, interval: DateComponents(day: 1),
                                text: "Anytime throughout the day", targetValues: [], duration: .allDay)
@@ -101,7 +116,7 @@ private extension OCKStore {
         kegels.impactsAdherence = true
         kegels.instructions = "Perform kegel exercies"
 
-        addTasks([nausea, doxylamine, kegels], callbackQueue: .main, completion: nil)
+        addTasks([asprin, nausea, doxylamine, kegels], callbackQueue: .main, completion: nil)
 
         var contact1 = OCKContact(id: "jane", givenName: "Jane",
                                   familyName: "Daniels", carePlanUUID: nil)

--- a/OCKSample/OCKSample/CareViewController.swift
+++ b/OCKSample/OCKSample/CareViewController.swift
@@ -64,7 +64,7 @@ class CareViewController: OCKDailyPageViewController {
     override func dailyPageViewController(_ dailyPageViewController: OCKDailyPageViewController,
                                           prepare listViewController: OCKListViewController, for date: Date) {
 
-        let identifiers = ["doxylamine", "nausea", "kegels", "steps", "heartRate"]
+        let identifiers = ["asprin", "doxylamine", "nausea", "kegels", "steps", "heartRate"]
         var query = OCKTaskQuery(for: date)
         query.ids = identifiers
         query.excludesTasksWithNoEvents = true
@@ -73,6 +73,17 @@ class CareViewController: OCKDailyPageViewController {
             switch result {
             case .failure(let error): print("Error: \(error)")
             case .success(let tasks):
+
+                // Create a card for the doxylamine task if there are events for it on this day.
+                if let asprinTask = tasks.first(where: { $0.id == "asprin" }) {
+                    
+                    let asprinCard = OCKChecklistTaskViewController(
+                        task: asprinTask,
+                        eventQuery: .init(for: date),
+                        storeManager: self.storeManager)
+                    
+                    listViewController.appendViewController(asprinCard, animated: false)
+                }
 
                 // Add a non-CareKit view into the list
                 let tipTitle = "Benefits of exercising"


### PR DESCRIPTION
The use case that triggered #545 was the creation of a new task that had a start date in the future. I suspect that this is a relatively common use case but there is not sample code other that demonstrates this. I think it would be helpful for others to have an example. This particular example is rather contrived so feel free to change or reject if there is a better way to demonstrate this use case.