### PR TITLE
Fix OCKStore inits

### DIFF
--- a/CareKitStore/CareKitStore/CoreData/OCKCDHealthKitLinkage.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKCDHealthKitLinkage.swift
@@ -37,13 +37,9 @@ class OCKCDHealthKitLinkage: NSManagedObject {
     @NSManaged var quantityIdentifier: String
     @NSManaged var quantityType: String
     @NSManaged var unitString: String
-
-    init(context: NSManagedObjectContext) {
-        super.init(entity: Self.entity(), insertInto: context)
-    }
     
-    init(link: OCKHealthKitLinkage, context: NSManagedObjectContext) {
-        super.init(entity: Self.entity(), insertInto: context)
+    convenience init(link: OCKHealthKitLinkage, context: NSManagedObjectContext) {
+        self.init(entity: Self.entity(), insertInto: context)
         self.quantityIdentifier = link.quantityIdentifier.rawValue
         self.quantityType = link.quantityType.rawValue
         self.unitString = link.unit.unitString

--- a/CareKitStore/CareKitStore/CoreData/OCKCDHealthKitTask.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKCDHealthKitTask.swift
@@ -36,8 +36,8 @@ class OCKCDHealthKitTask: OCKCDTaskBase {
 
     @NSManaged var healthKitLinkage: OCKCDHealthKitLinkage
 
-    init(task: OCKHealthKitTask, context: NSManagedObjectContext) {
-        super.init(entity: Self.entity(), insertInto: context)
+    convenience init(task: OCKHealthKitTask, context: NSManagedObjectContext) {
+        self.init(entity: Self.entity(), insertInto: context)
         self.copyVersionedValue(value: task, context: context)
         self.title = task.title
         self.instructions = task.instructions

--- a/CareKitStore/CareKitStore/CoreData/OCKCDPostalAddress.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKCDPostalAddress.swift
@@ -41,8 +41,8 @@ class OCKCDPostalAddress: NSManagedObject {
     @NSManaged var country: String
     @NSManaged var isoCountryCode: String
     
-    init(address: OCKPostalAddress, context: NSManagedObjectContext) {
-        super.init(entity: Self.entity(), insertInto: context)
+    convenience init(address: OCKPostalAddress, context: NSManagedObjectContext) {
+        self.init(entity: Self.entity(), insertInto: context)
         street = address.street
         subLocality = address.subLocality
         city = address.city


### PR DESCRIPTION
The inits for `OCKCDHealKitLinkage`, `OCKCDHealthKitTask`, and `OCKCDPostalAddress` are causing app crashes. The other entities seem to be calling self instead of super, so I switched these to self and didn't see crashes anymore.

Fix #554
