### PR TITLE
Only return one version of an outcome when a date interval is given

### DIFF
--- a/CareKitStore/CareKitStore/CoreData/OCKStore+Outcomes.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore+Outcomes.swift
@@ -117,9 +117,29 @@ extension OCKStore {
         var predicate = query.basicPredicate(enforceDateInterval: false)
         
         if let interval = query.dateInterval {
-            let beforePredicate = NSPredicate(format: "%K < %@", #keyPath(OCKCDOutcome.startDate), interval.end as NSDate)
-            let afterPredicate = NSPredicate(format: "%K >= %@", #keyPath(OCKCDOutcome.endDate), interval.start as NSDate)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, beforePredicate, afterPredicate])
+
+            let beforePredicate = NSPredicate(
+                format: "%K < %@",
+                #keyPath(OCKCDOutcome.startDate),
+                interval.end as NSDate
+            )
+
+            let afterPredicate = NSPredicate(
+                format: "%K >= %@",
+                #keyPath(OCKCDOutcome.endDate),
+                interval.start as NSDate
+            )
+
+            let nextPredicate = NSPredicate(
+                format: "%K.@count == 0 OR %K.@min > %@",
+                #keyPath(OCKCDOutcome.next),
+                #keyPath(OCKCDOutcome.next.effectiveDate),
+                interval.end as NSDate
+            )
+            
+            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                predicate, beforePredicate, afterPredicate, nextPredicate
+            ])
         }
 
         if !query.taskIDs.isEmpty {

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -301,4 +301,24 @@ class TestStoreOutcomes: XCTestCase {
         XCTAssertEqual(outcomeA.id, outcomeB.id)
         XCTAssertEqual(outcomeB.id, fetched.first?.id)
     }
+
+    func testFetchingLatestVersion() throws {
+        let schedule = OCKSchedule.mealTimesEachDay(start: Date(), end: nil)
+        let task = OCKTask(id: "A", title: "A", carePlanUUID: nil, schedule: schedule)
+        try store.addTaskAndWait(task)
+
+        let value = OCKOutcomeValue(0)
+        var outcome = OCKOutcome(taskUUID: task.uuid, taskOccurrenceIndex: 0, values: [value])
+        try store.addOutcomeAndWait(outcome)
+
+        for i in 1...5 {
+            outcome.values = [OCKOutcomeValue(i)]
+            outcome = try store.updateOutcomeAndWait(outcome)
+        }
+
+        let query = OCKOutcomeQuery(for: Date())
+        let fetched = try store.fetchOutcomesAndWait(query: query)
+        XCTAssert(fetched.count == 1)
+        XCTAssert(fetched.first?.values.first?.integerValue == 5)
+    }
 }


### PR DESCRIPTION
This PR is a proposed fix for #558.

When a date interval is specified on an outcome query, only one version of the outcome should be returned. Previously we were returning several, in error.