### PR TITLE
Fix localization look up through SPM

### DIFF
--- a/CareKitUI/CareKitUI/Shared/Localization/OCKLocalization.swift
+++ b/CareKitUI/CareKitUI/Shared/Localization/OCKLocalization.swift
@@ -86,11 +86,17 @@ public class OCKLocalization {
 /// - Parameter arguments: The `CVarArg` arguments to use in the formatted string
 /// This is a free function for developer convenience.
 public func loc(_ key: String, _ comment: String = "", arguments: [CVarArg] = []) -> String {
+    let bundle: Bundle?
+    #if SWIFT_PACKAGE
+    bundle = Bundle.module
+    #else
+    bundle = nil
+    #endif
 
    let localizedString = OCKLocalization.localized(
        key,
        tableName: nil,
-       bundle: nil,
+       bundle: bundle,
        value: "",
        comment: comment
    )


### PR DESCRIPTION
Accessing localized resources, if integrated using Swift Package Manager, [requires using Bundle.module](https://developer.apple.com/documentation/swift_packages/localizing_package_resources):

```swift
let localizedString = NSLocalizedString(”a_localized_string”, bundle: Bundle.module, comment: “a comment”).
```

This pull request fixes this issue in CareKitUI.