### PR TITLE
Fix #439

### DIFF
--- a/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
@@ -253,6 +253,7 @@ extension OCKCoreDataTaskStoreProtocol {
         assert(persistableValue.localDatabaseID != nil, "You shouldn't be calling this method with an object that hasn't been saved yet!")
         var value = OCKOutcomeValue(persistableValue.value, units: persistableValue.units)
         value.index = persistableValue.index?.intValue
+        value.kind = persistableValue.kind
         value.copyCommonValues(from: persistableValue)
         return value
     }

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -54,13 +54,13 @@ class TestStoreOutcomes: XCTestCase {
         var value = OCKOutcomeValue(42)
         value.kind = "number"
 
-        var outcome = OCKOutcome(taskUUID: taskUUID, taskOccurrenceIndex: 0, values: [value])
+        var outcome = OCKOutcome(taskID: taskID, taskOccurrenceIndex: 0, values: [value])
         outcome = try store.addOutcomeAndWait(outcome)
 
         let outcomes = try store.fetchOutcomesAndWait()
         XCTAssert(outcomes == [outcome])
         XCTAssert(outcomes.first?.values.first?.kind == "number")
-        XCTAssertNotNil(outcomes.first?.taskUUID)
+        XCTAssertNotNil(outcomes.first?.taskID)
         XCTAssertNotNil(outcomes.first?.schemaVersion)
     }
 

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -51,12 +51,16 @@ class TestStoreOutcomes: XCTestCase {
         let task = try store.addTaskAndWait(OCKTask(id: "A", title: "A", carePlanID: nil, schedule: schedule))
         let taskID = try task.getLocalID()
 
-        let value = OCKOutcomeValue(42)
-        var outcome = OCKOutcome(taskID: taskID, taskOccurrenceIndex: 0, values: [value])
+        var value = OCKOutcomeValue(42)
+        value.kind = "number"
+
+        var outcome = OCKOutcome(taskUUID: taskUUID, taskOccurrenceIndex: 0, values: [value])
         outcome = try store.addOutcomeAndWait(outcome)
+
         let outcomes = try store.fetchOutcomesAndWait()
         XCTAssert(outcomes == [outcome])
-        XCTAssertNotNil(outcomes.first?.localDatabaseID)
+        XCTAssert(outcomes.first?.values.first?.kind == "number")
+        XCTAssertNotNil(outcomes.first?.taskUUID)
         XCTAssertNotNil(outcomes.first?.schemaVersion)
     }
 


### PR DESCRIPTION
OCKOutcomeValue's kind property was being persisted, but was not being populated onto structs when rehydrated from CoreData.