### PR TITLE
Use asset when available in detail card view

### DIFF
--- a/CareKit/CareKit.xcodeproj/project.pbxproj
+++ b/CareKit/CareKit.xcodeproj/project.pbxproj
@@ -148,6 +148,8 @@
 		64EABE022321B1AF00CFBB9F /* OCKSynchronizedStoreManager+Publishers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EABDBF2321B1AF00CFBB9F /* OCKSynchronizedStoreManager+Publishers.swift */; };
 		64EABE0B2321B1AF00CFBB9F /* OCKContactUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EABDCB2321B1AF00CFBB9F /* OCKContactUtility.swift */; };
 		64EABE202321B1AF00CFBB9F /* locversion.plist in Resources */ = {isa = PBXBuildFile; fileRef = 64EABDE72321B1AF00CFBB9F /* locversion.plist */; };
+		70F79B5526434F4A00731C46 /* UIImage+Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F79B5426434F4A00731C46 /* UIImage+Asset.swift */; };
+		70F79B5626434F4A00731C46 /* UIImage+Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F79B5426434F4A00731C46 /* UIImage+Asset.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -287,6 +289,7 @@
 		64EABDCB2321B1AF00CFBB9F /* OCKContactUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OCKContactUtility.swift; sourceTree = "<group>"; };
 		64EABDE52321B1AF00CFBB9F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		64EABDE82321B1AF00CFBB9F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = en; path = en.lproj/locversion.plist; sourceTree = "<group>"; };
+		70F79B5426434F4A00731C46 /* UIImage+Asset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Asset.swift"; sourceTree = "<group>"; };
 		8605A5BA1C4F04EC00DD65FF /* CareKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CareKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -356,6 +359,7 @@
 				5125A214248F2E00009C9643 /* OCKTaskEvents+Extension.swift */,
 				032C86EF2326B68D00D0A0EA /* Calendar+Extensions.swift */,
 				510A6655236147FF00074275 /* OCKAnyEvent+Extension.swift */,
+				70F79B5426434F4A00731C46 /* UIImage+Asset.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1021,6 +1025,7 @@
 				51178E0D23AAAA2A0068BAB1 /* OCKSynchronizationContext.swift in Sources */,
 				515862CA23A9C4D600630AB5 /* InstructionsTaskView.swift in Sources */,
 				51178E0323AA95270068BAB1 /* OCKChecklistTaskController.swift in Sources */,
+				70F79B5626434F4A00731C46 /* UIImage+Asset.swift in Sources */,
 				51355EEA2499852D009DE0A4 /* OCKTaskEvents+Extension.swift in Sources */,
 				51178E0123AA95270068BAB1 /* OCKTaskController.swift in Sources */,
 				51178E1023AAAA2A0068BAB1 /* OCKSynchronizedStoreManager+Publishers.swift in Sources */,
@@ -1101,6 +1106,7 @@
 				513271EF234FA33D0025810A /* OCKTaskViewController.swift in Sources */,
 				51676C0223556B34002C97E7 /* OCKCalendarViewSynchronizerProtocol.swift in Sources */,
 				5112732A235E59AA007B18DF /* OCKButtonLogViewController.swift in Sources */,
+				70F79B5526434F4A00731C46 /* UIImage+Asset.swift in Sources */,
 				64EABDED2321B1AF00CFBB9F /* OCKListView.swift in Sources */,
 				51EF7E4A234FABA800B28C0A /* OCKButtonLogTaskViewSynchronizer.swift in Sources */,
 				64EABDEE2321B1AF00CFBB9F /* OCKHeaderBodyView.swift in Sources */,

--- a/CareKit/CareKit/Shared/Extensions/UIImage+Asset.swift
+++ b/CareKit/CareKit/Shared/Extensions/UIImage+Asset.swift
@@ -1,4 +1,3 @@
-//
 /*
  Copyright (c) 2021, Apple Inc. All rights reserved.
  

--- a/CareKit/CareKit/Shared/Extensions/UIImage+Asset.swift
+++ b/CareKit/CareKit/Shared/Extensions/UIImage+Asset.swift
@@ -1,5 +1,6 @@
+//
 /*
- Copyright (c) 2019, Apple Inc. All rights reserved.
+ Copyright (c) 2021, Apple Inc. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -27,44 +28,18 @@
  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#if canImport(UIKit)
 
-import Contacts
-import MapKit
+import Foundation
 import UIKit
 
-struct OCKContactUtility {
-    private static let addressFormatter: CNPostalAddressFormatter = {
-        let formatter = CNPostalAddressFormatter()
-        formatter.style = .mailingAddress
-        return formatter
-    }()
-
-    private static let nameFormatter: PersonNameComponentsFormatter = {
-        let nameFormatter = PersonNameComponentsFormatter()
-        nameFormatter.style = .long
-        return nameFormatter
-    }()
-
-    static func string(from location: CNPostalAddress?) -> String? {
-        guard let location = location else { return nil }
-        return addressFormatter.string(from: location)
-    }
-
-    static func string(from components: PersonNameComponents?) -> String? {
-        guard let components = components else { return nil }
-        return nameFormatter.string(from: components)
-    }
-/*
-    static func image(from asset: String?) -> UIImage? {
-        guard let asset = asset else { return nil }
-
+extension UIImage {
+    static func asset(_ name: String?) -> UIImage?{
         // We can't be sure if the image they provide is in the assets folder, in the bundle, or in a directory.
+        guard let asset = name else { return nil }
         // We can check all 3 possibilities and then choose whichever is non-nil.
         let symbol = UIImage(systemName: asset)
         let appAssetsImage = UIImage(named: asset)
         let otherUrlImage = UIImage(contentsOfFile: asset)
         return otherUrlImage ?? appAssetsImage ?? symbol
-    }*/
+    }
 }
-#endif

--- a/CareKit/CareKit/Shared/Extensions/UIImage+Asset.swift
+++ b/CareKit/CareKit/Shared/Extensions/UIImage+Asset.swift
@@ -35,11 +35,11 @@ import UIKit
 extension UIImage {
     static func asset(_ name: String?) -> UIImage?{
         // We can't be sure if the image they provide is in the assets folder, in the bundle, or in a directory.
-        guard let asset = name else { return nil }
+        guard let name = name else { return nil }
         // We can check all 3 possibilities and then choose whichever is non-nil.
-        let symbol = UIImage(systemName: asset)
-        let appAssetsImage = UIImage(named: asset)
-        let otherUrlImage = UIImage(contentsOfFile: asset)
+        let symbol = UIImage(systemName: name)
+        let appAssetsImage = UIImage(named: name)
+        let otherUrlImage = UIImage(contentsOfFile: name)
         return otherUrlImage ?? appAssetsImage ?? symbol
     }
 }

--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -444,7 +444,7 @@ open class OCKTaskController: ObservableObject {
         let detailViewController = OCKDetailViewController(showsCloseButton: true)
         detailViewController.detailView.titleLabel.text = task.title
         detailViewController.detailView.bodyLabel.text = task.instructions
-        detailViewController.detailView.imageView.image = task.asset != nil ? UIImage(named: task.asset!) : nil
+        detailViewController.detailView.imageView.image = UIImage(named: task.asset ?? "")
         return detailViewController
     }
 

--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -444,7 +444,13 @@ open class OCKTaskController: ObservableObject {
         let detailViewController = OCKDetailViewController(showsCloseButton: true)
         detailViewController.detailView.titleLabel.text = task.title
         detailViewController.detailView.bodyLabel.text = task.instructions
-        detailViewController.detailView.imageView.image = task.asset.map(UIImage.init(named:)) ?? nil
+        // We can't be sure if the image they provide is in the assets folder, in the bundle, or in a directory.
+        guard let asset = task.asset else { return detailViewController }
+        // We can check all 3 possibilities and then choose whichever is non-nil.
+        let symbol = UIImage(systemName: asset)
+        let appAssetsImage = UIImage(named: asset)
+        let otherUrlImage = UIImage(contentsOfFile: asset)
+        detailViewController.detailView.imageView.image = otherUrlImage ?? appAssetsImage ?? symbol
         return detailViewController
     }
 

--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -444,6 +444,13 @@ open class OCKTaskController: ObservableObject {
         let detailViewController = OCKDetailViewController(showsCloseButton: true)
         detailViewController.detailView.titleLabel.text = task.title
         detailViewController.detailView.bodyLabel.text = task.instructions
+        if let task = task as? OCKTask,
+           let asset = task.asset {
+            detailViewController.detailView.imageView.image = UIImage(named: asset)
+        } else if let task = task as? OCKHealthKitTask,
+                  let asset = task.asset {
+            detailViewController.detailView.imageView.image = UIImage(named: asset)
+        }
         return detailViewController
     }
 

--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -444,7 +444,7 @@ open class OCKTaskController: ObservableObject {
         let detailViewController = OCKDetailViewController(showsCloseButton: true)
         detailViewController.detailView.titleLabel.text = task.title
         detailViewController.detailView.bodyLabel.text = task.instructions
-        detailViewController.detailView.imageView.image = UIImage(named: task.asset ?? "")
+        detailViewController.detailView.imageView.image = task.asset.map(UIImage.init(named:)) ?? nil
         return detailViewController
     }
 

--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -444,9 +444,7 @@ open class OCKTaskController: ObservableObject {
         let detailViewController = OCKDetailViewController(showsCloseButton: true)
         detailViewController.detailView.titleLabel.text = task.title
         detailViewController.detailView.bodyLabel.text = task.instructions
-        if let asset = task.asset {
-            detailViewController.detailView.imageView.image = UIImage(named: asset)
-        }
+        detailViewController.detailView.imageView.image = task.asset.map(UIImage.init(named:))        
         return detailViewController
     }
 

--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -444,11 +444,7 @@ open class OCKTaskController: ObservableObject {
         let detailViewController = OCKDetailViewController(showsCloseButton: true)
         detailViewController.detailView.titleLabel.text = task.title
         detailViewController.detailView.bodyLabel.text = task.instructions
-        if let task = task as? OCKTask,
-           let asset = task.asset {
-            detailViewController.detailView.imageView.image = UIImage(named: asset)
-        } else if let task = task as? OCKHealthKitTask,
-                  let asset = task.asset {
+        if let asset = task.asset {
             detailViewController.detailView.imageView.image = UIImage(named: asset)
         }
         return detailViewController

--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -444,13 +444,7 @@ open class OCKTaskController: ObservableObject {
         let detailViewController = OCKDetailViewController(showsCloseButton: true)
         detailViewController.detailView.titleLabel.text = task.title
         detailViewController.detailView.bodyLabel.text = task.instructions
-        // We can't be sure if the image they provide is in the assets folder, in the bundle, or in a directory.
-        guard let asset = task.asset else { return detailViewController }
-        // We can check all 3 possibilities and then choose whichever is non-nil.
-        let symbol = UIImage(systemName: asset)
-        let appAssetsImage = UIImage(named: asset)
-        let otherUrlImage = UIImage(contentsOfFile: asset)
-        detailViewController.detailView.imageView.image = otherUrlImage ?? appAssetsImage ?? symbol
+        detailViewController.detailView.imageView.image = UIImage.asset(task.asset)
         return detailViewController
     }
 

--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -444,7 +444,7 @@ open class OCKTaskController: ObservableObject {
         let detailViewController = OCKDetailViewController(showsCloseButton: true)
         detailViewController.detailView.titleLabel.text = task.title
         detailViewController.detailView.bodyLabel.text = task.instructions
-        detailViewController.detailView.imageView.image = task.asset.map(UIImage.init(named:))        
+        detailViewController.detailView.imageView.image = task.asset != nil ? UIImage(named: task.asset!) : nil
         return detailViewController
     }
 

--- a/CareKit/CareKit/iOS/Utilities/OCKContactUtility.swift
+++ b/CareKit/CareKit/iOS/Utilities/OCKContactUtility.swift
@@ -55,16 +55,5 @@ struct OCKContactUtility {
         guard let components = components else { return nil }
         return nameFormatter.string(from: components)
     }
-/*
-    static func image(from asset: String?) -> UIImage? {
-        guard let asset = asset else { return nil }
-
-        // We can't be sure if the image they provide is in the assets folder, in the bundle, or in a directory.
-        // We can check all 3 possibilities and then choose whichever is non-nil.
-        let symbol = UIImage(systemName: asset)
-        let appAssetsImage = UIImage(named: asset)
-        let otherUrlImage = UIImage(contentsOfFile: asset)
-        return otherUrlImage ?? appAssetsImage ?? symbol
-    }*/
 }
 #endif

--- a/CareKit/CareKit/iOS/View Updaters/OCKHeaderView+Updatable.swift
+++ b/CareKit/CareKit/iOS/View Updaters/OCKHeaderView+Updatable.swift
@@ -64,7 +64,7 @@ extension OCKHeaderView: OCKEventUpdatable, OCKTaskUpdatable, OCKContactUpdatabl
 
         titleLabel.text = OCKContactUtility.string(from: contact.name)
         detailLabel.text = contact.title
-        iconImageView?.image = OCKContactUtility.image(from: contact.asset) ?? UIImage(systemName: "person.crop.circle")
+        iconImageView?.image = UIImage.asset(contact.asset) ?? UIImage(systemName: "person.crop.circle")
         updateAccessibilityLabel()
     }
 

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTask.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTask.swift
@@ -55,6 +55,9 @@ public protocol OCKAnyTask {
     /// An universally unique identifier for this task.
     var uuid: UUID { get }
 
+    /// A string representation of an asset.
+    var asset: String? { get }
+
     /// An identifier for this task in a remote store.
     var remoteID: String? { get }
 

--- a/OCKCatalog/OCKCatalog/Extensions/OCKStore+Extensions.swift
+++ b/OCKCatalog/OCKCatalog/Extensions/OCKStore+Extensions.swift
@@ -83,7 +83,7 @@ extension OCKStore {
         var task2 = OCKTask(id: Tasks.doxylamine.rawValue, title: "Doxylamine", carePlanUUID: nil,
                             schedule: .mealTimesEachDay(start: start, end: nil))
         task2.instructions = "Take the tablet with a full glass of water."
-
+        task2.asset = "pills"
         return [task1, task2]
     }
 

--- a/OCKSample/OCKSample/AppDelegate.swift
+++ b/OCKSample/OCKSample/AppDelegate.swift
@@ -85,7 +85,7 @@ private extension OCKStore {
         var doxylamine = OCKTask(id: "doxylamine", title: "Take Doxylamine",
                                  carePlanUUID: nil, schedule: schedule)
         doxylamine.instructions = "Take 25mg of doxylamine when you experience nausea."
-        doxylamine.asset = "AppIcon"
+        doxylamine.asset = "pills"
         let nauseaSchedule = OCKSchedule(composing: [
             OCKScheduleElement(start: beforeBreakfast, end: nil, interval: DateComponents(day: 1),
                                text: "Anytime throughout the day", targetValues: [], duration: .allDay)

--- a/OCKSample/OCKSample/AppDelegate.swift
+++ b/OCKSample/OCKSample/AppDelegate.swift
@@ -85,7 +85,7 @@ private extension OCKStore {
         var doxylamine = OCKTask(id: "doxylamine", title: "Take Doxylamine",
                                  carePlanUUID: nil, schedule: schedule)
         doxylamine.instructions = "Take 25mg of doxylamine when you experience nausea."
-
+        doxylamine.asset = "AppIcon"
         let nauseaSchedule = OCKSchedule(composing: [
             OCKScheduleElement(start: beforeBreakfast, end: nil, interval: DateComponents(day: 1),
                                text: "Anytime throughout the day", targetValues: [], duration: .allDay)


### PR DESCRIPTION
If a card is displaying an `OCKAnyTask` it will automatically display the asset tied to the task when details are tapped. Close #524 

@erik-apple and @gavirawson-apple I couldn't find testcases where I should add tests for this. Let me know where to look and I can add them if needed