### PR TITLE
Removes call to objectWillSend within Published properties of OCKTaskController subclasses

### DIFF
--- a/CareKit/CareKit/Shared/Task/Controller/OCKInstructionsTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKInstructionsTaskController.swift
@@ -34,9 +34,7 @@ import Foundation
 open class OCKInstructionsTaskController: OCKTaskController {
 
     /// Data used to create a `CareKitUI.InstructionsTaskView`.
-    @Published public private(set) var viewModel: InstructionsTaskViewModel? {
-        willSet { objectWillChange.send() }
-    }
+    @Published public private(set) var viewModel: InstructionsTaskViewModel?
 
     private var cancellable: AnyCancellable?
 

--- a/CareKit/CareKit/Shared/Task/Controller/OCKSimpleTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKSimpleTaskController.swift
@@ -34,9 +34,7 @@ import Foundation
 open class OCKSimpleTaskController: OCKTaskController {
 
     /// Data used to create a `CareKitUI.SimpleTaskView`.
-    @Published public private(set) var viewModel: SimpleTaskViewModel? {
-        willSet { objectWillChange.send() }
-    }
+    @Published public private(set) var viewModel: SimpleTaskViewModel?
 
     private var cancellable: AnyCancellable?
 


### PR DESCRIPTION
Prior to iOS 14.5, if a subclass of an `ObservableObject` has published properties, modifying their values will not automatically publish changes through the `objectWillChangePublisher`, forcing developers to call `objectWillChange.send()` within a `willSet` observer. 

This incorrect behaviour was resolved in iOS 14.5 ([release notes](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14_5-release-notes)):

> Using Published in a subclass of a type conforming to ObservableObject now correctly publishes changes. (71816443)

Closes #608