### PR TITLE
Modify access modifiers in OCKTaskController and OCKTaskControllerError to support external subclasses and extensions

### DIFF
--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -43,7 +43,7 @@ open class OCKTaskController: ObservableObject {
     @Published public final var taskEvents = OCKTaskEvents()
 
     /// The error encountered by the controller.
-    @Published public internal(set) var error: Error?
+    @Published public var error: Error?
 
     /// The store manager against which the task will be synchronized.
     public let storeManager: OCKSynchronizedStoreManager
@@ -497,14 +497,14 @@ private extension AnyCancellable {
     }
 }
 
-enum OCKTaskControllerError: Error, LocalizedError {
+public enum OCKTaskControllerError: Error, LocalizedError {
 
     case emptyTaskEvents
     case invalidIndexPath(_ indexPath: IndexPath)
     case noOutcomeValueForEvent(_ event: OCKAnyEvent, _ index: Int)
     case cannotMakeOutcomeFor(_ event: OCKAnyEvent)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .emptyTaskEvents: return "Task events is empty"
         case let .noOutcomeValueForEvent(event, index): return "Event has no outcome value at index \(index): \(event)"

--- a/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
+++ b/CareKit/CareKit/Shared/Task/Controller/OCKTaskController.swift
@@ -375,14 +375,14 @@ open class OCKTaskController: ObservableObject {
         return taskEvents[indexPath.section][indexPath.row]
     }
 
-    func validatedViewModel() throws -> OCKTaskEvents {
+    public func validatedViewModel() throws -> OCKTaskEvents {
         guard !taskEvents.isEmpty else {
             throw OCKTaskControllerError.emptyTaskEvents
         }
         return taskEvents
     }
 
-    func validatedEvent(forIndexPath indexPath: IndexPath) throws -> OCKAnyEvent {
+    public func validatedEvent(forIndexPath indexPath: IndexPath) throws -> OCKAnyEvent {
         guard let event = eventFor(indexPath: indexPath) else {
             throw OCKTaskControllerError.invalidIndexPath(indexPath)
         }


### PR DESCRIPTION
`OCKTaskController` is marked as an open class, and when attempting to follow the guidance in the README for subclassing it for use with contextual task views (e.g. `OCKInstructionsTaskView`), or writing extensions to support use-cases, there are some limitations when attempting to do this externally from the CareKit framework itself.  This pull request makes the following modifications to support extension outside of the framework:

* Removes the `internal` access modifier from the setter on the `error` property, making it public.
* Adds the `public` access modifier to both `validatedViewModel()` and `validatedEvent(forIndexPath:)` methods to enable external subclasses/extensions to leverage those when creating new methods for manipulating events and outcomes, using a similar pattern to those established by methods like `setEvent()` or `appendOutcomeValue()`.
* Adds the `public` access modifier to `OCKTaskControllerError` to support the changes in (2) above, as well as enable external subclasses/extensions to leverage that type in other code that may throw those errors.