### PR TITLE
Async/Await extensions for OCKStoreProtocol Constituents

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,6 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_13.app
+        run: sudo xcode-select -s /Applications/Xcode_12.4.app
       - name: Build
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -verbose -workspace CKWorkspace.xcworkspace -scheme ${{ matrix.scheme }} -destination ${{ matrix.destination }} build test | xcpretty

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
@@ -106,7 +106,7 @@ public protocol OCKAnyCarePlanStore: OCKAnyReadOnlyCarePlanStore {
     /// `deleteAnyCarePlan` asynchronously deletes a single care plan from the store.
     ///
     /// - Parameters:
-    ///   - plans: n single care plan to be deleted. The care plans must exist in the store.
+    ///   - plans: A single care plan to be deleted. The care plans must exist in the store.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func deleteAnyCarePlan(_ plan: OCKAnyCarePlan, callbackQueue: DispatchQueue, completion: OCKResultClosure<OCKAnyCarePlan>?)
@@ -146,7 +146,6 @@ public extension OCKAnyCarePlanStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyReadOnlyCarePlanStore
 
 @available(iOS 15.0, *)
@@ -175,7 +174,6 @@ public extension OCKAnyReadOnlyCarePlanStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyCarePlanStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
@@ -37,7 +37,7 @@ public protocol OCKAnyReadOnlyCarePlanStore: OCKAnyResettableStore {
     /// In `CareKit` apps, the delegate will be set automatically, and it should not be modified.
     var carePlanDelegate: OCKCarePlanStoreDelegate? { get set }
 
-    /// `fetchCarePlans` asynchronously retrieves an array of care plans from the store.
+    /// `fetchAnyCarePlans` asynchronously retrieves an array of care plans from the store.
     ///
     /// - Parameters:
     ///   - query: A query used to constrain the values that will be fetched.
@@ -48,7 +48,7 @@ public protocol OCKAnyReadOnlyCarePlanStore: OCKAnyResettableStore {
 
     // MARK: Singular Methods - Implementation Provided
 
-    /// `fetchCarePlan` asynchronously retrieves a single care plans from the store.
+    /// `fetchAnyCarePlan` asynchronously retrieves a single care plans from the store.
     ///
     /// - Parameters:
     ///   - id: The identifier of the item to be fetched.
@@ -61,7 +61,7 @@ public protocol OCKAnyReadOnlyCarePlanStore: OCKAnyResettableStore {
 /// Any store able to write to one ore more types conforming to `OCKAnyCarePlan` is considered an `OCKAnyCarePlanStore`.
 public protocol OCKAnyCarePlanStore: OCKAnyReadOnlyCarePlanStore {
 
-    /// `addCarePlans` asynchronously adds an array of care plans to the store.
+    /// `addAnyCarePlans` asynchronously adds an array of care plans to the store.
     ///
     /// - Parameters:
     ///   - plans: An array of plans to be added to the store.
@@ -69,7 +69,7 @@ public protocol OCKAnyCarePlanStore: OCKAnyReadOnlyCarePlanStore {
     ///   - completion: A callback that will fire on the provided callback queue.
     func addAnyCarePlans(_ plans: [OCKAnyCarePlan], callbackQueue: DispatchQueue, completion: OCKResultClosure<[OCKAnyCarePlan]>?)
 
-    /// `updateCarePlans` asynchronously updates an array of care plans in the store.
+    /// `updateAnyCarePlans` asynchronously updates an array of care plans in the store.
     ///
     /// - Parameters:
     ///   - plans: An array of care plans to be updated. The care plans must already exist in the store.
@@ -77,7 +77,7 @@ public protocol OCKAnyCarePlanStore: OCKAnyReadOnlyCarePlanStore {
     ///   - completion: A callback that will fire on the provided callback queue.
     func updateAnyCarePlans(_ plans: [OCKAnyCarePlan], callbackQueue: DispatchQueue, completion: OCKResultClosure<[OCKAnyCarePlan]>?)
 
-    /// `deleteCarePlans` asynchronously deletes an array of care plans from the store.
+    /// `deleteAnyCarePlans` asynchronously deletes an array of care plans from the store.
     ///
     /// - Parameters:
     ///   - plans: An array of care plans to be deleted. The care plans must exist in the store.
@@ -95,7 +95,7 @@ public protocol OCKAnyCarePlanStore: OCKAnyReadOnlyCarePlanStore {
     ///   - completion: A callback that will fire on the provided callback queue.
     func addAnyCarePlan(_ plan: OCKAnyCarePlan, callbackQueue: DispatchQueue, completion: OCKResultClosure<OCKAnyCarePlan>?)
 
-    /// `updateCarePlan` asynchronously updates a single care plan in the store.
+    /// `updateAnyCarePlan` asynchronously updates a single care plan in the store.
     ///
     /// - Parameters:
     ///   - plan: A single care plan to be updated. The care plans must already exist in the store.
@@ -103,10 +103,10 @@ public protocol OCKAnyCarePlanStore: OCKAnyReadOnlyCarePlanStore {
     ///   - completion: A callback that will fire on the provided callback queue.
     func updateAnyCarePlan(_ plan: OCKAnyCarePlan, callbackQueue: DispatchQueue, completion: OCKResultClosure<OCKAnyCarePlan>?)
 
-    /// `deleteCarePlan` asynchronously deletes a single care plan from the store.
+    /// `deleteAnyCarePlan` asynchronously deletes a single care plan from the store.
     ///
     /// - Parameters:
-    ///   - plans: An single care plan to be deleted. The care plans must exist in the store.
+    ///   - plans: n single care plan to be deleted. The care plans must exist in the store.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func deleteAnyCarePlan(_ plan: OCKAnyCarePlan, callbackQueue: DispatchQueue, completion: OCKResultClosure<OCKAnyCarePlan>?)
@@ -143,5 +143,103 @@ public extension OCKAnyCarePlanStore {
     func deleteAnyCarePlan(_ plan: OCKAnyCarePlan, callbackQueue: DispatchQueue = .main, completion: OCKResultClosure<OCKAnyCarePlan>? = nil) {
         deleteAnyCarePlans([plan], callbackQueue: callbackQueue, completion:
             chooseFirst(then: completion, replacementError: .deleteFailed(reason: "Failed to delete care plan")))
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyReadOnlyCarePlanStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyReadOnlyCarePlanStore {
+
+    /// `fetchAnyCarePlans` asynchronously retrieves an array of care plans from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchAnyCarePlans(query: OCKCarePlanQuery) async throws -> [OCKAnyCarePlan] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyCarePlans(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `fetchAnyCarePlan` asynchronously retrieves a single care plans from the store.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the item to be fetched.
+    func fetchAnyCarePlan(withID id: String) async throws -> OCKAnyCarePlan {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyCarePlan(withID: id, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyCarePlanStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyCarePlanStore {
+
+    /// `addAnyCarePlans` asynchronously adds an array of care plans to the store.
+    ///
+    /// - Parameters:
+    ///   - plans: An array of plans to be added to the store.
+    func addAnyCarePlans(_ plans: [OCKAnyCarePlan]) async throws -> [OCKAnyCarePlan] {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyCarePlans(plans, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyCarePlans` asynchronously updates an array of care plans in the store.
+    ///
+    /// - Parameters:
+    ///   - plans: An array of care plans to be updated. The care plans must already exist in the store.
+    func updateAnyCarePlans(_ plans: [OCKAnyCarePlan]) async throws -> [OCKAnyCarePlan] {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyCarePlans(plans, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteAnyCarePlans` asynchronously deletes an array of care plans from the store.
+    ///
+    /// - Parameters:
+    ///   - plans: An array of care plans to be deleted. The care plans must exist in the store.
+    func deleteAnyCarePlans(_ plans: [OCKAnyCarePlan]) async throws -> [OCKAnyCarePlan] {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyCarePlans(plans, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `addAnyCarePlan` asynchronously adds a single care plan to the store.
+    ///
+    /// - Parameters:
+    ///   - plan: A single plan to be added to the store.
+    func addAnyCarePlan(_ plan: OCKAnyCarePlan) async throws -> OCKAnyCarePlan {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyCarePlan(plan, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyCarePlan` asynchronously updates a single care plan in the store.
+    ///
+    /// - Parameters:
+    ///   - plan: A single care plan to be updated. The care plans must already exist in the store.
+    func updateAnyCarePlan(_ plan: OCKAnyCarePlan) async throws -> OCKAnyCarePlan {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyCarePlan(plan, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteAnyCarePlan` asynchronously deletes a single care plan from the store.
+    ///
+    /// - Parameters:
+    ///   - plan: A single care plan to be deleted. The care plans must exist in the store.
+    func deleteAnyCarePlan(_ plan: OCKAnyCarePlan) async throws -> OCKAnyCarePlan {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyCarePlan(plan, callbackQueue: .main, completion: continuation.resume)
+        }
     }
 }

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
@@ -148,7 +148,8 @@ public extension OCKAnyCarePlanStore {
 
 // MARK: Async methods for OCKAnyReadOnlyCarePlanStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyCarePlanStore {
 
     /// `fetchAnyCarePlans` asynchronously retrieves an array of care plans from the store.
@@ -173,10 +174,12 @@ public extension OCKAnyReadOnlyCarePlanStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKAnyCarePlanStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyCarePlanStore {
 
     /// `addAnyCarePlans` asynchronously adds an array of care plans to the store.
@@ -241,3 +244,4 @@ public extension OCKAnyCarePlanStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
@@ -148,6 +148,8 @@ public extension OCKAnyCarePlanStore {
 
 // MARK: Async methods for OCKAnyReadOnlyCarePlanStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyCarePlanStore {
@@ -178,6 +180,8 @@ public extension OCKAnyReadOnlyCarePlanStore {
 
 // MARK: Async methods for OCKAnyCarePlanStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyCarePlanStore {

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
@@ -183,7 +183,8 @@ public extension OCKCarePlanStore {
 
 // MARK: Async methods for OCKReadableCarePlanStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableCarePlanStore {
 
     /// `fetchCarePlans` asynchronously retrieves an array of care plans from the store.
@@ -209,10 +210,12 @@ public extension OCKReadableCarePlanStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKCarePlanStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKCarePlanStore {
 
     /// `addCarePlans` asynchronously adds an array of care plans to the store.
@@ -279,3 +282,4 @@ public extension OCKCarePlanStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
@@ -181,7 +181,6 @@ public extension OCKCarePlanStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKReadableCarePlanStore
 
 @available(iOS 15.0, *)
@@ -211,7 +210,6 @@ public extension OCKReadableCarePlanStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKCarePlanStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
@@ -183,6 +183,8 @@ public extension OCKCarePlanStore {
 
 // MARK: Async methods for OCKReadableCarePlanStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableCarePlanStore {
@@ -214,6 +216,8 @@ public extension OCKReadableCarePlanStore {
 
 // MARK: Async methods for OCKCarePlanStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKCarePlanStore {

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
@@ -180,3 +180,104 @@ public extension OCKCarePlanStore {
         deleteCarePlans(plans, callbackQueue: callbackQueue) { completion?($0.map { $0.map { $0 as OCKAnyCarePlan } }) }
     }
 }
+
+// MARK: JW
+// MARK: Async methods for OCKReadableCarePlanStore
+
+@available(iOS 15.0, *)
+public extension OCKReadableCarePlanStore {
+
+    /// `fetchCarePlans` asynchronously retrieves an array of care plans from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchCarePlans(query: OCKCarePlanQuery) async throws -> [Plan] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchCarePlans(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `fetchCarePlan` asynchronously retrieves a care plan from the store using its user-defined unique identifier. If a care plan with the
+    /// specified identifier is not found, the completion handler will be called with an error.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the item to be fetched.
+    func fetchCarePlan(withID id: String) async throws -> Plan {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchCarePlan(withID: id, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKCarePlanStore
+
+@available(iOS 15.0, *)
+public extension OCKCarePlanStore {
+
+    /// `addCarePlans` asynchronously adds an array of care plans to the store.
+    ///
+    /// - Parameters:
+    ///   - plans: An array of plans to be added to the store.
+    func addCarePlans(_ plans: [Plan]) async throws -> [Plan] {
+        try await withCheckedThrowingContinuation { continuation in
+            addCarePlans(plans, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateCarePlans` asynchronously updates an array of care plans in the store.
+    ///
+    /// - Parameters:
+    ///   - plans: An array of care plans to be updated. The care plans must already exist in the store.
+    func updateCarePlans(_ plans: [Plan]) async throws -> [Plan] {
+        try await withCheckedThrowingContinuation { continuation in
+            updateCarePlans(plans, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteCarePlans` asynchronously deletes an array of care plans from the store.
+    ///
+    /// - Parameters:
+    ///   - plans: An array of care plans to be deleted. The care plans must exist in the store.
+    func deleteCarePlans(_ plans: [Plan]) async throws -> [Plan] {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteCarePlans(plans, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `addCarePlan` asynchronously adds a care plans to the store.
+    ///
+    /// - Parameters:
+    ///   - plan: A care plan to be added to the store.
+    func addCarePlan(_ plan: Plan) async throws -> Plan {
+        try await withCheckedThrowingContinuation { continuation in
+            addCarePlan(plan, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateCarePlan` asynchronously updates a care plan in the store.
+    ///
+    /// - Parameters:
+    ///   - plan: A care plan to be updated. The care plan must already exist in the store.
+    ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
+    ///   - completion: A callback that will fire on the provided callback queue.
+    func updateCarePlan(_ plan: Plan) async throws -> Plan {
+        try await withCheckedThrowingContinuation { continuation in
+            updateCarePlan(plan, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteCarePlan` asynchronously deletes a care plan from the store.
+    ///
+    /// - Parameters:
+    ///   - plan: A care plan to be deleted. The care plan must exist in the store.
+    func deleteCarePlan(_ plan: Plan) async throws -> Plan {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteCarePlan(plan, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
@@ -146,6 +146,8 @@ public extension OCKAnyContactStore {
 
 // MARK: Async methods for OCKAnyReadOnlyContactStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyContactStore {
@@ -176,6 +178,8 @@ public extension OCKAnyReadOnlyContactStore {
 
 // MARK: Async methods for OCKAnyContactStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyContactStore {

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
@@ -146,7 +146,8 @@ public extension OCKAnyContactStore {
 
 // MARK: Async methods for OCKAnyReadOnlyContactStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyContactStore {
 
     /// `fetchAnyContacts` asynchronously retrieves an array of contacts from the store.
@@ -171,10 +172,12 @@ public extension OCKAnyReadOnlyContactStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKAnyContactStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyContactStore {
 
     /// `addAnyContacts` asynchronously adds an array of contacts to the store.
@@ -239,3 +242,4 @@ public extension OCKAnyContactStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
@@ -51,7 +51,6 @@ public protocol OCKAnyReadOnlyContactStore: OCKAnyResettableStore {
     ///
     /// - Parameters:
     ///   - id: The identifier of the item to be fetched.
-    ///   - query: A query used to constrain the values that will be fetched.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func fetchAnyContact(withID id: String, callbackQueue: DispatchQueue, completion: @escaping OCKResultClosure<OCKAnyContact>)
@@ -84,7 +83,7 @@ public protocol OCKAnyContactStore: OCKAnyReadOnlyContactStore {
     ///   - completion: A callback that will fire on the provided callback queue.
     func deleteAnyContacts(_ contacts: [OCKAnyContact], callbackQueue: DispatchQueue, completion: OCKResultClosure<[OCKAnyContact]>?)
 
-    // MARK: Singular Methods - Implementation Privided
+    // MARK: Singular Methods - Implementation Provided
 
     /// `addAnyContact` asynchronously adds a single contact to the store.
     ///
@@ -105,7 +104,7 @@ public protocol OCKAnyContactStore: OCKAnyReadOnlyContactStore {
     /// `deleteAnyContact` asynchronously deletes a single contact from the store.
     ///
     /// - Parameters:
-    ///   - contact: An single contact to be deleted. The contact must exist in the store.
+    ///   - contact: A single contact to be deleted. The contact must exist in the store.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func deleteAnyContact(_ contact: OCKAnyContact, callbackQueue: DispatchQueue, completion: OCKResultClosure<OCKAnyContact>?)
@@ -142,5 +141,103 @@ public extension OCKAnyContactStore {
     func deleteAnyContact(_ contact: OCKAnyContact, callbackQueue: DispatchQueue = .main, completion: OCKResultClosure<OCKAnyContact>? = nil) {
         deleteAnyContacts([contact], callbackQueue: callbackQueue, completion:
             chooseFirst(then: completion, replacementError: .deleteFailed(reason: "Failed to delete contact")))
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyReadOnlyContactStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyReadOnlyContactStore {
+
+    /// `fetchAnyContacts` asynchronously retrieves an array of contacts from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchAnyContacts(query: OCKContactQuery) async throws -> [OCKAnyContact] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyContacts(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `fetchAnyContact` asynchronously retrieves a single contact from the store.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the item to be fetched.
+    func fetchAnyContact(withID id: String) async throws -> OCKAnyContact {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyContact(withID: id, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyContactStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyContactStore {
+
+    /// `addAnyContacts` asynchronously adds an array of contacts to the store.
+    ///
+    /// - Parameters:
+    ///   - contacts: An array of contacts to be added to the store.
+    func addAnyContacts(_ contacts: [OCKAnyContact]) async throws -> [OCKAnyContact] {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyContacts(contacts, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyContacts` asynchronously updates an array of contacts in the store.
+    ///
+    /// - Parameters:
+    ///   - contacts: An array of contacts to be updated. The contacts must already exist in the store.
+    func updateAnyContacts(_ contacts: [OCKAnyContact]) async throws -> [OCKAnyContact] {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyContacts(contacts, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteAnyContacts` asynchronously deletes an array of contacts from the store.
+    ///
+    /// - Parameters:
+    ///   - contacts: An array of contacts to be deleted. The contacts must exist in the store.
+    func deleteAnyContacts(_ contacts: [OCKAnyContact]) async throws -> [OCKAnyContact] {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyContacts(contacts, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `addAnyContact` asynchronously adds a single contact to the store.
+    ///
+    /// - Parameters:
+    ///   - contact: A single contact to be added to the store.
+    func addAnyContact(_ contact: OCKAnyContact) async throws -> OCKAnyContact {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyContact(contact, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyContact` asynchronously update a single contact in the store.
+    ///
+    /// - Parameters:
+    ///   - contact: A single contact to be updated. The contact must already exist in the store.
+    func updateAnyContact(_ contact: OCKAnyContact) async throws -> OCKAnyContact {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyContact(contact, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteAnyContact` asynchronously deletes a single contact from the store.
+    ///
+    /// - Parameters:
+    ///   - contact: A single contact to be deleted. The contact must exist in the store.
+    func deleteAnyContact(_ contact: OCKAnyContact) async throws -> OCKAnyContact {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyContact(contact, callbackQueue: .main, completion: continuation.resume)
+        }
     }
 }

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
@@ -144,7 +144,6 @@ public extension OCKAnyContactStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyReadOnlyContactStore
 
 @available(iOS 15.0, *)
@@ -173,7 +172,6 @@ public extension OCKAnyReadOnlyContactStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyContactStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
@@ -182,6 +182,8 @@ public extension OCKContactStore {
 
 // MARK: Async methods for OCKReadableContactStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableContactStore {
@@ -213,6 +215,8 @@ public extension OCKReadableContactStore {
 
 // MARK: Async methods for OCKContactStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKContactStore {

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
@@ -180,7 +180,6 @@ public extension OCKContactStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKReadableContactStore
 
 @available(iOS 15.0, *)
@@ -210,7 +209,6 @@ public extension OCKReadableContactStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKContactStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
@@ -179,3 +179,102 @@ public extension OCKContactStore {
         deleteContacts(contacts, callbackQueue: callbackQueue) { completion?($0.map { $0.map { $0 as OCKAnyContact } }) }
     }
 }
+
+// MARK: JW
+// MARK: Async methods for OCKReadableContactStore
+
+@available(iOS 15.0, *)
+public extension OCKReadableContactStore {
+
+    /// `fetchContacts` asynchronously retrieves an array of contacts from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchContacts(query: OCKContactQuery) async throws -> [Contact] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchContacts(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `fetchContact` asynchronously retrieves a contact from the store using its user-defined unique identifier. If a contact with the
+    /// specified identifier is not found, the completion handler will be called with an error.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the item to be fetched.
+    func fetchContact(withID id: String) async throws -> Contact {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchContact(withID: id, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKContactStore
+
+@available(iOS 15.0, *)
+public extension OCKContactStore {
+
+    /// `addContacts` asynchronously adds an array of contacts to the store.
+    ///
+    /// - Parameters:
+    ///   - contacts: An array of contacts to be added to the store.
+    func addContacts(_ contacts: [Contact]) async throws -> [Contact] {
+        try await withCheckedThrowingContinuation { continuation in
+            addContacts(contacts, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateContacts` asynchronously updates an array of contacts in the store.
+    ///
+    /// - Parameters:
+    ///   - contacts: An array of contacts to be updated. The contacts must already exist in the store.
+    func updateContacts(_ contacts: [Contact]) async throws -> [Contact] {
+        try await withCheckedThrowingContinuation { continuation in
+            updateContacts(contacts, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteContacts` asynchronously deletes an array of contacts from the store.
+    ///
+    /// - Parameters:
+    ///   - contacts: An array of contacts to be deleted. The contacts must exist in the store.
+    func deleteContacts(_ contacts: [Contact]) async throws -> [Contact] {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteContacts(contacts, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `addContact` asynchronously adds a contact to the store.
+    ///
+    /// - Parameters:
+    ///   - contact: A contact to be added to the store.
+    func addContact(_ contact: Contact) async throws -> Contact {
+        try await withCheckedThrowingContinuation { continuation in
+            addContact(contact, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateContact` asynchronously updates a contacts in the store.
+    ///
+    /// - Parameters:
+    ///   - contact: A contact to be updated. The contact must already exist in the store.
+    func updateContact(_ contact: Contact) async throws -> Contact {
+        try await withCheckedThrowingContinuation { continuation in
+            updateContact(contact, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteContact` asynchronously deletes a contact from the store.
+    ///
+    /// - Parameters:
+    ///   - contact: A contact to be deleted. The contact must exist in the store.
+    func deleteContact(_ contact: Contact) async throws -> Contact {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteContact(contact, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
@@ -182,7 +182,8 @@ public extension OCKContactStore {
 
 // MARK: Async methods for OCKReadableContactStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableContactStore {
 
     /// `fetchContacts` asynchronously retrieves an array of contacts from the store.
@@ -208,10 +209,12 @@ public extension OCKReadableContactStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKContactStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKContactStore {
 
     /// `addContacts` asynchronously adds an array of contacts to the store.
@@ -276,3 +279,4 @@ public extension OCKContactStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
@@ -166,6 +166,8 @@ public extension OCKAnyReadOnlyEventStore {
 
 // MARK: Async methods for OCKAnyReadOnlyEventStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyEventStore {

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
@@ -166,7 +166,8 @@ public extension OCKAnyReadOnlyEventStore {
 
 // MARK: Async methods for OCKAnyReadOnlyEventStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyEventStore {
 
     /// `fetchAnyEvents` retrieves all the occurrences of the specified task in the interval specified by the provided query.
@@ -214,3 +215,4 @@ public extension OCKAnyReadOnlyEventStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
@@ -51,7 +51,7 @@ public protocol OCKAnyReadOnlyEventStore: OCKAnyReadOnlyTaskStore, OCKAnyReadOnl
     /// - Parameter completion: A callback that will fire on the specified queue.
     func fetchAnyEvent(forTask task: OCKAnyTask, occurrence: Int, callbackQueue: DispatchQueue, completion: @escaping OCKResultClosure<OCKAnyEvent>)
 
-    /// `fetchAnyAdherence` retrieves all the events and calculates the percent of tasks completed for every day between two dates.
+    /// `fetchAdherence` retrieves all the events and calculates the percent of tasks completed for every day between two dates.
     ///
     /// The way completion is computed depends on how many `expectedValues` a task has. If it has no expected values,
     /// then having an outcome with at least one value will count as complete. If a task has expected values, completion
@@ -161,5 +161,57 @@ public extension OCKAnyReadOnlyEventStore {
     // to indicate if there were any tasks defined on that day.
     private func datesWithTasks(query: OCKAdherenceQuery, tasks: [OCKAnyTask]) -> [Bool] {
         query.dates().map { date in tasks.map { $0.schedule.exists(onDay: date) }.contains(true) }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyReadOnlyEventStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyReadOnlyEventStore {
+
+    /// `fetchAnyEvents` retrieves all the occurrences of the specified task in the interval specified by the provided query.
+    ///
+    /// - Parameters:
+    ///   - taskID: A user-defined unique identifier for the task.
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchAnyEvents(taskID: String, query: OCKEventQuery) async throws -> [OCKAnyEvent] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyEvents(taskID: taskID, query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `fetchAnyEvent` retrieves a single occurrence of the specified task.
+    ///
+    /// - Parameter task: The task for which to retrieve an event.
+    /// - Parameter occurrence: The occurrence index of the desired event.
+    func fetchAnyEvent(forTask task: OCKAnyTask, occurrence: Int) async throws -> OCKAnyEvent {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyEvent(forTask: task, occurrence: occurrence, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `fetchAdherence` retrieves all the events and calculates the percent of tasks completed for every day between two dates.
+    ///
+    /// The way completion is computed depends on how many `expectedValues` a task has. If it has no expected values,
+    /// then having an outcome with at least one value will count as complete. If a task has expected values, completion
+    /// will be computed as ratio of the number of outcome values to the number of expected values.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchAdherence(query: OCKAdherenceQuery) async throws -> [OCKAdherence] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAdherence(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `fetchInsights` computes a metric for a given task between two dates using the provided closure.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchInsights(query: OCKInsightQuery) async throws -> [Double] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchInsights(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
     }
 }

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
@@ -164,7 +164,6 @@ public extension OCKAnyReadOnlyEventStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyReadOnlyEventStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
@@ -219,3 +219,33 @@ public extension OCKReadOnlyEventStore where Task: OCKAnyVersionableTask {
         return events
     }
 }
+
+// MARK: JW
+// MARK: Async methods for OCKReadOnlyEventStore
+
+@available(iOS 15.0, *)
+public extension OCKReadOnlyEventStore {
+
+    /// `fetchEvents` retrieves all the occurrences of the specified task in the interval specified by the provided query.
+    ///
+    /// - Parameters:
+    ///   - taskID: A user-defined unique identifier for the task.
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchEvents(taskID id: String, query: OCKEventQuery) async throws -> [Event] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchEvents(taskID: id, query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `fetchEvent` retrieves a single occurrence of the specified task.
+    ///
+    /// - Parameter task: The task for which to retrieve an event.
+    /// - Parameter occurrence: The occurrence index of the desired event.
+    func fetchEvent(forTask task: Task, occurrence: Int) async throws -> Event {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchEvent(forTask: task, occurrence: occurrence, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
@@ -222,6 +222,8 @@ public extension OCKReadOnlyEventStore where Task: OCKAnyVersionableTask {
 
 // MARK: Async methods for OCKReadOnlyEventStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadOnlyEventStore {

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
@@ -220,7 +220,6 @@ public extension OCKReadOnlyEventStore where Task: OCKAnyVersionableTask {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKReadOnlyEventStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
@@ -222,7 +222,8 @@ public extension OCKReadOnlyEventStore where Task: OCKAnyVersionableTask {
 
 // MARK: Async methods for OCKReadOnlyEventStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadOnlyEventStore {
 
     /// `fetchEvents` retrieves all the occurrences of the specified task in the interval specified by the provided query.
@@ -248,3 +249,4 @@ public extension OCKReadOnlyEventStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
@@ -60,7 +60,7 @@ public protocol OCKAnyReadOnlyOutcomeStore: OCKAnyResettableStore {
 
 public protocol OCKAnyOutcomeStore: OCKAnyReadOnlyOutcomeStore {
 
-    /// `addOutcomes` asynchronously adds an array of outcomes to the store.
+    /// `addAnyOutcomes` asynchronously adds an array of outcomes to the store.
     ///
     /// - Parameters:
     ///   - outcomes: An array of outcomes to be added to the store.
@@ -68,7 +68,7 @@ public protocol OCKAnyOutcomeStore: OCKAnyReadOnlyOutcomeStore {
     ///   - completion: A callback that will fire on the provided callback queue.
     func addAnyOutcomes(_ outcomes: [OCKAnyOutcome], callbackQueue: DispatchQueue, completion: OCKResultClosure<[OCKAnyOutcome]>?)
 
-    /// `updateOutcomes` asynchronously updates an array of outcomes in the store.
+    /// `updateAnyOutcomes` asynchronously updates an array of outcomes in the store.
     ///
     /// - Parameters:
     ///   - contacts: An array of outcomes to be updated. The outcomes must already exist in the store.
@@ -76,7 +76,7 @@ public protocol OCKAnyOutcomeStore: OCKAnyReadOnlyOutcomeStore {
     ///   - completion: A callback that will fire on the provided callback queue.
     func updateAnyOutcomes(_ outcomes: [OCKAnyOutcome], callbackQueue: DispatchQueue, completion: OCKResultClosure<[OCKAnyOutcome]>?)
 
-    /// `deleteOutcomes` asynchronously deletes an array of outcomes from the store.
+    /// `deleteAnyOutcomes` asynchronously deletes an array of outcomes from the store.
     ///
     /// - Parameters:
     ///   - outcomes: An array of outcomes to be deleted. The outcomes must exist in the store.
@@ -86,7 +86,7 @@ public protocol OCKAnyOutcomeStore: OCKAnyReadOnlyOutcomeStore {
 
     // MARK: Singular Methods - Implementation Provided
 
-    /// `addOutcome` asynchronously adds an outcome to the store.
+    /// `addAnyOutcome` asynchronously adds an outcome to the store.
     ///
     /// - Parameters:
     ///   - outcome: An outcome to be added to the store.
@@ -94,7 +94,7 @@ public protocol OCKAnyOutcomeStore: OCKAnyReadOnlyOutcomeStore {
     ///   - completion: A callback that will fire on the provided callback queue.
     func addAnyOutcome(_ outcome: OCKAnyOutcome, callbackQueue: DispatchQueue, completion: OCKResultClosure<OCKAnyOutcome>?)
 
-    /// `updateOutcome` asynchronously updates an outcome in the store.
+    /// `updateAnyOutcome` asynchronously updates an outcome in the store.
     ///
     /// - Parameters:
     ///   - outcome: An outcome to be updated. The outcome must already exist in the store.
@@ -102,7 +102,7 @@ public protocol OCKAnyOutcomeStore: OCKAnyReadOnlyOutcomeStore {
     ///   - completion: A callback that will fire on the provided callback queue.
     func updateAnyOutcome(_ outcome: OCKAnyOutcome, callbackQueue: DispatchQueue, completion: OCKResultClosure<OCKAnyOutcome>?)
 
-    /// `deleteOutcome` asynchronously deletes an outcome from the store.
+    /// `deleteAnyOutcome` asynchronously deletes an outcome from the store.
     ///
     /// - Parameters:
     ///   - outcome: An outcome to be deleted. The outcome must exist in the store.
@@ -138,5 +138,104 @@ public extension OCKAnyOutcomeStore {
     func deleteAnyOutcome(_ outcome: OCKAnyOutcome, callbackQueue: DispatchQueue = .main, completion: OCKResultClosure<OCKAnyOutcome>? = nil) {
         deleteAnyOutcomes([outcome], callbackQueue: callbackQueue, completion:
             chooseFirst(then: completion, replacementError: .deleteFailed(reason: "Failed to delete outcome")))
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyReadOnlyOutcomeStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyReadOnlyOutcomeStore {
+
+    /// `fetchAnyOutcomes` asynchronously retrieves an array of outcomes from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchAnyOutcomes(query: OCKOutcomeQuery) async throws -> [OCKAnyOutcome] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyOutcomes(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `fetchAnyOutcome` asynchronously retrieves a single outcome from the store. If more than one outcome matches the query, only the first
+    /// will be returned. If no matching outcomes exist, the completion handler will be called with an error.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchAnyOutcome(query: OCKOutcomeQuery) async throws -> OCKAnyOutcome {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyOutcome(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyOutcomeStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyOutcomeStore {
+
+    /// `addAnyOutcomes` asynchronously adds an array of outcomes to the store.
+    ///
+    /// - Parameters:
+    ///   - outcomes: An array of outcomes to be added to the store.
+    func addAnyOutcomes(_ outcomes: [OCKAnyOutcome]) async throws -> [OCKAnyOutcome] {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyOutcomes(outcomes, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyOutcomes` asynchronously updates an array of outcomes in the store.
+    ///
+    /// - Parameters:
+    ///   - contacts: An array of outcomes to be updated. The outcomes must already exist in the store.
+    func updateAnyOutcomes(_ outcomes: [OCKAnyOutcome]) async throws -> [OCKAnyOutcome] {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyOutcomes(outcomes, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteAnyOutcomes` asynchronously deletes an array of outcomes from the store.
+    ///
+    /// - Parameters:
+    ///   - outcomes: An array of outcomes to be deleted. The outcomes must exist in the store.
+    func deleteAnyOutcomes(_ outcomes: [OCKAnyOutcome]) async throws -> [OCKAnyOutcome] {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyOutcomes(outcomes, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `addAnyOutcome` asynchronously adds an outcome to the store.
+    ///
+    /// - Parameters:
+    ///   - outcome: An outcome to be added to the store.
+    func addAnyOutcome(_ outcome: OCKAnyOutcome) async throws -> OCKAnyOutcome {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyOutcome(outcome, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyOutcome` asynchronously updates an outcome in the store.
+    ///
+    /// - Parameters:
+    ///   - outcome: An outcome to be updated. The outcome must already exist in the store.
+    func updateAnyOutcome(_ outcome: OCKAnyOutcome) async throws -> OCKAnyOutcome {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyOutcome(outcome, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteAnyOutcome` asynchronously deletes an outcome from the store.
+    ///
+    /// - Parameters:
+    ///   - outcome: An outcome to be deleted. The outcome must exist in the store.
+    func deleteAnyOutcome(_ outcome: OCKAnyOutcome) async throws -> OCKAnyOutcome {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyOutcome(outcome, callbackQueue: .main, completion: continuation.resume)
+        }
     }
 }

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
@@ -143,6 +143,8 @@ public extension OCKAnyOutcomeStore {
 
 // MARK: Async methods for OCKAnyReadOnlyOutcomeStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyOutcomeStore {
@@ -174,6 +176,8 @@ public extension OCKAnyReadOnlyOutcomeStore {
 
 // MARK: Async methods for OCKAnyOutcomeStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyOutcomeStore {

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
@@ -143,7 +143,8 @@ public extension OCKAnyOutcomeStore {
 
 // MARK: Async methods for OCKAnyReadOnlyOutcomeStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyOutcomeStore {
 
     /// `fetchAnyOutcomes` asynchronously retrieves an array of outcomes from the store.
@@ -169,10 +170,12 @@ public extension OCKAnyReadOnlyOutcomeStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKAnyOutcomeStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyOutcomeStore {
 
     /// `addAnyOutcomes` asynchronously adds an array of outcomes to the store.
@@ -237,3 +240,4 @@ public extension OCKAnyOutcomeStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
@@ -141,7 +141,6 @@ public extension OCKAnyOutcomeStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyReadOnlyOutcomeStore
 
 @available(iOS 15.0, *)
@@ -171,7 +170,6 @@ public extension OCKAnyReadOnlyOutcomeStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyOutcomeStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
@@ -66,7 +66,7 @@ public protocol OCKOutcomeStore: OCKAnyOutcomeStore & OCKReadableOutcomeStore {
     /// `updateOutcomes` asynchronously updates an array of outcomes in the store.
     ///
     /// - Parameters:
-    ///   - contacts: An array of outcomes to be updated. The outcomes must already exist in the store.
+    ///   - outcomes: An array of outcomes to be updated. The outcomes must already exist in the store.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func updateOutcomes(_ outcomes: [Outcome], callbackQueue: DispatchQueue, completion: OCKResultClosure<[Outcome]>?)
@@ -172,5 +172,102 @@ public extension OCKOutcomeStore {
             return
         }
         deleteOutcomes(outcomes, callbackQueue: callbackQueue) { completion?($0.map { $0.map { $0 as OCKAnyOutcome } }) }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKReadableOutcomeStore
+
+@available(iOS 15.0, *)
+public extension OCKReadableOutcomeStore {
+
+    /// `fetchOutcomes` asynchronously retrieves an array of outcomes from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchOutcomes(query: OCKOutcomeQuery) async throws -> [Outcome] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchOutcomes(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `fetchOutcome` asynchronously retrieves a single outcome from the store. If more than one outcome matches the query, only the first
+    /// will be returned. If no matching outcomes exist, the completion handler will be called with an error.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchOutcome(query: OCKOutcomeQuery) async throws -> Outcome {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchOutcome(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKOutcomeStore
+
+@available(iOS 15.0, *)
+public extension OCKOutcomeStore {
+
+    /// `addOutcomes` asynchronously adds an array of outcomes to the store.
+    ///
+    /// - Parameters:
+    ///   - outcomes: An array of outcomes to be added to the store.
+    func addOutcomes(_ outcomes: [Outcome]) async throws -> [Outcome] {
+        try await withCheckedThrowingContinuation { continuation in
+            addOutcomes(outcomes, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateOutcomes` asynchronously updates an array of outcomes in the store.
+    ///
+    /// - Parameters:
+    ///   - outcomes: An array of outcomes to be updated. The outcomes must already exist in the store.
+    func updateOutcomes(_ outcomes: [Outcome]) async throws -> [Outcome] {
+        try await withCheckedThrowingContinuation { continuation in
+            updateOutcomes(outcomes, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteOutcomes` asynchronously deletes an array of outcomes from the store.
+    ///
+    /// - Parameters:
+    ///   - outcomes: An array of outcomes to be deleted. The outcomes must exist in the store.
+    func deleteOutcomes(_ outcomes: [Outcome]) async throws -> [Outcome] {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteOutcomes(outcomes, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `addOutcome` asynchronously adds an outcome to the store.
+    ///
+    /// - Parameters:
+    ///   - outcome: An outcome to be added to the store.
+    func addOutcome(_ outcome: Outcome) async throws -> Outcome {
+        try await withCheckedThrowingContinuation { continuation in
+            addOutcome(outcome, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateOutcome` asynchronously updates an outcome in the store.
+    ///
+    /// - Parameters:
+    ///   - outcome: An outcome to be updated. The outcome must already exist in the store.
+    func updateOutcome(_ outcome: Outcome) async throws -> Outcome {
+        try await withCheckedThrowingContinuation { continuation in
+            updateOutcome(outcome, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteOutcome` asynchronously deletes an outcome from the store.
+    ///
+    /// - Parameters:
+    ///   - outcome: An outcome to be deleted. The outcome must exist in the store.
+    func deleteOutcome(_ outcome: Outcome) async throws -> Outcome {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteOutcome(outcome, callbackQueue: .main, completion: continuation.resume)
+        }
     }
 }

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
@@ -177,7 +177,8 @@ public extension OCKOutcomeStore {
 
 // MARK: Async methods for OCKReadableOutcomeStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableOutcomeStore {
 
     /// `fetchOutcomes` asynchronously retrieves an array of outcomes from the store.
@@ -201,10 +202,12 @@ public extension OCKReadableOutcomeStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKOutcomeStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKOutcomeStore {
 
     /// `addOutcomes` asynchronously adds an array of outcomes to the store.
@@ -269,3 +272,4 @@ public extension OCKOutcomeStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
@@ -177,6 +177,8 @@ public extension OCKOutcomeStore {
 
 // MARK: Async methods for OCKReadableOutcomeStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableOutcomeStore {
@@ -206,6 +208,8 @@ public extension OCKReadableOutcomeStore {
 
 // MARK: Async methods for OCKOutcomeStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKOutcomeStore {

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
@@ -175,7 +175,6 @@ public extension OCKOutcomeStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKReadableOutcomeStore
 
 @available(iOS 15.0, *)
@@ -203,7 +202,6 @@ public extension OCKReadableOutcomeStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKOutcomeStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
@@ -145,7 +145,6 @@ public extension OCKAnyPatientStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyReadOnlyPatientStore
 
 @available(iOS 15.0, *)
@@ -174,7 +173,6 @@ public extension OCKAnyReadOnlyPatientStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyPatientStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
@@ -147,6 +147,8 @@ public extension OCKAnyPatientStore {
 
 // MARK: Async methods for OCKAnyReadOnlyPatientStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyPatientStore {
@@ -177,6 +179,8 @@ public extension OCKAnyReadOnlyPatientStore {
 
 // MARK: Async methods for OCKAnyPatientStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyPatientStore {

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
@@ -52,7 +52,6 @@ public protocol OCKAnyReadOnlyPatientStore: OCKAnyResettableStore {
     ///
     /// - Parameters:
     ///   - id: The identifier of the item to be fetched.
-    ///   - query: A query used to constrain the values that will be fetched.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func fetchAnyPatient(withID id: String, callbackQueue: DispatchQueue, completion: @escaping OCKResultClosure<OCKAnyPatient>)
@@ -64,7 +63,7 @@ public protocol OCKAnyPatientStore: OCKAnyReadOnlyPatientStore {
     /// `addAnyPatients` asynchronously adds an array of patients to the store.
     ///
     /// - Parameters:
-    ///   - patients: A array of patients to be added to the store.
+    ///   - patients: An array of patients to be added to the store.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func addAnyPatients(_ patients: [OCKAnyPatient], callbackQueue: DispatchQueue, completion: OCKResultClosure<[OCKAnyPatient]>?)
@@ -98,7 +97,7 @@ public protocol OCKAnyPatientStore: OCKAnyReadOnlyPatientStore {
     /// `updateAnyPatient` asynchronously updates a single patient in the store.
     ///
     /// - Parameters:
-    ///   - patient: An single patient to be updated. The patients must already exist in the store.
+    ///   - patient: A single patient to be updated. The patients must already exist in the store.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func updateAnyPatient(_ patient: OCKAnyPatient, callbackQueue: DispatchQueue, completion: OCKResultClosure<OCKAnyPatient>?)
@@ -106,7 +105,7 @@ public protocol OCKAnyPatientStore: OCKAnyReadOnlyPatientStore {
     /// `deleteAnyPatient` asynchronously deletes a single patient from the store.
     ///
     /// - Parameters:
-    ///   - patients: A single patient to be deleted. The patients must exist in the store.
+    ///   - patient: A single patient to be deleted. The patients must exist in the store.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func deleteAnyPatient(_ patient: OCKAnyPatient, callbackQueue: DispatchQueue, completion: OCKResultClosure<OCKAnyPatient>?)
@@ -143,5 +142,103 @@ public extension OCKAnyPatientStore {
     func deleteAnyPatient(_ patient: OCKAnyPatient, callbackQueue: DispatchQueue = .main, completion: OCKResultClosure<OCKAnyPatient>? = nil) {
         deleteAnyPatients([patient], callbackQueue: callbackQueue, completion:
             chooseFirst(then: completion, replacementError: .deleteFailed(reason: "Failed to delete patient")))
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyReadOnlyPatientStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyReadOnlyPatientStore {
+
+    /// `fetchAnyPatients` asynchronously retrieves an array of patients from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchAnyPatients(query: OCKPatientQuery) async throws -> [OCKAnyPatient] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyPatients(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `fetchAnyPatient` asynchronously retrieves a single patient from the store.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the item to be fetched.
+    func fetchAnyPatient(withID id: String) async throws -> OCKAnyPatient {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyPatient(withID: id, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyPatientStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyPatientStore {
+
+    /// `addAnyPatients` asynchronously adds an array of patients to the store.
+    ///
+    /// - Parameters:
+    ///   - patients: An array of patients to be added to the store.
+    func addAnyPatients(_ patients: [OCKAnyPatient]) async throws -> [OCKAnyPatient] {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyPatients(patients, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyPatients` asynchronously updates an array of patients in the store.
+    ///
+    /// - Parameters:
+    ///   - patients: An array of patients to be updated. The patients must already exist in the store.
+    func updateAnyPatients(_ patients: [OCKAnyPatient]) async throws -> [OCKAnyPatient] {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyPatients(patients, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteAnyPatients` asynchronously deletes an array of patients from the store.
+    ///
+    /// - Parameters:
+    ///   - patients: An array of patients to be deleted. The patients must exist in the store.
+    func deleteAnyPatients(_ patients: [OCKAnyPatient]) async throws -> [OCKAnyPatient] {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyPatients(patients, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `addAnyPatient` asynchronously adds a single patient to the store.
+    ///
+    /// - Parameters:
+    ///   - patient: A single patient to be added to the store.
+    func addAnyPatient(_ patient: OCKAnyPatient) async throws -> OCKAnyPatient {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyPatient(patient, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyPatient` asynchronously updates a single patient in the store.
+    ///
+    /// - Parameters:
+    ///   - patient: A single patient to be updated. The patients must already exist in the store.
+    func updateAnyPatient(_ patient: OCKAnyPatient) async throws -> OCKAnyPatient {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyPatient(patient, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteAnyPatient` asynchronously deletes a single patient from the store.
+    ///
+    /// - Parameters:
+    ///   - patient: A single patient to be deleted. The patients must exist in the store.
+    func deleteAnyPatient(_ patient: OCKAnyPatient) async throws -> OCKAnyPatient {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyPatient(patient, callbackQueue: .main, completion: continuation.resume)
+        }
     }
 }

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
@@ -147,7 +147,8 @@ public extension OCKAnyPatientStore {
 
 // MARK: Async methods for OCKAnyReadOnlyPatientStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyPatientStore {
 
     /// `fetchAnyPatients` asynchronously retrieves an array of patients from the store.
@@ -172,10 +173,12 @@ public extension OCKAnyReadOnlyPatientStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKAnyPatientStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyPatientStore {
 
     /// `addAnyPatients` asynchronously adds an array of patients to the store.
@@ -240,3 +243,4 @@ public extension OCKAnyPatientStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
@@ -184,7 +184,6 @@ public extension OCKPatientStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKReadablePatientStore
 
 @available(iOS 15.0, *)
@@ -214,7 +213,6 @@ public extension OCKReadablePatientStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKPatientStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
@@ -183,3 +183,102 @@ public extension OCKPatientStore {
         deletePatients(patients, callbackQueue: callbackQueue) { completion?($0.map { $0.map { $0 as OCKAnyPatient } }) }
     }
 }
+
+// MARK: JW
+// MARK: Async methods for OCKReadablePatientStore
+
+@available(iOS 15.0, *)
+public extension OCKReadablePatientStore {
+
+    /// `fetchPatients` asynchronously retrieves an array of patients from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchPatients(query: OCKPatientQuery) async throws -> [Patient] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchPatients(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `fetchPatient` asynchronously fetches a single patient from the store using its user-defined identifier. If a patient with the specified
+    /// identifier does not exist, the completion handler will be called with an error.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the item to be fetched.
+    func fetchPatient(withID id: String) async throws -> Patient {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchPatient(withID: id, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKPatientStore
+
+@available(iOS 15.0, *)
+public extension OCKPatientStore {
+
+    /// `addPatients` asynchronously adds an array of patients to the store.
+    ///
+    /// - Parameters:
+    ///   - patients: An array of patients to be added to the store.
+    func addPatients(_ patients: [Patient]) async throws -> [Patient] {
+        try await withCheckedThrowingContinuation { continuation in
+            addPatients(patients, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updatePatients` asynchronously updates an array of patients in the store.
+    ///
+    /// - Parameters:
+    ///   - patients: An array of patients to be updated. The patients must already exist in the store.
+    func updatePatients(_ patients: [Patient]) async throws -> [Patient] {
+        try await withCheckedThrowingContinuation { continuation in
+            updatePatients(patients, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deletePatients` asynchronously deletes an array of patients from the store.
+    ///
+    /// - Parameters:
+    ///   - patients: An array of patients to be deleted. The patients must exist in the store.
+    func deletePatients(_ patients: [Patient]) async throws -> [Patient] {
+        try await withCheckedThrowingContinuation { continuation in
+            deletePatients(patients, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `addPatient` asynchronously adds a patient to the store.
+    ///
+    /// - Parameters:
+    ///   - patient: A patient to be added to the store.
+    func addPatient(_ patient: Patient) async throws -> Patient {
+        try await withCheckedThrowingContinuation { continuation in
+            addPatient(patient, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updatePatient` asynchronously updates a patient in the store.
+    ///
+    /// - Parameters:
+    ///   - patient: A patient to be updated. The patient must already exist in the store.
+    func updatePatient(_ patient: Patient) async throws -> Patient {
+        try await withCheckedThrowingContinuation { continuation in
+            updatePatient(patient, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deletePatient` asynchronously deletes a patient from the store.
+    ///
+    /// - Parameters:
+    ///   - patient: A patient to be deleted. The patient must exist in the store.
+    func deletePatient(_ patient: Patient) async throws -> Patient {
+        try await withCheckedThrowingContinuation { continuation in
+            deletePatient(patient, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
@@ -186,6 +186,8 @@ public extension OCKPatientStore {
 
 // MARK: Async methods for OCKReadablePatientStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadablePatientStore {
@@ -217,6 +219,8 @@ public extension OCKReadablePatientStore {
 
 // MARK: Async methods for OCKPatientStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKPatientStore {

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
@@ -186,7 +186,8 @@ public extension OCKPatientStore {
 
 // MARK: Async methods for OCKReadablePatientStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadablePatientStore {
 
     /// `fetchPatients` asynchronously retrieves an array of patients from the store.
@@ -212,10 +213,12 @@ public extension OCKReadablePatientStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKPatientStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKPatientStore {
 
     /// `addPatients` asynchronously adds an array of patients to the store.
@@ -280,3 +283,4 @@ public extension OCKPatientStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
@@ -144,7 +144,6 @@ public extension OCKAnyTaskStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyReadOnlyTaskStore
 
 @available(iOS 15.0, *)
@@ -174,7 +173,6 @@ public extension OCKAnyReadOnlyTaskStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKAnyTaskStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
@@ -146,6 +146,8 @@ public extension OCKAnyTaskStore {
 
 // MARK: Async methods for OCKAnyReadOnlyTaskStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyTaskStore {
@@ -177,6 +179,8 @@ public extension OCKAnyReadOnlyTaskStore {
 
 // MARK: Async methods for OCKAnyTaskStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyTaskStore {

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
@@ -143,3 +143,100 @@ public extension OCKAnyTaskStore {
             chooseFirst(then: completion, replacementError: .deleteFailed(reason: "Failed to delete task")))
     }
 }
+
+// MARK: JW
+// MARK: Async methods for OCKAnyReadOnlyTaskStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyReadOnlyTaskStore {
+
+    /// `fetchAnyTasks` asynchronously retrieves an array of tasks from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchAnyTasks(query: OCKTaskQuery) async throws -> [OCKAnyTask] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyTasks(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `fetchAnyTask` asynchronously retrieves an array of tasks from the store using its user-defined unique identifier. If a task with the
+    /// specified identifier is not found, the completion handler will be called with an error.
+    ///
+    /// - Parameters:
+    ///   - id: A unique user-defined identifier
+    func fetchAnyTask(withID id: String) async throws -> OCKAnyTask {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchAnyTask(withID: id, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKAnyTaskStore
+
+@available(iOS 15.0, *)
+public extension OCKAnyTaskStore {
+
+    /// `addAnyTasks` asynchronously adds an array of tasks to the store.
+    ///
+    /// - Parameters:
+    ///   - tasks: An array of tasks to be added to the store.
+    func addAnyTasks(_ tasks: [OCKAnyTask]) async throws -> [OCKAnyTask] {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyTasks(tasks, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyTasks` asynchronously updates an array of tasks in the store.
+    ///
+    /// - Parameters:
+    ///   - tasks: An array of tasks to be updated. The tasks must already exist in the store.
+    func updateAnyTasks(_ tasks: [OCKAnyTask]) async throws -> [OCKAnyTask] {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyTasks(tasks, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteAnyTasks` asynchronously deletes an array of tasks from the store.
+    ///
+    /// - Parameters:
+    ///   - tasks: An array of tasks to be deleted. The tasks must exist in the store.
+    ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
+    ///   - completion: A callback that will fire on the provided callback queue.
+    func deleteAnyTasks(_ tasks: [OCKAnyTask]) async throws -> [OCKAnyTask] {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyTasks(tasks, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `addAnyTask` asynchronously adds a task to the store.
+    ///
+    /// - Parameters:
+    ///   - task: A task to be added to the store.
+    func addAnyTask(_ task: OCKAnyTask) async throws -> OCKAnyTask {
+        try await withCheckedThrowingContinuation { continuation in
+            addAnyTask(task, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateAnyTask` asynchronously updates a task in the store.
+    ///
+    /// - Parameters:
+    ///   - contact: A task to be updated. The task must already exist in the store.
+    func updateAnyTask(_ task: OCKAnyTask) async throws -> OCKAnyTask {
+        try await withCheckedThrowingContinuation { continuation in
+            updateAnyTask(task, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteTask` asynchronously deletes a task from the store.
+    ///
+    /// - Parameters:
+    ///   - task: A task to be deleted. The task must exist in the store.
+    func deleteAnyTask(_ task: OCKAnyTask) async throws -> OCKAnyTask {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteAnyTask(task, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
@@ -146,7 +146,8 @@ public extension OCKAnyTaskStore {
 
 // MARK: Async methods for OCKAnyReadOnlyTaskStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyTaskStore {
 
     /// `fetchAnyTasks` asynchronously retrieves an array of tasks from the store.
@@ -172,10 +173,12 @@ public extension OCKAnyReadOnlyTaskStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKAnyTaskStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyTaskStore {
 
     /// `addAnyTasks` asynchronously adds an array of tasks to the store.
@@ -240,3 +243,4 @@ public extension OCKAnyTaskStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
@@ -52,7 +52,7 @@ public protocol OCKAnyReadOnlyTaskStore: OCKAnyResettableStore {
     /// specified identifier is not found, the completion handler will be called with an error.
     ///
     /// - Parameters:
-    ///   - id: A unique user-defined identifier
+    ///   - id: The identifier of the item to be fetched.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func fetchAnyTask(withID id: String, callbackQueue: DispatchQueue,
@@ -99,7 +99,7 @@ public protocol OCKAnyTaskStore: OCKAnyReadOnlyTaskStore {
     /// `updateAnyTask` asynchronously updates a task in the store.
     ///
     /// - Parameters:
-    ///   - contact: A task to be updated. The task must already exist in the store.
+    ///   - task: A task to be updated. The task must already exist in the store.
     ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
     ///   - completion: A callback that will fire on the provided callback queue.
     func updateAnyTask(_ task: OCKAnyTask, callbackQueue: DispatchQueue, completion: ((Result<OCKAnyTask, OCKStoreError>) -> Void)?)
@@ -160,11 +160,13 @@ public extension OCKAnyReadOnlyTaskStore {
         }
     }
 
+    // MARK: Singular Methods - Implementation Provided
+
     /// `fetchAnyTask` asynchronously retrieves an array of tasks from the store using its user-defined unique identifier. If a task with the
     /// specified identifier is not found, the completion handler will be called with an error.
     ///
     /// - Parameters:
-    ///   - id: A unique user-defined identifier
+    ///   - id: The identifier of the item to be fetched.
     func fetchAnyTask(withID id: String) async throws -> OCKAnyTask {
         try await withCheckedThrowingContinuation { continuation in
             fetchAnyTask(withID: id, callbackQueue: .main, completion: continuation.resume)
@@ -202,13 +204,13 @@ public extension OCKAnyTaskStore {
     ///
     /// - Parameters:
     ///   - tasks: An array of tasks to be deleted. The tasks must exist in the store.
-    ///   - callbackQueue: The queue that the completion closure should be called on. In most cases this should be the main queue.
-    ///   - completion: A callback that will fire on the provided callback queue.
     func deleteAnyTasks(_ tasks: [OCKAnyTask]) async throws -> [OCKAnyTask] {
         try await withCheckedThrowingContinuation { continuation in
             deleteAnyTasks(tasks, callbackQueue: .main, completion: continuation.resume)
         }
     }
+
+    // MARK: Singular Methods - Implementation Provided
 
     /// `addAnyTask` asynchronously adds a task to the store.
     ///
@@ -223,7 +225,7 @@ public extension OCKAnyTaskStore {
     /// `updateAnyTask` asynchronously updates a task in the store.
     ///
     /// - Parameters:
-    ///   - contact: A task to be updated. The task must already exist in the store.
+    ///   - task: A task to be updated. The task must already exist in the store.
     func updateAnyTask(_ task: OCKAnyTask) async throws -> OCKAnyTask {
         try await withCheckedThrowingContinuation { continuation in
             updateAnyTask(task, callbackQueue: .main, completion: continuation.resume)

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
@@ -182,7 +182,8 @@ public extension OCKTaskStore {
 
 // MARK: Async methods for OCKReadableTaskStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableTaskStore {
 
     /// `fetchTasks` asynchronously retrieves an array of tasks from the store.
@@ -208,10 +209,12 @@ public extension OCKReadableTaskStore {
         }
     }
 }
+#endif
 
 // MARK: Async methods for OCKTaskStore
 
-@available(iOS 15.0, *)
+#if swift(>=5.5)
+@available(iOS 15.0, watchOS 9.0, *)
 public extension OCKTaskStore {
 
     /// `addTasks` asynchronously adds an array of tasks to the store.
@@ -276,3 +279,4 @@ public extension OCKTaskStore {
         }
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
@@ -180,7 +180,6 @@ public extension OCKTaskStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKReadableTaskStore
 
 @available(iOS 15.0, *)
@@ -210,7 +209,6 @@ public extension OCKReadableTaskStore {
     }
 }
 
-// MARK: JW
 // MARK: Async methods for OCKTaskStore
 
 @available(iOS 15.0, *)

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
@@ -179,3 +179,102 @@ public extension OCKTaskStore {
         deleteTasks(tasks, callbackQueue: callbackQueue) { completion?($0.map { $0.map { $0 as OCKAnyTask } }) }
     }
 }
+
+// MARK: JW
+// MARK: Async methods for OCKReadableTaskStore
+
+@available(iOS 15.0, *)
+public extension OCKReadableTaskStore {
+
+    /// `fetchTasks` asynchronously retrieves an array of tasks from the store.
+    ///
+    /// - Parameters:
+    ///   - query: A query used to constrain the values that will be fetched.
+    func fetchTasks(query: OCKTaskQuery) async throws -> [Task] {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchTasks(query: query, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `fetchTask` asynchronously retrieves an array of tasks from the store using its user-defined unique identifier. If a task with the
+    /// specified identifier is not found, the completion handler will be called with an error.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the item to be fetched.
+    func fetchTask(withID id: String) async throws -> Task {
+        try await withCheckedThrowingContinuation { continuation in
+            fetchTask(withID: id, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}
+
+// MARK: JW
+// MARK: Async methods for OCKTaskStore
+
+@available(iOS 15.0, *)
+public extension OCKTaskStore {
+
+    /// `addTasks` asynchronously adds an array of tasks to the store.
+    ///
+    /// - Parameters:
+    ///   - tasks: An array of tasks to be added to the store.
+    func addTasks(_ tasks: [Task]) async throws -> [Task] {
+        try await withCheckedThrowingContinuation { continuation in
+            addTasks(tasks, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateTasks` asynchronously updates an array of tasks in the store.
+    ///
+    /// - Parameters:
+    ///   - tasks: An array of tasks to be updated. The tasks must already exist in the store.
+    func updateTasks(_ tasks: [Task]) async throws -> [Task] {
+        try await withCheckedThrowingContinuation { continuation in
+            updateTasks(tasks, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteTasks` asynchronously deletes an array of tasks from the store.
+    ///
+    /// - Parameters:
+    ///   - tasks: An array of tasks to be deleted. The tasks must exist in the store.
+    func deleteTasks(_ tasks: [Task]) async throws -> [Task] {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteTasks(tasks, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    // MARK: Singular Methods - Implementation Provided
+
+    /// `addTask` asynchronously adds a task to the store.
+    ///
+    /// - Parameters:
+    ///   - task: A task to be added to the store.
+    func addTask(_ task: Task) async throws -> Task {
+        try await withCheckedThrowingContinuation { continuation in
+            addTask(task, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `updateTask` asynchronously updates a task in the store.
+    ///
+    /// - Parameters:
+    ///   - task: A task to be updated. The task must already exist in the store.
+    func updateTask(_ task: Task) async throws -> Task {
+        try await withCheckedThrowingContinuation { continuation in
+            updateTask(task, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+
+    /// `deleteTask` asynchronously deletes a task from the store.
+    ///
+    /// - Parameters:
+    ///   - task: A task to be deleted. The task must exist in the store.
+    func deleteTask(_ task: Task) async throws -> Task {
+        try await withCheckedThrowingContinuation { continuation in
+            deleteTask(task, callbackQueue: .main, completion: continuation.resume)
+        }
+    }
+}

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
@@ -182,6 +182,8 @@ public extension OCKTaskStore {
 
 // MARK: Async methods for OCKReadableTaskStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableTaskStore {
@@ -213,6 +215,8 @@ public extension OCKReadableTaskStore {
 
 // MARK: Async methods for OCKTaskStore
 
+// Remove this once Xcode 13 is available on GitHub actions
+// https://github.com/carekit-apple/CareKit/issues/619
 #if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKTaskStore {


### PR DESCRIPTION
I have added async/await extensions to all constituent protocols of OCKStoreProtocol and fixed miscellaneous documentation typos in those protocols.

These changes compile cleanly with Xcode 13 beta 4 and do run on iOS 15 simulator. However I haven't tested every method, nor have I committed any of my unit tests. If anyone feels unit tests are needed, please comment.
