### PR TITLE
Bump CI to Xcode 12.4

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,12 +15,12 @@ jobs:
   
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=14.0,name=iPhone\ 11\ Pro\ Max']
+        destination: ['platform=iOS\ Simulator,OS=14.4,name=iPhone\ 11\ Pro\ Max']
         scheme: ['CareKit\ iOS', 'CareKitStore\ iOS', 'CareKitUI\ iOS', 'CareKitFHIR']
   
     steps:
       - uses: actions/checkout@v2
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_12.app
+        run: sudo xcode-select -s /Applications/Xcode_12.4.app
       - name: Build
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -verbose -workspace CKWorkspace.xcworkspace -scheme ${{ matrix.scheme }} -destination ${{ matrix.destination }} build test | xcpretty


### PR DESCRIPTION
Xcode 12.4 is the latest publicly available in Actions. It looks like the CI has been running agains 12.0 for awhile. Current software: https://github.com/actions/virtual-environments/blob/macOS-10.15/20210801.1/images/macos/macos-10.15-Readme.md

This will need to be bumped manually from time-to-time because of the discussion here: https://github.com/carekit-apple/CareKit/pull/492#issuecomment-675167708

Maybe this gets rid of CI failures since it's not running on older Xcode? Or at least make them less frequent.