### PR TITLE
Removed "#if swift(>=5.5)" now that Xcode 13 is supported by CI.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,7 @@ jobs:
   
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=14.4,name=iPhone\ 11\ Pro\ Max']
+        destination: ['platform=iOS\ Simulator,OS=15.0,name=iPhone\ 11\ Pro\ Max']
         scheme: ['CareKit\ iOS', 'CareKitStore\ iOS', 'CareKitUI\ iOS', 'CareKitFHIR']
   
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,6 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_13.0.app
+        run: sudo xcode-select -s /Applications/Xcode_13.app
       - name: Build
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -verbose -workspace CKWorkspace.xcworkspace -scheme ${{ matrix.scheme }} -destination ${{ matrix.destination }} build test | xcpretty

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,6 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_12.4.app
+        run: sudo xcode-select -s /Applications/Xcode_13.0.app
       - name: Build
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -verbose -workspace CKWorkspace.xcworkspace -scheme ${{ matrix.scheme }} -destination ${{ matrix.destination }} build test | xcpretty

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,6 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_13.app
+        run: sudo xcode-select -s /Applications/Xcode_13.0.app
       - name: Build
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -verbose -workspace CKWorkspace.xcworkspace -scheme ${{ matrix.scheme }} -destination ${{ matrix.destination }} build test | xcpretty

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ jobs:
         
   test:
     
-    runs-on: macos-latest
+    runs-on: macos-11
   
     strategy:
       matrix:

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
@@ -148,9 +148,6 @@ public extension OCKAnyCarePlanStore {
 
 // MARK: Async methods for OCKAnyReadOnlyCarePlanStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyCarePlanStore {
 
@@ -176,13 +173,9 @@ public extension OCKAnyReadOnlyCarePlanStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKAnyCarePlanStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyCarePlanStore {
 
@@ -248,4 +241,3 @@ public extension OCKAnyCarePlanStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
@@ -183,9 +183,6 @@ public extension OCKCarePlanStore {
 
 // MARK: Async methods for OCKReadableCarePlanStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableCarePlanStore {
 
@@ -212,13 +209,9 @@ public extension OCKReadableCarePlanStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKCarePlanStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKCarePlanStore {
 
@@ -286,4 +279,3 @@ public extension OCKCarePlanStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
@@ -146,9 +146,6 @@ public extension OCKAnyContactStore {
 
 // MARK: Async methods for OCKAnyReadOnlyContactStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyContactStore {
 
@@ -174,13 +171,9 @@ public extension OCKAnyReadOnlyContactStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKAnyContactStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyContactStore {
 
@@ -246,4 +239,3 @@ public extension OCKAnyContactStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
@@ -182,9 +182,6 @@ public extension OCKContactStore {
 
 // MARK: Async methods for OCKReadableContactStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableContactStore {
 
@@ -211,13 +208,9 @@ public extension OCKReadableContactStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKContactStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKContactStore {
 
@@ -283,4 +276,3 @@ public extension OCKContactStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
@@ -166,9 +166,6 @@ public extension OCKAnyReadOnlyEventStore {
 
 // MARK: Async methods for OCKAnyReadOnlyEventStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyEventStore {
 
@@ -217,4 +214,3 @@ public extension OCKAnyReadOnlyEventStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
@@ -222,9 +222,6 @@ public extension OCKReadOnlyEventStore where Task: OCKAnyVersionableTask {
 
 // MARK: Async methods for OCKReadOnlyEventStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadOnlyEventStore {
 
@@ -251,4 +248,3 @@ public extension OCKReadOnlyEventStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
@@ -143,9 +143,6 @@ public extension OCKAnyOutcomeStore {
 
 // MARK: Async methods for OCKAnyReadOnlyOutcomeStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyOutcomeStore {
 
@@ -172,13 +169,9 @@ public extension OCKAnyReadOnlyOutcomeStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKAnyOutcomeStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyOutcomeStore {
 
@@ -244,4 +237,3 @@ public extension OCKAnyOutcomeStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
@@ -177,9 +177,6 @@ public extension OCKOutcomeStore {
 
 // MARK: Async methods for OCKReadableOutcomeStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableOutcomeStore {
 
@@ -204,13 +201,9 @@ public extension OCKReadableOutcomeStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKOutcomeStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKOutcomeStore {
 
@@ -276,4 +269,3 @@ public extension OCKOutcomeStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
@@ -147,9 +147,6 @@ public extension OCKAnyPatientStore {
 
 // MARK: Async methods for OCKAnyReadOnlyPatientStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyPatientStore {
 
@@ -175,13 +172,9 @@ public extension OCKAnyReadOnlyPatientStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKAnyPatientStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyPatientStore {
 
@@ -247,4 +240,3 @@ public extension OCKAnyPatientStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
@@ -186,9 +186,6 @@ public extension OCKPatientStore {
 
 // MARK: Async methods for OCKReadablePatientStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadablePatientStore {
 
@@ -215,13 +212,9 @@ public extension OCKReadablePatientStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKPatientStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKPatientStore {
 
@@ -287,4 +280,3 @@ public extension OCKPatientStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
@@ -146,9 +146,6 @@ public extension OCKAnyTaskStore {
 
 // MARK: Async methods for OCKAnyReadOnlyTaskStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyReadOnlyTaskStore {
 
@@ -175,13 +172,9 @@ public extension OCKAnyReadOnlyTaskStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKAnyTaskStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKAnyTaskStore {
 
@@ -247,4 +240,3 @@ public extension OCKAnyTaskStore {
         }
     }
 }
-#endif

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
@@ -182,9 +182,6 @@ public extension OCKTaskStore {
 
 // MARK: Async methods for OCKReadableTaskStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKReadableTaskStore {
 
@@ -211,13 +208,9 @@ public extension OCKReadableTaskStore {
         }
     }
 }
-#endif
 
 // MARK: Async methods for OCKTaskStore
 
-// Remove this once Xcode 13 is available on GitHub actions
-// https://github.com/carekit-apple/CareKit/issues/619
-#if swift(>=5.5)
 @available(iOS 15.0, watchOS 9.0, *)
 public extension OCKTaskStore {
 
@@ -283,4 +276,3 @@ public extension OCKTaskStore {
         }
     }
 }
-#endif


### PR DESCRIPTION
https://github.com/carekit-apple/CareKit/issues/619

Updated source and workflow script.

