### PR TITLE
async methods should work on watchOS 8+

### DIFF
--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKAnyCarePlanStore.swift
@@ -148,7 +148,7 @@ public extension OCKAnyCarePlanStore {
 
 // MARK: Async methods for OCKAnyReadOnlyCarePlanStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyReadOnlyCarePlanStore {
 
     /// `fetchAnyCarePlans` asynchronously retrieves an array of care plans from the store.
@@ -176,7 +176,7 @@ public extension OCKAnyReadOnlyCarePlanStore {
 
 // MARK: Async methods for OCKAnyCarePlanStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyCarePlanStore {
 
     /// `addAnyCarePlans` asynchronously adds an array of care plans to the store.

--- a/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CarePlans/OCKCarePlanStore.swift
@@ -183,7 +183,7 @@ public extension OCKCarePlanStore {
 
 // MARK: Async methods for OCKReadableCarePlanStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKReadableCarePlanStore {
 
     /// `fetchCarePlans` asynchronously retrieves an array of care plans from the store.
@@ -212,7 +212,7 @@ public extension OCKReadableCarePlanStore {
 
 // MARK: Async methods for OCKCarePlanStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKCarePlanStore {
 
     /// `addCarePlans` asynchronously adds an array of care plans to the store.

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKAnyContactStore.swift
@@ -146,7 +146,7 @@ public extension OCKAnyContactStore {
 
 // MARK: Async methods for OCKAnyReadOnlyContactStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyReadOnlyContactStore {
 
     /// `fetchAnyContacts` asynchronously retrieves an array of contacts from the store.
@@ -174,7 +174,7 @@ public extension OCKAnyReadOnlyContactStore {
 
 // MARK: Async methods for OCKAnyContactStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyContactStore {
 
     /// `addAnyContacts` asynchronously adds an array of contacts to the store.

--- a/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Contacts/OCKContactStore.swift
@@ -182,7 +182,7 @@ public extension OCKContactStore {
 
 // MARK: Async methods for OCKReadableContactStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKReadableContactStore {
 
     /// `fetchContacts` asynchronously retrieves an array of contacts from the store.
@@ -211,7 +211,7 @@ public extension OCKReadableContactStore {
 
 // MARK: Async methods for OCKContactStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKContactStore {
 
     /// `addContacts` asynchronously adds an array of contacts to the store.

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKAnyEventStore.swift
@@ -166,7 +166,7 @@ public extension OCKAnyReadOnlyEventStore {
 
 // MARK: Async methods for OCKAnyReadOnlyEventStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyReadOnlyEventStore {
 
     /// `fetchAnyEvents` retrieves all the occurrences of the specified task in the interval specified by the provided query.

--- a/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Events/OCKEventStore.swift
@@ -222,7 +222,7 @@ public extension OCKReadOnlyEventStore where Task: OCKAnyVersionableTask {
 
 // MARK: Async methods for OCKReadOnlyEventStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKReadOnlyEventStore {
 
     /// `fetchEvents` retrieves all the occurrences of the specified task in the interval specified by the provided query.

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKAnyOutcomeStore.swift
@@ -143,7 +143,7 @@ public extension OCKAnyOutcomeStore {
 
 // MARK: Async methods for OCKAnyReadOnlyOutcomeStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyReadOnlyOutcomeStore {
 
     /// `fetchAnyOutcomes` asynchronously retrieves an array of outcomes from the store.
@@ -172,7 +172,7 @@ public extension OCKAnyReadOnlyOutcomeStore {
 
 // MARK: Async methods for OCKAnyOutcomeStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyOutcomeStore {
 
     /// `addAnyOutcomes` asynchronously adds an array of outcomes to the store.

--- a/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Outcomes/OCKOutcomeStore.swift
@@ -177,7 +177,7 @@ public extension OCKOutcomeStore {
 
 // MARK: Async methods for OCKReadableOutcomeStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKReadableOutcomeStore {
 
     /// `fetchOutcomes` asynchronously retrieves an array of outcomes from the store.
@@ -204,7 +204,7 @@ public extension OCKReadableOutcomeStore {
 
 // MARK: Async methods for OCKOutcomeStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKOutcomeStore {
 
     /// `addOutcomes` asynchronously adds an array of outcomes to the store.

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKAnyPatientStore.swift
@@ -147,7 +147,7 @@ public extension OCKAnyPatientStore {
 
 // MARK: Async methods for OCKAnyReadOnlyPatientStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyReadOnlyPatientStore {
 
     /// `fetchAnyPatients` asynchronously retrieves an array of patients from the store.
@@ -175,7 +175,7 @@ public extension OCKAnyReadOnlyPatientStore {
 
 // MARK: Async methods for OCKAnyPatientStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyPatientStore {
 
     /// `addAnyPatients` asynchronously adds an array of patients to the store.

--- a/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Patients/OCKPatientStore.swift
@@ -186,7 +186,7 @@ public extension OCKPatientStore {
 
 // MARK: Async methods for OCKReadablePatientStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKReadablePatientStore {
 
     /// `fetchPatients` asynchronously retrieves an array of patients from the store.
@@ -215,7 +215,7 @@ public extension OCKReadablePatientStore {
 
 // MARK: Async methods for OCKPatientStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKPatientStore {
 
     /// `addPatients` asynchronously adds an array of patients to the store.

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKAnyTaskStore.swift
@@ -146,7 +146,7 @@ public extension OCKAnyTaskStore {
 
 // MARK: Async methods for OCKAnyReadOnlyTaskStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyReadOnlyTaskStore {
 
     /// `fetchAnyTasks` asynchronously retrieves an array of tasks from the store.
@@ -175,7 +175,7 @@ public extension OCKAnyReadOnlyTaskStore {
 
 // MARK: Async methods for OCKAnyTaskStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKAnyTaskStore {
 
     /// `addAnyTasks` asynchronously adds an array of tasks to the store.

--- a/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/Tasks/OCKTaskStore.swift
@@ -182,7 +182,7 @@ public extension OCKTaskStore {
 
 // MARK: Async methods for OCKReadableTaskStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKReadableTaskStore {
 
     /// `fetchTasks` asynchronously retrieves an array of tasks from the store.
@@ -211,7 +211,7 @@ public extension OCKReadableTaskStore {
 
 // MARK: Async methods for OCKTaskStore
 
-@available(iOS 15.0, watchOS 9.0, *)
+@available(iOS 15.0, watchOS 8.0, *)
 public extension OCKTaskStore {
 
     /// `addTasks` asynchronously adds an array of tasks to the store.


### PR DESCRIPTION
watchOS async methods are currently set to watchOS 9, reference: https://developer.apple.com/documentation/swift/3814989-withcheckedthrowingcontinuation