### PR TITLE
Add scripts for generating Swift-DocC documentation

### DIFF
--- a/Scripts/generate-documentation
+++ b/Scripts/generate-documentation
@@ -1,0 +1,140 @@
+#!/bin/bash
+#
+# Copyright (c) 2022, Apple Inc. All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+# 
+# 1.  Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+# 
+# 2.  Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder(s) nor the names of any contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission. No license is granted to the trademarks of
+# the copyright holders even if such marks are included in this software.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+# First get the absolute path to this file so we can get the absolute file path to the Swift-DocC root source dir.
+CAREKIT_ROOT="$(dirname $(dirname $(filepath $0)))"
+DOCS_DIR="$CAREKIT_ROOT/.build/swift-docc"
+SGFS_DIR="$DOCS_DIR/symbol-graph-files"
+TEMP_WORKSPACE_DIR="$DOCS_DIR/temporary-workspace-holding-directory"
+
+DOCC_CMD=convert
+OUTPUT_PATH="$DOCS_DIR/CareKit.doccarchive"
+HOSTING_BASE_PATH=""
+PUBLISH="NO"
+
+# Process command line arguments
+OUTPUT_PATH_PROCESSED=0
+HOSTING_BASE_PATH_PROCESSED=0
+while test $# -gt 0; do
+  case "$1" in
+    --help)
+      echo "Usage: $(basename $0) [<output-path>] [<hosting-base-path>] [--preview] [--publish] [--help]"
+      echo
+      echo "Builds CareKit and generates or previews the Swift-DocC documentation."
+      echo
+      echo "    --preview: Starts a preview server after generating documentation."
+      echo "    --publish: Configures the documentation build for publishing on GitHub pages."
+      echo
+      exit 0
+      ;;
+    --preview)
+      DOCC_CMD=preview
+      shift
+      ;;
+    --publish)
+      PUBLISH="YES"
+      shift
+    ;;
+    *)
+      if [ ${OUTPUT_PATH_PROCESSED} -eq 0 ]; then
+        OUTPUT_PATH="$1"
+        OUTPUT_PATH_PROCESSED=1
+      elif [ ${HOSTING_BASE_PATH_PROCESSED} -eq 0 ]; then
+        HOSTING_BASE_PATH="$1"
+        HOSTING_BASE_PATH_PROCESSED=1
+      else
+        echo "Unrecognised argument \"$1\""
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [ "$PUBLISH" = "YES" ]; then
+  if [ ${HOSTING_BASE_PATH_PROCESSED} -eq 0 ]; then
+    echo "A hosting base path must be provided if the '--publish' flag is passed."
+    echo "See '--help' for details."
+    exit 1
+  fi
+fi
+
+# Create the output directory for the symbol graphs if needed.
+mkdir -p "$DOCS_DIR"
+mkdir -p "$SGFS_DIR"
+rm -f $SGFS_DIR/*.*
+
+cd "$CAREKIT_ROOT"  
+
+# Temporarily move the Xcode workspace aside so that xcodebuild uses the Swift package directly
+mkdir "$TEMP_WORKSPACE_DIR"
+mv CKWorkspace.xcworkspace "$TEMP_WORKSPACE_DIR/CKWorkspace.xcworkspace"
+
+xcodebuild clean build -scheme CareKit \
+    -destination generic/platform=iOS \
+    OTHER_SWIFT_FLAGS="-emit-symbol-graph -emit-symbol-graph-dir '$SGFS_DIR'"
+
+mv "$TEMP_WORKSPACE_DIR/CKWorkspace.xcworkspace" ./CKWorkspace.xcworkspace
+rm -r "$TEMP_WORKSPACE_DIR"
+
+# Pretty print DocC JSON output so that it can be consistently diffed between commits
+export DOCC_JSON_PRETTYPRINT="YES"
+
+# By default pass the --index flag so we produce a full DocC archive.
+EXTRA_DOCC_FLAGS="--index"
+
+# If building for publishing, don't pass the --index flag but pass additional flags for
+# static hosting configuration.
+if [ "$PUBLISH" = "YES" ]; then
+    EXTRA_DOCC_FLAGS="--transform-for-static-hosting --hosting-base-path CareKit/$HOSTING_BASE_PATH"
+fi
+
+# Handle the case where a DocC catalog does not exist in the CareKit repo
+if [ -d CareKit.docc ]; then
+    # The DocC catalog exists, so pass it to the docc invocation.
+    DOCC_CMD="$DOCC_CMD CareKit.docc"
+fi
+
+xcrun docc $DOCC_CMD \
+    --additional-symbol-graph-dir "$SGFS_DIR" \
+    --output-path "$OUTPUT_PATH" $EXTRA_DOCC_FLAGS \
+    --fallback-display-name CareKit \
+    --fallback-bundle-identifier com.apple.CareKit \
+    --fallback-bundle-version 1.0.0
+
+if [[ "$DOCC_CMD" == "convert"* ]]; then
+    echo
+    echo "Generated DocC archive at: $OUTPUT_PATH"
+fi

--- a/Scripts/update-gh-pages-documentation-site
+++ b/Scripts/update-gh-pages-documentation-site
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright (c) 2022, Apple Inc. All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+# 
+# 1.  Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+# 
+# 2.  Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# 3. Neither the name of the copyright holder(s) nor the names of any contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission. No license is granted to the trademarks of
+# the copyright holders even if such marks are included in this software.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set -eu
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+CAREKIT_ROOT="$(dirname $(dirname $(filepath $0)))"
+
+# Set current directory to the repository root
+cd "$CAREKIT_ROOT"
+
+# Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
+git fetch
+git worktree add --checkout gh-pages origin/gh-pages
+
+# Get the name of the current branch to use as the subdirectory for the deployment
+CURRENT_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD`
+
+# Replace any forward slashes in the current branch name with dashes
+DEPLOYMENT_SUBDIRECTORY=${CURRENT_BRANCH_NAME//\//-}
+
+# Create a subdirectory for the current branch name if it doesn't exist
+mkdir -p "./gh-pages/$DEPLOYMENT_SUBDIRECTORY"
+
+# Generate documentation output it
+# to the /docs subdirectory in the gh-pages worktree directory.
+./Scripts/generate-documentation "$CAREKIT_ROOT/gh-pages/$DEPLOYMENT_SUBDIRECTORY" "$DEPLOYMENT_SUBDIRECTORY" --publish
+
+# Save the current commit we've just built documentation from in a variable
+CURRENT_COMMIT_HASH=`git rev-parse --short HEAD`
+
+# Commit and push our changes to the gh-pages branch
+cd gh-pages
+git add "$DEPLOYMENT_SUBDIRECTORY"
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Documentation changes found. Commiting the changes to the 'gh-pages' branch and pushing to origin."
+    git commit -m "Update documentation to $CURRENT_COMMIT_HASH on '$CURRENT_BRANCH_NAME'"
+    git push origin HEAD:gh-pages
+else
+  # No changes found, nothing to commit.
+  echo "No documentation changes found."
+fi
+
+# Delete the git worktree we created
+cd ..
+git worktree remove gh-pages


### PR DESCRIPTION
## Summary

Adds scripts for generating, previewing, and publishing Swift-DocC documentation for CareKit.

## Details

- `Scripts/generate-documentation` will generate a DocC archive containing the documentation for CareKit and emit the path of the archive.
- `Scripts/generate-documentation --preview` will start a local web server to allow for previewing of the current CareKit documentation.
- `Scripts/update-gh-pages-documentation-site` will build the documentation for CareKit and deploy it to the `gh-pages` branch on the remote.
    - The script checks the name of the branch it's being run from and automatically creates a separate documentation site per branch. So, moving forward, we'll be able to run the script from the `main` and `stable` branches in this repository and have up-to-date documentation for both at separate paths.

## Testing

1. Run `Scripts/preview-documentation` and confirm that the documentation site behaves as expected.
2. I've deployed the documentation to the `gh-pages` branch on my fork which can be viewed here:
    - https://ethan-kusters.github.io/CareKit/stable/documentation/carekit/
    - https://ethan-kusters.github.io/CareKit/main/documentation/carekit/

## Notes

There will be a follow-up PR that adds a DocC catalog to the `stable` branch of CareKit and properly organizes the project's API.