### PR TITLE
fix survey, contact, and task view tint colors

### DIFF
--- a/CareKit/CareKit/iOS/Contact/View Controllers/OCKContactViewController.swift
+++ b/CareKit/CareKit/iOS/Contact/View Controllers/OCKContactViewController.swift
@@ -225,10 +225,9 @@ UIViewController, OCKContactViewDelegate, MFMessageComposeViewControllerDelegate
             contactViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self,
                                                                                       action: #selector(dismissViewController))
             let navigationController = UINavigationController(rootViewController: contactViewController)
-            if contactView.window?.tintColor == nil {
-                contactViewController.view.tintColor = view.tintColor
-                navigationController.navigationBar.tintColor = view.tintColor
-            }
+            let tintColor = determineTintColor(from: view)
+            contactViewController.view.tintColor = tintColor
+            navigationController.navigationBar.tintColor = tintColor
             present(navigationController, animated: true, completion: nil)
         }
     }

--- a/CareKit/CareKit/iOS/Contact/View Controllers/OCKContactViewController.swift
+++ b/CareKit/CareKit/iOS/Contact/View Controllers/OCKContactViewController.swift
@@ -225,6 +225,10 @@ UIViewController, OCKContactViewDelegate, MFMessageComposeViewControllerDelegate
             contactViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self,
                                                                                       action: #selector(dismissViewController))
             let navigationController = UINavigationController(rootViewController: contactViewController)
+            if contactView.window?.tintColor == nil {
+                contactViewController.view.tintColor = view.tintColor
+                navigationController.navigationBar.tintColor = view.tintColor
+            }
             present(navigationController, animated: true, completion: nil)
         }
     }

--- a/CareKit/CareKit/iOS/Contact/View Controllers/OCKContactViewController.swift
+++ b/CareKit/CareKit/iOS/Contact/View Controllers/OCKContactViewController.swift
@@ -222,11 +222,11 @@ UIViewController, OCKContactViewDelegate, MFMessageComposeViewControllerDelegate
 
     open func didSelectContactView(_ contactView: UIView & OCKContactDisplayable) {
         handleThrowable(method: controller.initiateSystemContactLookup) { [weak self] contactViewController in
+            let tintColor = determineTintColor(from: view)
+            contactViewController.view.tintColor = tintColor
             contactViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self,
                                                                                       action: #selector(dismissViewController))
             let navigationController = UINavigationController(rootViewController: contactViewController)
-            let tintColor = determineTintColor(from: view)
-            contactViewController.view.tintColor = tintColor
             navigationController.navigationBar.tintColor = tintColor
             present(navigationController, animated: true, completion: nil)
         }

--- a/CareKit/CareKit/iOS/Contact/View Controllers/OCKContactViewController.swift
+++ b/CareKit/CareKit/iOS/Contact/View Controllers/OCKContactViewController.swift
@@ -222,6 +222,12 @@ UIViewController, OCKContactViewDelegate, MFMessageComposeViewControllerDelegate
 
     open func didSelectContactView(_ contactView: UIView & OCKContactDisplayable) {
         handleThrowable(method: controller.initiateSystemContactLookup) { [weak self] contactViewController in
+            /*
+             TODO: Remove in the future. Explicitly setting the tint color here to support
+             current developers that have a SwiftUI lifecycle app and wrap this view
+             controller in a `UIViewControllerRepresentable` implementation...Tint color
+             is not propagated...etc.
+             */
             let tintColor = determineTintColor(from: view)
             contactViewController.view.tintColor = tintColor
             contactViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self,

--- a/CareKit/CareKit/iOS/Extensions/UIViewController+Extensions.swift
+++ b/CareKit/CareKit/iOS/Extensions/UIViewController+Extensions.swift
@@ -50,5 +50,9 @@ internal extension UIViewController {
         stackView.insertArrangedSubview(view, at: index, animated: animated)
         didMove(toParent: containerViewController)
     }
+    
+    func determineTintColor(from view: UIView) -> UIColor {
+        self.view.window?.tintColor ?? view.tintColor
+    }
 }
 #endif

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -153,6 +153,12 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKTaskController,
 
             warningAlert.addAction(cancelAction)
             warningAlert.addAction(confirmAction)
+            /*
+             TODO: Remove in the future. Explicitly setting the tint color here to support
+             current developers that have a SwiftUI lifecycle app and wrap this view
+             controller in a `UIViewControllerRepresentable` implementation...Tint color
+             is not propagated...etc.
+             */
             warningAlert.view.tintColor = determineTintColor(from: view)
             present(warningAlert, animated: true, completion: nil)
 
@@ -170,6 +176,12 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKTaskController,
         ).last!.appendingPathComponent("ResearchKit", isDirectory: true)
 
         surveyViewController.outputDirectory = directory
+        /*
+         TODO: Remove in the future. Explicitly setting the tint color here to support
+         current developers that have a SwiftUI lifecycle app and wrap this view
+         controller in a `UIViewControllerRepresentable` implementation...Tint color
+         is not propagated...etc.
+         */
         surveyViewController.view.tintColor = determineTintColor(from: view)
         surveyViewController.delegate = self
 

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -169,6 +169,7 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKTaskController,
         ).last!.appendingPathComponent("ResearchKit", isDirectory: true)
 
         surveyViewController.outputDirectory = directory
+        surveyViewController.view.tintColor = view.tintColor
         surveyViewController.delegate = self
 
         present(surveyViewController, animated: true, completion: nil)

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -153,9 +153,7 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKTaskController,
 
             warningAlert.addAction(cancelAction)
             warningAlert.addAction(confirmAction)
-            if self.view.window?.tintColor == nil {
-                warningAlert.view.tintColor = view.tintColor
-            }
+            warningAlert.view.tintColor = determineTintColor(from: view)
             present(warningAlert, animated: true, completion: nil)
 
             return
@@ -172,9 +170,7 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKTaskController,
         ).last!.appendingPathComponent("ResearchKit", isDirectory: true)
 
         surveyViewController.outputDirectory = directory
-        if self.view.window?.tintColor == nil {
-            surveyViewController.view.tintColor = view.tintColor
-        }
+        surveyViewController.view.tintColor = determineTintColor(from: view)
         surveyViewController.delegate = self
 
         present(surveyViewController, animated: true, completion: nil)

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -169,7 +169,9 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKTaskController,
         ).last!.appendingPathComponent("ResearchKit", isDirectory: true)
 
         surveyViewController.outputDirectory = directory
-        surveyViewController.view.tintColor = view.tintColor
+        if surveyViewController.view.tintColor == UIColor.systemBlue {
+            surveyViewController.view.tintColor = view.tintColor
+        }
         surveyViewController.delegate = self
 
         present(surveyViewController, animated: true, completion: nil)

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -169,7 +169,7 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKTaskController,
         ).last!.appendingPathComponent("ResearchKit", isDirectory: true)
 
         surveyViewController.outputDirectory = directory
-        if surveyViewController.view.tintColor == UIColor.systemBlue {
+        if self.view.window?.tintColor == nil {
             surveyViewController.view.tintColor = view.tintColor
         }
         surveyViewController.delegate = self

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -153,6 +153,9 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKTaskController,
 
             warningAlert.addAction(cancelAction)
             warningAlert.addAction(confirmAction)
+            if self.view.window?.tintColor == nil {
+                warningAlert.view.tintColor = view.tintColor
+            }
             present(warningAlert, animated: true, completion: nil)
 
             return

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKTaskViewController.swift
@@ -193,6 +193,12 @@ UIViewController, OCKTaskViewDelegate {
                 alert.popoverPresentationController?.sourceView = anchor
                 alert.popoverPresentationController?.permittedArrowDirections = .any
             }
+            /*
+             TODO: Remove in the future. Explicitly setting the tint color here to support
+             current developers that have a SwiftUI lifecycle app and wrap this view
+             controller in a `UIViewControllerRepresentable` implementation...Tint color
+             is not propagated...etc.
+             */
             alert.view.tintColor = determineTintColor(from: view)
             present(alert, animated: true, completion: nil)
         } catch {
@@ -210,6 +216,12 @@ UIViewController, OCKTaskViewDelegate {
     open func didSelectTaskView(_ taskView: UIView & OCKTaskDisplayable, eventIndexPath: IndexPath) {
         do {
             let detailsViewController = try controller.initiateDetailsViewController(forIndexPath: eventIndexPath)
+            /*
+             TODO: Remove in the future. Explicitly setting the tint color here to support
+             current developers that have a SwiftUI lifecycle app and wrap this view
+             controller in a `UIViewControllerRepresentable` implementation...Tint color
+             is not propagated...etc.
+             */
             detailsViewController.view.tintColor = determineTintColor(from: view)
             present(detailsViewController, animated: true)
         } catch {

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKTaskViewController.swift
@@ -193,9 +193,7 @@ UIViewController, OCKTaskViewDelegate {
                 alert.popoverPresentationController?.sourceView = anchor
                 alert.popoverPresentationController?.permittedArrowDirections = .any
             }
-            if self.view.window?.tintColor == nil {
-                alert.view.tintColor = view.tintColor
-            }
+            alert.view.tintColor = determineTintColor(from: view)
             present(alert, animated: true, completion: nil)
         } catch {
             if delegate == nil {
@@ -212,9 +210,7 @@ UIViewController, OCKTaskViewDelegate {
     open func didSelectTaskView(_ taskView: UIView & OCKTaskDisplayable, eventIndexPath: IndexPath) {
         do {
             let detailsViewController = try controller.initiateDetailsViewController(forIndexPath: eventIndexPath)
-            if self.view.window?.tintColor == nil {
-                detailsViewController.view.tintColor = view.tintColor
-            }
+            detailsViewController.view.tintColor = determineTintColor(from: view)
             present(detailsViewController, animated: true)
         } catch {
             if delegate == nil {

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKTaskViewController.swift
@@ -193,6 +193,9 @@ UIViewController, OCKTaskViewDelegate {
                 alert.popoverPresentationController?.sourceView = anchor
                 alert.popoverPresentationController?.permittedArrowDirections = .any
             }
+            if self.view.window?.tintColor == nil {
+                alert.view.tintColor = view.tintColor
+            }
             present(alert, animated: true, completion: nil)
         } catch {
             if delegate == nil {
@@ -209,6 +212,9 @@ UIViewController, OCKTaskViewDelegate {
     open func didSelectTaskView(_ taskView: UIView & OCKTaskDisplayable, eventIndexPath: IndexPath) {
         do {
             let detailsViewController = try controller.initiateDetailsViewController(forIndexPath: eventIndexPath)
+            if self.view.window?.tintColor == nil {
+                detailsViewController.view.tintColor = view.tintColor
+            }
             present(detailsViewController, animated: true)
         } catch {
             if delegate == nil {


### PR DESCRIPTION
When an app is using the SwiftUI lifecycle (`App` protocol) and doesn't use the scene delegate, the `tintColor` isn't properly inherited in `surveyViewController` in `OCKSurveyTaskViewController` from the calling view. This occurs with the latest commit on the main of CareKit and the latest commit on the main of ResearchKit (https://github.com/ResearchKit/ResearchKit/commit/a89059f5dc2a91f36785b184f914b5e5fdb05877)

The fix is to set the `tintColor` directly when setting up the ResearchKit task. This works for the most part with the exception of the ResearchKit `Done` button and some others (selecting a survey option) still don't inherit the color from the calling view. I believe the button issue is a ResearchKit issue and not a CareKit issue. When the ResearchKit `Done` button is disabled because the required questions hasn't been answered, the button shows the correct `tintColor`. 

Since the app no longer depends on `UIWindow`; `ORKWindowTintcolor` doesn't work properly for a SwiftUI lifecycle based app, forcing everything to the default tintColor not set by the SwiftUI based app. This also causes issues when displaying a contact or tapping in other items in a list view. The problems using ResearchKit (https://github.com/ResearchKit/ResearchKit/commit/a89059f5dc2a91f36785b184f914b5e5fdb05877) look like below:

## The button still has the wrong color
<img src="https://user-images.githubusercontent.com/8621344/201484103-a14a78bf-8e4f-46c1-9602-9ce02006b9ea.png" width="300">

## The disabled button still has the correct color
<img src="https://user-images.githubusercontent.com/8621344/201484119-828df255-8896-43d8-9661-ace18e773be0.png" width="300">

## The enabled button still has the incorrect color
<img src="https://user-images.githubusercontent.com/8621344/201484134-87b5d2dd-019d-4048-8aa5-cc3c8acd35c5.png" width="300">

## The selected answers still have the incorrect color
<img src="https://user-images.githubusercontent.com/8621344/201485101-ebdb9872-a095-4dbf-abe5-23a6ae92b2d2.png" width="300">


