### PR TITLE
Fix Xcode errors when using Framework in SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,10 +40,7 @@ let package = Package(
         .target(
             name: "CareKitStore",
             path: "CareKitStore/CareKitStore",
-            exclude: ["Info.plist"],
-            resources: [
-                .process("CoreData/Migrations/2_0To2_1/2.0_2.1_Mapping.xcmappingmodel")
-            ]),
+            exclude: ["Info.plist", "CoreData/Migrations/2_0To2_1/2.0_2.1_Mapping.xcmappingmodel"]),
 
         .target(
             name: "CareKitFHIR",


### PR DESCRIPTION
One way to partially address #665 is to exclude the migrations file, `CoreData/Migrations/2_0To2_1/2.0_2.1_Mapping.xcmappingmodel` when using SPM. Though this is not ideal, we can recommend that users who need to migrate from an old version of OCKStore use drop the CareKit project into their projects directly as specified in https://github.com/carekit-apple/CareKit/issues/665#issuecomment-1377562666.

People already using the current data store won't be effected by this change.