### PR TITLE
Build CareKitStore and CareKitFHIR for macOS

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,13 +15,8 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=16.2,name=iPhone\ 14\ Pro\ Max', 'platform=watchOS\ Simulator,OS=9.1,name=Apple\ Watch\ Series\ 5\ \(40mm\)', platform=macOS]
+        destination: ['platform=iOS\ Simulator,OS=16.2,name=iPhone\ 14\ Pro\ Max', 'platform=watchOS\ Simulator,OS=9.1,name=Apple\ Watch\ Series\ 5\ \(40mm\)']
         scheme: ['CareKit', 'CareKitStore', 'CareKitUI', 'CareKitFHIR']
-        exclude:
-          - destination: 'platform=macOS'
-            scheme: 'CareKit' 
-          - destination: 'platform=macOS'
-            scheme: 'CareKitUI' 
     steps:
       - uses: actions/checkout@v2
       - name: Set Xcode Version

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=16.3,name=iPhone\ 14\ Pro\ Max', 'platform=watchOS\ Simulator,OS=9.2,name=Apple\ Watch\ Series\ 5\ \(40mm\)', 'platform=macOS']
+        destination: ['platform=iOS\ Simulator,OS=16.4,name=iPhone\ 14\ Pro\ Max', 'platform=watchOS\ Simulator,OS=9.4,name=Apple\ Watch\ Series\ 5\ \(40mm\)', 'platform=macOS']
         scheme: ['CareKit', 'CareKitStore', 'CareKitUI', 'CareKitFHIR']
         exclude:
           - destination: 'platform=macOS'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,15 +12,20 @@ concurrency:
 
 jobs:        
   test:
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=16.2,name=iPhone\ 14\ Pro\ Max', 'platform=watchOS\ Simulator,OS=9.1,name=Apple\ Watch\ Series\ 5\ \(40mm\)']
+        destination: ['platform=iOS\ Simulator,OS=16.3,name=iPhone\ 14\ Pro\ Max', 'platform=watchOS\ Simulator,OS=9.2,name=Apple\ Watch\ Series\ 5\ \(40mm\)', 'platform=macOS']
         scheme: ['CareKit', 'CareKitStore', 'CareKitUI', 'CareKitFHIR']
+        exclude:
+          - destination: 'platform=macOS'
+            scheme: 'CareKit' 
+          - destination: 'platform=macOS'
+            scheme: 'CareKitUI' 
     steps:
       - uses: actions/checkout@v2
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_14.2.app
+        run: sudo xcode-select -s /Applications/Xcode_14.3.app
       - name: Use multiple cores
         run: defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
       - name: Build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,10 +17,11 @@ jobs:
       matrix:
         destination: ['platform=iOS\ Simulator,OS=16.2,name=iPhone\ 14\ Pro\ Max', 'platform=watchOS\ Simulator,OS=9.1,name=Apple\ Watch\ Series\ 5\ \(40mm\)', platform=macOS]
         scheme: ['CareKit', 'CareKitStore', 'CareKitUI', 'CareKitFHIR']
-        - destination: 'platform=macOS'
-          scheme: 'CareKit' 
-        - destination: 'platform=macOS'
-          scheme: 'CareKitUI' 
+        exclude:
+          - destination: 'platform=macOS'
+            scheme: 'CareKit' 
+          - destination: 'platform=macOS'
+            scheme: 'CareKitUI' 
     steps:
       - uses: actions/checkout@v2
       - name: Set Xcode Version

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,8 +15,12 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=16.2,name=iPhone\ 14\ Pro\ Max', 'platform=watchOS\ Simulator,OS=9.1,name=Apple\ Watch\ Series\ 5\ \(40mm\)']
+        destination: ['platform=iOS\ Simulator,OS=16.2,name=iPhone\ 14\ Pro\ Max', 'platform=watchOS\ Simulator,OS=9.1,name=Apple\ Watch\ Series\ 5\ \(40mm\)', platform=macOS]
         scheme: ['CareKit', 'CareKitStore', 'CareKitUI', 'CareKitFHIR']
+        - destination: 'platform=macOS'
+          scheme: 'CareKit' 
+        - destination: 'platform=macOS'
+          scheme: 'CareKitUI' 
     steps:
       - uses: actions/checkout@v2
       - name: Set Xcode Version

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -23,7 +23,7 @@ jobs:
           - destination: 'platform=macOS'
             scheme: 'CareKitUI' 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set Xcode Version
         run: sudo xcode-select -s /Applications/Xcode_14.3.app
       - name: Use multiple cores

--- a/.spi.yml
+++ b/.spi.yml
@@ -3,7 +3,6 @@ builder:
    configs:
    - documentation_targets: ["CareKit", "CareKitUI", "CareKitStore", "CareKitFHIR"]
      platform: ios
-   - platform: ios
      scheme: "CareKit"
    - platform: watchos
      scheme: "CareKit"

--- a/CareKitFHIR/CareKitFHIR.xcodeproj/project.pbxproj
+++ b/CareKitFHIR/CareKitFHIR.xcodeproj/project.pbxproj
@@ -528,6 +528,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = org.carekit.CareKitFHIR;
@@ -535,7 +536,7 @@
 				RUN_DOCUMENTATION_COMPILER = YES;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -568,6 +569,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = org.carekit.CareKitFHIR;
@@ -575,7 +577,7 @@
 				RUN_DOCUMENTATION_COMPILER = YES;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
@@ -599,10 +601,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Apple.com.CareKitFHIRTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -626,10 +629,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Apple.com.CareKitFHIRTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;

--- a/CareKitStore/CareKitStore.xcodeproj/project.pbxproj
+++ b/CareKitStore/CareKitStore.xcodeproj/project.pbxproj
@@ -1386,6 +1386,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = org.carekit.CareKitStore;
@@ -1393,7 +1394,7 @@
 				RUN_DOCUMENTATION_COMPILER = YES;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_UIKITFORMAC = NO;
@@ -1427,6 +1428,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = org.carekit.CareKitStore;
@@ -1434,7 +1436,7 @@
 				RUN_DOCUMENTATION_COMPILER = YES;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_UIKITFORMAC = NO;
@@ -1449,6 +1451,7 @@
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = CareKitStoreTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -1457,10 +1460,12 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Apple.CareKitStoreTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "watchsimulator watchos iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				TARGETED_DEVICE_FAMILY = "1,2,4";
 			};
 			name = Debug;
@@ -1470,6 +1475,7 @@
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = CareKitStoreTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -1478,10 +1484,12 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Apple.CareKitStoreTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "watchsimulator watchos iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				TARGETED_DEVICE_FAMILY = "1,2,4";
 			};
 			name = Release;

--- a/CareKitStore/CareKitStore/CoreData/OCKStore.swift
+++ b/CareKitStore/CareKitStore/CoreData/OCKStore.swift
@@ -244,7 +244,9 @@ open class OCKStore: OCKStoreProtocol, Equatable {
         descriptor.url = storeURL
         descriptor.type = NSSQLiteStoreType
         descriptor.shouldAddStoreAsynchronously = false
+        #if !os(macOS)
         descriptor.setOption(storeType.securityClass as NSObject, forKey: NSPersistentStoreFileProtectionKey)
+        #endif
         container.persistentStoreDescriptions = [descriptor]
 
         // This closure runs synchronously because of the settings above

--- a/CareKitStore/CareKitStore/CoreData/Synchronization/OCKWatchConnectivityPeer.swift
+++ b/CareKitStore/CareKitStore/CoreData/Synchronization/OCKWatchConnectivityPeer.swift
@@ -28,6 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if canImport(WatchConnectivity)
 import Foundation
 import WatchConnectivity
 
@@ -245,3 +246,4 @@ open class OCKWatchConnectivityPeer: OCKRemoteSynchronizable {
         #endif
     }
 }
+#endif

--- a/CareKitStore/CareKitStore/StoreCoordinator/OCKStoreCoordinator.swift
+++ b/CareKitStore/CareKitStore/StoreCoordinator/OCKStoreCoordinator.swift
@@ -348,7 +348,7 @@ open class OCKStoreCoordinator: OCKAnyStoreProtocol {
     ///   - outcome: The outcome that needs to be written.
     open func outcomeStore(_ store: OCKAnyReadOnlyOutcomeStore, shouldHandleWritingOutcome outcome: OCKAnyOutcome) -> Bool {
 
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
         if #available(iOS 15, watchOS 8, *) {
             // Only the HK passthrough store should handle HK outcomes
             if outcome is OCKHealthKitOutcome || store is OCKHealthKitPassthroughStore {

--- a/CareKitStore/CareKitStoreTests/CoreDataSchema/TestCoreDataSchema+Migrations.swift
+++ b/CareKitStore/CareKitStoreTests/CoreDataSchema/TestCoreDataSchema+Migrations.swift
@@ -76,7 +76,9 @@ class TestCoreDataSchemaMigrations: XCTestCase {
         descriptor.url = dir.appendingPathComponent("SampleStore2.0.sqlite")
         descriptor.type = NSSQLiteStoreType
         descriptor.shouldAddStoreAsynchronously = false
+        #if !os(macOS)
         descriptor.setOption(FileProtectionType.complete as NSObject, forKey: NSPersistentStoreFileProtectionKey)
+        #endif
         descriptor.shouldMigrateStoreAutomatically = true
 
         let container = NSPersistentContainer(name: "sut", managedObjectModel: sharedManagedObjectModel)

--- a/CareKitStore/CareKitStoreTests/TestWatchConnectivityPeer.swift
+++ b/CareKitStore/CareKitStoreTests/TestWatchConnectivityPeer.swift
@@ -28,6 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if canImport(WatchConnectivity)
 @testable import CareKitStore
 import XCTest
 
@@ -149,3 +150,4 @@ private final class MockPeer: OCKWatchConnectivityPeer {
         self.peersStore.resolveConflicts(completion: completion)
     }
 }
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "CareKit",
     defaultLocalization: "en",
-    platforms: [.iOS(.v14), .macOS(.v11), .watchOS(.v7)],
+    platforms: [.iOS(.v14), .macOS(.v13), .watchOS(.v7)],
     products: [
         .library(
             name: "CareKit",


### PR DESCRIPTION
- [x] Build CareKitStore and CareKitFHIR for macOS 13+
- [x] Fix documentation build on SPI
- [x] Bump CI to macOS 13 and Xcode 14.3

## Notes
- Cannot build CareKit due to CareKitUI using UIKit, UIColor, etc. This seems like it would need a lot more changes. I speculate with future changes, the SwiftUI based CareKit views build for macOS
- HealthKit is only available on macOS 13+
- ~~Can't build/test in GitHub actions due to macOS 12 only being available, so I removed the changes in the CI for now. I have tested locally, and all tests pass for CareKitStore and CareKitFHIR on macOS 13~~