### PR TITLE
Fix ios platform in .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,7 +3,6 @@ builder:
    configs:
    - documentation_targets: ["CareKit", "CareKitUI", "CareKitStore", "CareKitFHIR"]
      platform: ios
-   - platform: ios
      scheme: "CareKit"
    - platform: watchos
      scheme: "CareKit"


### PR DESCRIPTION
Hi @cbaker6 , our documentation test picked up that docs aren't properly generated for the package and the reason is probably the duplicate `platform: ios` entry in `.spi.yml`. This should fix that.