### PR TITLE
Fix: Don’t deploy CareKitFHIR documentation to Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,7 +1,7 @@
 version: 1
 builder:
    configs:
-   - documentation_targets: ["CareKit", "CareKitUI", "CareKitStore", "CareKitFHIR"]
+   - documentation_targets: ["CareKit", "CareKitUI", "CareKitStore"]
      platform: ios
    - platform: ios
      scheme: "CareKit"


### PR DESCRIPTION
Avoid publishing the CareKitFHIR documentation to Swift Package Index until the DocC catalog is polished. 