### PR TITLE
feat: Update OCKSurveyTaskViewController to support ResearchKit 3.0

### DIFF
--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -34,6 +34,7 @@ import CareKitUI
 import ResearchKit
 #if canImport(ResearchKitUI)
 import ResearchKitUI
+public typealias ORKTaskViewControllerFinishReason = ORKTaskFinishReason
 #endif
 import UIKit
 

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -32,6 +32,7 @@
 import CareKitStore
 import CareKitUI
 import ResearchKit
+import ResearchKitUI
 import UIKit
 
 // MARK: OCKSurveyTaskViewControllerDelegate

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -65,25 +65,12 @@ public protocol OCKSurveyTaskViewControllerDelegate: AnyObject {
 
 public extension OCKSurveyTaskViewControllerDelegate {
 
-    #if canImport(ResearchKitUI)
-
-    func surveyTask(
-        viewController: OCKSurveyTaskViewController,
-        for task: OCKAnyTask,
-        didFinish result: Result<ORKTaskFinishReason, Error>) {
-        // No-op
-    }
-
-    #else
-
     func surveyTask(
         viewController: OCKSurveyTaskViewController,
         for task: OCKAnyTask,
         didFinish result: Result<ORKTaskViewControllerFinishReason, Error>) {
         // No-op
     }
-
-    #endif
 
     func surveyTask(
         viewController: OCKSurveyTaskViewController,
@@ -219,68 +206,6 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKSurveyTaskViewS
     }
 
     // MARK: ORKTaskViewControllerDelegate
-    #if canImport(ResearchKitUI)
-
-    open func taskViewController(
-        _ taskViewController: ORKTaskViewController,
-        didFinishWith reason: ORKTaskFinishReason,
-        error: Error?) {
-
-        taskViewController.dismiss(animated: true, completion: nil)
-
-        guard let task = viewModel.first?.first?.task else {
-            assertionFailure("Task controller is missing its task")
-            return
-        }
-
-        if let error = error {
-            surveyDelegate?.surveyTask(
-                viewController: self,
-                for: task,
-                didFinish: .failure(error)
-            )
-            return
-        }
-
-        guard reason == .completed else {
-            return
-        }
-
-        let indexPath = IndexPath(item: 0, section: 0)
-        let event = viewModel[indexPath.section][indexPath.row]
-
-        guard let values = extractOutcome(taskViewController.result) else {
-            return
-        }
-
-        let outcome = OCKOutcome(
-            taskUUID: event.task.uuid,
-            taskOccurrenceIndex: event.scheduleEvent.occurrence,
-            values: values
-        )
-
-        store.addAnyOutcome(
-            outcome,
-            callbackQueue: .main) { result in
-
-            if case let .failure(error) = result {
-
-                self.surveyDelegate?.surveyTask(
-                    viewController: self,
-                    for: task,
-                    didFinish: .failure(error)
-                )
-            }
-
-            self.surveyDelegate?.surveyTask(
-                viewController: self,
-                for: task,
-                didFinish: .success(reason)
-            )
-        }
-    }
-
-    #else
 
     open func taskViewController(
         _ taskViewController: ORKTaskViewController,
@@ -340,8 +265,6 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKSurveyTaskViewS
             )
         }
     }
-
-    #endif
 
 }
 

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -254,7 +254,6 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKSurveyTaskViewS
             )
         }
     }
-
 }
 
 #endif

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -41,7 +41,7 @@ public protocol OCKSurveyTaskViewControllerDelegate: AnyObject {
     func surveyTask(
         viewController: OCKSurveyTaskViewController,
         for task: OCKAnyTask,
-        didFinish result: Result<ORKTaskViewControllerFinishReason, Error>)
+        didFinish result: Result<ORKTaskFinishReason, Error>)
 
     func surveyTask(
         viewController: OCKSurveyTaskViewController,
@@ -53,7 +53,7 @@ public extension OCKSurveyTaskViewControllerDelegate {
     func surveyTask(
         viewController: OCKSurveyTaskViewController,
         for task: OCKAnyTask,
-        didFinish result: Result<ORKTaskViewControllerFinishReason, Error>) {
+        didFinish result: Result<ORKTaskFinishReason, Error>) {
         // No-op
     }
 
@@ -194,7 +194,7 @@ open class OCKSurveyTaskViewController: OCKTaskViewController<OCKSurveyTaskViewS
     
     open func taskViewController(
         _ taskViewController: ORKTaskViewController,
-        didFinishWith reason: ORKTaskViewControllerFinishReason,
+        didFinishWith reason: ORKTaskFinishReason,
         error: Error?) {
 
         taskViewController.dismiss(animated: true, completion: nil)

--- a/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
+++ b/CareKit/CareKit/iOS/Task/View Controllers/OCKSurveyTaskViewController.swift
@@ -42,21 +42,10 @@ import UIKit
 
 public protocol OCKSurveyTaskViewControllerDelegate: AnyObject {
 
-    #if canImport(ResearchKitUI)
-
-    func surveyTask(
-        viewController: OCKSurveyTaskViewController,
-        for task: OCKAnyTask,
-        didFinish result: Result<ORKTaskFinishReason, Error>)
-
-    #else
-
     func surveyTask(
         viewController: OCKSurveyTaskViewController,
         for task: OCKAnyTask,
         didFinish result: Result<ORKTaskViewControllerFinishReason, Error>)
-
-    #endif
 
     func surveyTask(
         viewController: OCKSurveyTaskViewController,


### PR DESCRIPTION
Some minor changes are required to support RK 3.0. 
- https://github.com/carekit-apple/CareKit/pull/711/commits/c9ab6388ce592896c74275cae830654b6035804e Supports both old and new RK, but has redundant code
- https://github.com/carekit-apple/CareKit/pull/711/commits/d1a87996001487789f13cdc3d9bd68101f5a8b28 These changes will make CK not compatible with older versions of RK and doesn't have redundant code

I've left the current commit with the redundant code, but have tested both. The former works with old/new versions of RK. The second only works with new versions of RK