### PR TITLE
feat: Allow developers to create instances of LinearCareTaskProgress and BinaryCareTaskProgress

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=17.4,name=iPhone\ 15\ Pro\ Max', 'platform=watchOS\ Simulator,OS=10.4,name=Apple\ Watch\ Series\ 7\ \(45mm\)']
+        destination: ['platform=iOS\ Simulator,OS=17.5,name=iPhone\ 15\ Pro\ Max', 'platform=watchOS\ Simulator,OS=10.5,name=Apple\ Watch\ Series\ 7\ \(45mm\)']
         scheme: ['CareKit', 'CareKitStore', 'CareKitUI', 'CareKitFHIR']
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Build
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -verbose -workspace CKWorkspace.xcworkspace -scheme ${{ matrix.scheme }} -destination ${{ matrix.destination }} build test | xcpretty

--- a/CareKitStore/CareKitStore/TaskProgress/AggregatedCareTaskProgress.swift
+++ b/CareKitStore/CareKitStore/TaskProgress/AggregatedCareTaskProgress.swift
@@ -93,7 +93,7 @@ public struct AggregatedCareTaskProgress: CareTaskProgress, Hashable, Sendable {
         self.fractionCompleted = fractionCompleted
     }
 
-    /// Create user progress  by computing and combining the progress for multiple tasks using a single strategy.
+    /// Create user progress by computing and combining the progress for multiple tasks using a single strategy.
     ///
     /// - Parameters:
     ///   - events: The events used to compute progress.

--- a/CareKitStore/CareKitStore/TaskProgress/BinaryCareTaskProgress.swift
+++ b/CareKitStore/CareKitStore/TaskProgress/BinaryCareTaskProgress.swift
@@ -55,10 +55,10 @@ public struct BinaryCareTaskProgress: CareTaskProgress, Hashable, Sendable {
         return percentCompleted
     }
 
-    /// Create user progress by specifying complete or incomplete.
+    /// Create user progress for a task that is either completed or incomplete.
     ///
     /// - Parameters:
-    ///   - isCompleted: The user progress for a task is either completed or incomplete.
+    ///   - isCompleted: True if the task is considered completed.
     public init(isCompleted: Bool) {
         self.isCompleted = isCompleted
     }

--- a/CareKitStore/CareKitStore/TaskProgress/BinaryCareTaskProgress.swift
+++ b/CareKitStore/CareKitStore/TaskProgress/BinaryCareTaskProgress.swift
@@ -54,4 +54,12 @@ public struct BinaryCareTaskProgress: CareTaskProgress, Hashable, Sendable {
         let percentCompleted: Double = isCompleted ? 1 : 0
         return percentCompleted
     }
+
+    /// Create user progress by specifying complete or incomplete.
+    ///
+    /// - Parameters:
+    ///   - isCompleted: The user progress for a task is either completed or incomplete.
+    public init(isCompleted: Bool) {
+        self.isCompleted = isCompleted
+    }
 }

--- a/CareKitStore/CareKitStore/TaskProgress/LinearCareTaskProgress.swift
+++ b/CareKitStore/CareKitStore/TaskProgress/LinearCareTaskProgress.swift
@@ -64,7 +64,7 @@ public struct LinearCareTaskProgress: CareTaskProgress, Hashable, Sendable {
         didSet { Self.validate(goal: goal) }
     }
 
-    init(
+    public init(
         value: Double,
         goal: Double? = nil
     ) {

--- a/CareKitStore/CareKitStore/TaskProgress/LinearCareTaskProgress.swift
+++ b/CareKitStore/CareKitStore/TaskProgress/LinearCareTaskProgress.swift
@@ -64,12 +64,11 @@ public struct LinearCareTaskProgress: CareTaskProgress, Hashable, Sendable {
         didSet { Self.validate(goal: goal) }
     }
 
-    /// Create user progress by specifying the current value and goal of the progress. 
+    /// Create a structure that defines user progress for a task that can be completed over time.
     /// 
     /// - Parameters: 
-    ///   - value: The current value of a users progress for the task. 
-    ///   - goal: The goal user progress value to consider the task complete. If there's no goal, the task is considered completed if
-    /// the progress value is greater than zero.
+    ///   - value: The progress that's been made towards reaching the goal.
+    ///   - goal: A value that indicates whether the task is complete. When there is no goal, the value is `nil`.  The task is considered completed if the progress value is greater than zero.
     public init(
         value: Double,
         goal: Double? = nil

--- a/CareKitStore/CareKitStore/TaskProgress/LinearCareTaskProgress.swift
+++ b/CareKitStore/CareKitStore/TaskProgress/LinearCareTaskProgress.swift
@@ -64,6 +64,12 @@ public struct LinearCareTaskProgress: CareTaskProgress, Hashable, Sendable {
         didSet { Self.validate(goal: goal) }
     }
 
+    /// Create user progress by specifying the current value and goal of the progress. 
+    /// 
+    /// - Parameters: 
+    ///   - value: The current value of a users progress for the task. 
+    ///   - goal: The goal user progress value to consider the task complete. If there's no goal, the task is considered completed if
+    /// the progress value is greater than zero.
     public init(
         value: Double,
         goal: Double? = nil

--- a/CareKitStore/CareKitStoreTests/TaskProgress/TestAggregatedCareTaskProgress.swift
+++ b/CareKitStore/CareKitStoreTests/TaskProgress/TestAggregatedCareTaskProgress.swift
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@testable import CareKitStore
+import CareKitStore
 
 import XCTest
 

--- a/CareKitStore/CareKitStoreTests/TaskProgress/TestBinaryCareTaskProgress.swift
+++ b/CareKitStore/CareKitStoreTests/TaskProgress/TestBinaryCareTaskProgress.swift
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@testable import CareKitStore
+import CareKitStore
 
 import Foundation
 import XCTest

--- a/CareKitStore/CareKitStoreTests/TaskProgress/TestLinearCareTaskProgress.swift
+++ b/CareKitStore/CareKitStoreTests/TaskProgress/TestLinearCareTaskProgress.swift
@@ -28,7 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@testable import CareKitStore
+import CareKitStore
 
 import Foundation
 import XCTest


### PR DESCRIPTION
Making the initializer public allows developers create linear progress, similar to https://github.com/carekit-apple/CareKit/blob/be7749c23c0601a81d5aaf5d169b51b1d1e4b80b/CareKitStore/CareKitStore/TaskProgress/AggregatedCareTaskProgress.swift#L96-L110