### PR TITLE
fix: KeyPath crash when querying CareStore

### DIFF
--- a/CareKitStore/CareKitStore/StoreCoordinator/OCKPersistentStoreCoordinator+Outcomes.swift
+++ b/CareKitStore/CareKitStore/StoreCoordinator/OCKPersistentStoreCoordinator+Outcomes.swift
@@ -45,7 +45,7 @@ extension OCKStoreCoordinator {
         }
 
         let sortDescriptor = NSSortDescriptor(
-            keyPath: \OCKAnyOutcome.id,
+            keyPath: \OCKCDOutcome.id,
             ascending: true
         )
 

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKCarePlanQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKCarePlanQuery.swift
@@ -42,9 +42,9 @@ public struct OCKCarePlanQuery: Equatable, OCKQueryProtocol {
         var nsSortDescriptor: NSSortDescriptor {
             switch self {
             case let .effectiveDate(ascending):
-                return NSSortDescriptor(keyPath: \OCKAnyCarePlan.effectiveDate, ascending: ascending)
+                return NSSortDescriptor(keyPath: \OCKCDCarePlan.effectiveDate, ascending: ascending)
             case let .title(ascending):
-                return NSSortDescriptor(keyPath: \OCKAnyCarePlan.title, ascending: ascending)
+                return NSSortDescriptor(keyPath: \OCKCDCarePlan.title, ascending: ascending)
             }
         }
     }

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKContactQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKContactQuery.swift
@@ -43,11 +43,11 @@ public struct OCKContactQuery: Equatable, OCKQueryProtocol {
         var nsSortDescriptor: NSSortDescriptor {
             switch self {
             case let .effectiveDate(ascending):
-                return NSSortDescriptor(keyPath: \OCKAnyContact.effectiveDate, ascending: ascending)
+                return NSSortDescriptor(keyPath: \OCKCDContact.effectiveDate, ascending: ascending)
             case let .givenName(ascending):
-                return NSSortDescriptor(keyPath: \OCKAnyContact.name.givenName, ascending: ascending)
+                return NSSortDescriptor(keyPath: \OCKCDContact.name.givenName, ascending: ascending)
             case let .familyName(ascending):
-                return NSSortDescriptor(keyPath: \OCKAnyContact.name.familyName, ascending: ascending)
+                return NSSortDescriptor(keyPath: \OCKCDContact.name.familyName, ascending: ascending)
             }
         }
     }

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKPatientQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKPatientQuery.swift
@@ -44,13 +44,13 @@ public struct OCKPatientQuery: Equatable, OCKQueryProtocol {
         var nsSortDescriptor: NSSortDescriptor {
             switch self {
             case let .groupIdentifier(ascending):
-                return NSSortDescriptor(keyPath: \OCKAnyPatient.groupIdentifier, ascending: ascending)
+                return NSSortDescriptor(keyPath: \OCKCDPatient.groupIdentifier, ascending: ascending)
             case let .givenName(ascending):
-                return NSSortDescriptor(keyPath: \OCKAnyPatient.name.givenName, ascending: ascending)
+                return NSSortDescriptor(keyPath: \OCKCDPatient.name.givenName, ascending: ascending)
             case let .familyName(ascending):
-                return NSSortDescriptor(keyPath: \OCKAnyPatient.name.familyName, ascending: ascending)
+                return NSSortDescriptor(keyPath: \OCKCDPatient.name.familyName, ascending: ascending)
             case let .effectiveDate(ascending):
-                return NSSortDescriptor(keyPath: \OCKAnyPatient.effectiveDate, ascending: ascending)
+                return NSSortDescriptor(keyPath: \OCKCDPatient.effectiveDate, ascending: ascending)
             }
         }
     }

--- a/CareKitStore/CareKitStore/Structs/Queries/OCKTaskQuery.swift
+++ b/CareKitStore/CareKitStore/Structs/Queries/OCKTaskQuery.swift
@@ -44,19 +44,19 @@ public struct OCKTaskQuery: Equatable, OCKQueryProtocol {
 
             case let .effectiveDate(ascending):
                 return NSSortDescriptor(
-                    keyPath: \OCKAnyTask.effectiveDate,
+                    keyPath: \OCKCDTask.effectiveDate,
                     ascending: ascending
                 )
 
             case let .groupIdentifier(ascending):
                 return NSSortDescriptor(
-                    keyPath: \OCKAnyTask.groupIdentifier,
+                    keyPath: \OCKCDTask.groupIdentifier,
                     ascending: ascending
                 )
 
             case let .title(ascending):
                 return NSSortDescriptor(
-                    keyPath: \OCKAnyTask.title,
+                    keyPath: \OCKCDTask.title,
                     ascending: ascending
                 )
             }


### PR DESCRIPTION
The framework crashes when you stream using: `OCKOutcomeQuery`, `OCKCarePlanQuery`, `OCKContactQuery`, `OCKPatientQuery`, `OCKTaskQuery`. Most likely happens with a standard fetch as well, but I didn't test those...

Resulting in:

<img width="1603" alt="image" src="https://github.com/carekit-apple/CareKit/assets/8621344/1ab715af-a01b-4282-9a58-f828ac43c8d4">

<img width="1609" alt="image" src="https://github.com/carekit-apple/CareKit/assets/8621344/25f5f250-12c7-449f-8903-94d168b6348d">


This can be replicated by using a simple streaming query within a view:

```swift
// A view that has the CareStore in it's environment 
struct SimpleCareView: View {

    @CareStoreFetchRequest(query: query()) private var outcomes

    var body: some View {
         // I want to display outcomes...
    }

    // Simple query
    static func query() -> OCKOutcomeQuery {
        OCKOutcomeQuery(for: Date())
    }
}
```

This most likely results from `NSSortDescriptor` not liking keyPaths of value types and prefers reference types (I'm guessing as I'm seen some other issues in the past with value type keyPaths and using NS...). In addition, since we are querying from CoreData, we should probably use the CD representations. Lastly, all other uses of `NSSortDescriptor` in `CareKitStore` use their `OCKCD...` counterparts instead of the value type counterparts. 

## Note

When I ran the test suite, none of the current tests for the framework hit the lines I changed which is probably why this wasn't caught 🙃. This is because the tests are conducted at a lower level than the value type representations, but solidifies that we should use the CoreData Entity representations for querying keyPaths: https://github.com/carekit-apple/CareKit/blob/7416cce107875e58d0dbfd54afb16e007ef79033/CareKitStore/CareKitStoreTests/Streaming/TestCoreDataQueryMonitor.swift#L65-L70

https://github.com/carekit-apple/CareKit/blob/7416cce107875e58d0dbfd54afb16e007ef79033/CareKitStore/CareKitStore/Streaming/CoreDataQueryMonitor.swift#L47-L63