### PR TITLE
fix: HealthKit store crash when querying objects with zero descriptors

### DIFF
--- a/CareKitStore/CareKitStore/HealthKit/OCKHealthKitPassthroughStore+EventUtilities.swift
+++ b/CareKitStore/CareKitStore/HealthKit/OCKHealthKitPassthroughStore+EventUtilities.swift
@@ -396,6 +396,12 @@ extension OCKHealthKitPassthroughStore {
 
         let descriptors = makeQueryDescriptors(for: events)
 
+        // Only perform query if there are one or more descriptors.
+        guard descriptors.count > 0 else {
+            completion(.success([]))
+            return
+        }
+
         // We're not storing the query anchor because we're only fetching the
         // initial samples, and aren't concerned with changes that occur to the samples
         // in the HK store.

--- a/CareKitStore/CareKitStore/Streaming/HealthKitQueryMonitor.swift
+++ b/CareKitStore/CareKitStore/Streaming/HealthKitQueryMonitor.swift
@@ -57,6 +57,9 @@ final class HealthKitQueryMonitor: QueryMonitor {
         // Don't perform the query again if it's already running
         guard query == nil else { return }
 
+        // Only perform query if there are one or more descriptors.
+        guard queryDescriptors.count > 0 else { return }
+
         // Create a query for the initial results
         query = HKAnchoredObjectQuery(
             queryDescriptors: queryDescriptors,


### PR DESCRIPTION
The HealthKit store doesn't like being queried when there are no descriptors (no Care Events). When querying when there's no descriptors, this will automatically cause the app crash below:

<img width="1107" alt="image" src="https://github.com/user-attachments/assets/67ff8c83-98ac-4f97-9817-746667a218ea">

## Logs
```bash
*** Terminating app due to uncaught exception 'HKQueryValidationFailureException', reason: 'HKAnchoredObjectQuery data type must be non-nil'
*** First throw call stack:
(
	0   CoreFoundation                      0x00000001804b757c __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x000000018008eda8 objc_exception_throw + 72
	2   CoreFoundation                      0x00000001804b748c -[NSException initWithCoder:] + 0
	3   HealthKit                           0x000000019d5302c0 -[HKAnchoredObjectQuery queue_validate] + 164
	4   HealthKit                           0x000000019d51afe4 __72-[HKQuery activateWithClientQueue:healthStore:delegate:time:completion:]_block_invoke.76 + 496
	5   libdispatch.dylib                   0x00000001013827b8 _dispatch_client_callout + 16
	6   libdispatch.dylib                   0x0000000101393530 _dispatch_lane_barrier_sync_invoke_and_complete + 144
	7   HealthKit                           0x000000019d51ab20 -[HKQuery activateWithClientQueue:healthStore:delegate:time:completion:] + 376
	8   HealthKit                           0x000000019d4a0e44 -[HKHealthStore executeQuery:activationHandler:] + 240
	9   Assuage.debug.dylib                 0x0000000108038ee8 $s12CareKitStore09OCKHealthb11PassthroughC0C011fetchHealthB7Samples6events10completionySayAA8OCKEventVyAA0dB4TaskVAA0dB7OutcomeVGG_ys6ResultOySayAA6SampleVGs5Error_pGctF + 252
	10  Assuage.debug.dylib                 0x0000000108042568 $s12CareKitStore09OCKHealthb11PassthroughC0C11fetchEvents5query13callbackQueue10completionyAA13OCKEventQueryV_So17OS_dispatch_queueCys6ResultOySayAA0L0VyAA0dB4TaskVAA0dB7OutcomeVGGAA13OCKStoreErr	11  Assuage.debug.dylib                 0x00000001080433c0 $s12CareKitStore09OCKHealthb11PassthroughC0C13fetchOutcomes33_555E1FEFC67AA75C04CF71818620FDA9LL6events0F7Samples021updateCumulativeSumOfO010completionySayAA8OCKEventVyAA0dB4TaskVAA0dB7OutcomeVGG	12  Assuage.debug.dylib                 0x0000000108043000 $s12CareKitStore09OCKHealthb11PassthroughC0C11fetchEvents5query13callbackQueue0F7Samples021updateCumulativeSumOfK010completionyAA12OCKTaskQueryV_So17OS_dispatch_queueCySayAA8OCKEventVyAA0dB4TaskV	13  Assuage.debug.dylib                 0x000000010804322c $s12CareKitStore09OCKHealthb11PassthroughC0C11fetchEvents5query13callbackQueue0F7Samples021updateCumulativeSumOfK010completionyAA12OCKTaskQueryV_So17OS_dispatch_queueCySayAA8OCKEventVyAA0dB4TaskV	14  Assuage.debug.dylib                 0x0000000108089ce8 $s12CareKitStore016OCKReadOnlyEventC0PA2A21OCKAnyVersionableTask0I0RpzrlE18fetchPartialEvents5query13callbackQueue10completionyAA12OCKTaskQueryV_So17OS_dispatch_queueCys6ResultOySayAA0kF0VyAFGGAA	15  Assuage.debug.dylib                 0x000000010808a008 $s12CareKitStore016OCKReadOnlyEventC0PA2A21OCKAnyVersionableTask0I0RpzrlE18fetchPartialEvents5query13callbackQueue10completionyAA12OCKTaskQueryV_So17OS_dispatch_queueCys6ResultOySayAA0kF0VyAFGGAA	16  Assuage.debug.dylib                 0x0000000108091864 $ss6ResultOySaySay4Task12CareKitStore011OCKReadablebE0PQzGGAD13OCKStoreErrorOGIegg_ALIegn_AD016OCKReadOnlyEventE0RzAD017OCKAnyVersionableB0ACRpzlTR + 80
	17  Assuage.debug.dylib                 0x000000010805fa80 $s12CareKitStore9aggregate_13callbackQueue10completionySayyys6ResultOyxq_GccG_So17OS_dispatch_queueCyAFySayxGq_Gcts5ErrorR_r0_lFyycfU0_ + 520
	18  Assuage.debug.dylib                 0x0000000107ff0004 $sIeg_IeyB_TR + 48
	19  libdispatch.dylib                   0x0000000101380ec0 _dispatch_call_block_and_release + 24
	20  libdispatch.dylib                   0x00000001013827b8 _dispatch_client_callout + 16
	21  libdispatch.dylib                   0x000000010139245c _dispatch_main_queue_drain + 1224
	22  libdispatch.dylib                   0x0000000101391f84 _dispatch_main_queue_callback_4CF + 40
	23  CoreFoundation                      0x000000018041b2dc __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
	24  CoreFoundation                      0x0000000180415838 __CFRunLoopRun + 1944
	25  CoreFoundation                      0x0000000180414c24 CFRunLoopRunSpecific + 552
	26  GraphicsServices                    0x000000019020ab10 GSEventRunModal + 160
	27  UIKitCore                           0x0000000185ad82fc -[UIApplication _run] + 796
	28  UIKitCore                           0x0000000185adc4f4 UIApplicationMain + 124
	29  SwiftUI                             0x00000001d290b41c $s7SwiftUI17KitRendererCommon33_ACC2C5639A7D76F611E170E831FCA491LLys5NeverOyXlXpFAESpySpys4Int8VGSgGXEfU_ + 164
	30  SwiftUI                             0x00000001d290b144 $s7SwiftUI6runAppys5NeverOxAA0D0RzlF + 84
	31  SwiftUI                             0x00000001d266bef4 $s7SwiftUI3AppPAAE4mainyyFZ + 148
	32  Assuage.debug.dylib                 0x0000000107949a88 $s7Assuage0A3AppV5$mainyyFZ + 40
	33  Assuage.debug.dylib                 0x0000000107949e08 __debug_main_executable_dylib_entry_point + 12
	34  dyld                                0x0000000100869410 start_sim + 20
	35  ???                                 0x0000000100746274 0x0 + 4302594676
)
libc++abi: terminating due to uncaught exception of type NSException
```

## Fix
Check if there any descriptors created, if not, don't attempt to query the HealthKit store. Possibly addresses #624 and #626