### PR TITLE
fix: App crash when faults are not realized on CoreData objects

### DIFF
--- a/CareKitStore/CareKitStore/CoreData/Synchronization/OCKStore+Synchronization.swift
+++ b/CareKitStore/CareKitStore/CoreData/Synchronization/OCKStore+Synchronization.swift
@@ -90,6 +90,7 @@ extension NSManagedObjectContext {
 
         let request = NSFetchRequest<T>(entityName: entityName)
         request.fetchLimit = 1
+        request.returnsObjectsAsFaults = false
 
         request.predicate = NSPredicate(
             format: "%K IN %@",
@@ -105,6 +106,7 @@ extension NSManagedObjectContext {
         let request = NSFetchRequest<T>(entityName: String(describing: T.self))
         request.fetchLimit = 1
         request.predicate = NSPredicate(format: "%K == %@", #keyPath(OCKCDObject.uuid), uuid as CVarArg)
+        request.returnsObjectsAsFaults = false
         guard let object = try fetch(request).first else {
             throw OCKStoreError.fetchFailed(reason: "No object \(T.self) for UUID \(uuid)")
         }

--- a/CareKitStore/CareKitStore/Streaming/CoreDataQueryMonitor.swift
+++ b/CareKitStore/CareKitStore/Streaming/CoreDataQueryMonitor.swift
@@ -57,6 +57,7 @@ final class CoreDataQueryMonitor<
 
         request.predicate = predicate
         request.sortDescriptors = sortDescriptors
+        request.returnsObjectsAsFaults = false
 
         self.request = request
         self.context = context


### PR DESCRIPTION
- [x] Sometimes the CoreData objects cross thread boundaries, so this ensures faults are realized for the rest of the objects that may be used in other places