### PR TITLE
fix: HealthStore deleteOutcomes should return on success

### DIFF
--- a/CareKitStore/CareKitStore/HealthKit/OCKHealthKitStore+Outcomes.swift
+++ b/CareKitStore/CareKitStore/HealthKit/OCKHealthKitStore+Outcomes.swift
@@ -133,6 +133,10 @@ public extension OCKHealthKitPassthroughStore {
                             reason: "Failed to delete HealthKit samples. Error: \(error.localizedDescription)")))
                     }
                     return
+                } else {
+                    callbackQueue.async {
+                        completion?(.success(outcomes))
+                    }
                 }
             }
         } catch {


### PR DESCRIPTION
- [x] Ensure HealthStore returns on correct queue after deletion