### PR TITLE
Add Hashable Conformance for some concrete CareKit types

### DIFF
--- a/CareKit/CareKit/Shared/Synchronization/CareStoreFetchedResult.swift
+++ b/CareKit/CareKit/Shared/Synchronization/CareStoreFetchedResult.swift
@@ -52,3 +52,11 @@ extension CareStoreFetchedResult: Equatable where Result: Equatable {
             lhs.store === rhs.store
     }
 }
+
+extension CareStoreFetchedResult: Hashable where Result: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(result)
+        hasher.combine(ObjectIdentifier(store))
+    }
+}

--- a/CareKit/CareKitTests/Synchronization/TestCareStoreFetchRequestController.swift
+++ b/CareKit/CareKitTests/Synchronization/TestCareStoreFetchRequestController.swift
@@ -107,7 +107,7 @@ class TestCareStoreFetchRequestController: XCTestCase {
             }
         )
 
-        let expectedResults = [
+        let expectedResults: [Set<CareStoreFetchedResult<Int>>] = [
             [],
             [
                 CareStoreFetchedResult(id: "", result: 1, store: store),
@@ -115,7 +115,7 @@ class TestCareStoreFetchRequestController: XCTestCase {
             ]
         ]
 
-        var observedResults: [[CareStoreFetchedResult<Int>]] = []
+        var observedResults: [Set<CareStoreFetchedResult<Int>>] = []
 
         let didStreamResult = XCTestExpectation(description: "Result streamed")
         didStreamResult.assertForOverFulfill = true
@@ -124,7 +124,7 @@ class TestCareStoreFetchRequestController: XCTestCase {
         handleFetchedResults = controller.$fetchedResults.sink { fetchedResults in
 
             let storage = fetchedResults?.storage ?? []
-            observedResults.append(storage)
+            observedResults.append(Set(storage))
             didStreamResult.fulfill()
         }
 

--- a/CareKitStore/CareKitStore/HealthKit/OCKHealthKitTask.swift
+++ b/CareKitStore/CareKitStore/HealthKit/OCKHealthKitTask.swift
@@ -34,7 +34,7 @@ import Foundation
 /// An `OCKHealthKitTask` represents some task or action that a patient is supposed to perform. Tasks are optionally associable with an `OCKCarePlan`
 /// and must have a unique id and schedule. The schedule determines when and how often the task should be performed, and the
 /// `impactsAdherence` flag may be used to specify whether or not the patients adherence to this task will affect their daily completion rings.
-public struct OCKHealthKitTask: Codable, Equatable, OCKAnyVersionableTask, OCKAnyMutableTask {
+public struct OCKHealthKitTask: Codable, Hashable, OCKAnyVersionableTask, OCKAnyMutableTask {
 
     /// The UUID of the care plan to which this task belongs.
     public var carePlanUUID: UUID?

--- a/CareKitStore/CareKitStore/Structs/OCKAdherence.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKAdherence.swift
@@ -31,7 +31,7 @@
 import Foundation
 
 /// `OCKAdherence` specifies how many of their assigned tasks a patient has completed.
-public enum OCKAdherence: Equatable, Sendable {
+public enum OCKAdherence: Hashable, Sendable {
 
     /// Indicates that there were no tasks scheduled anytime during the interval in which adherence was computed.
     case noTasks

--- a/CareKitStore/CareKitStore/Structs/OCKBiologicalSex.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKBiologicalSex.swift
@@ -34,7 +34,7 @@ private let maleStringRepresentation = "male"
 private let femaleStringRepresentation = "female"
 
 /// Represents a person's biological sex.
-public enum OCKBiologicalSex: RawRepresentable, Codable, Equatable, Sendable {
+public enum OCKBiologicalSex: RawRepresentable, Codable, Hashable, Sendable {
     case male
     case female
     case other(String)

--- a/CareKitStore/CareKitStore/Structs/OCKCarePlan.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKCarePlan.swift
@@ -35,7 +35,7 @@ import Foundation
 /// or her treatment for a specific condition. For example, a care plan for obesity may include tasks requiring the patient to exercise, record their
 /// weight, and log meals. As the care plan evolves with the patient's progress, the care provider may modify the exercises and include notes each
 /// time about why the changes were made.
-public struct OCKCarePlan: Codable, Equatable, Identifiable, OCKAnyCarePlan {
+public struct OCKCarePlan: Codable, Hashable, Identifiable, OCKAnyCarePlan {
 
     /// The UUID of the patient to whom this care plan belongs.
     public var patientUUID: UUID?

--- a/CareKitStore/CareKitStore/Structs/OCKContact.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKContact.swift
@@ -33,7 +33,7 @@ import Foundation
 
 /// An `OCKContact` represents a contact that a user may want to get in touch with. A contact may be a care provider, a friend, or a family
 /// member. Contacts must have at least a name, and may optionally have numerous other addresses at which to be contacted.
-public struct OCKContact: Codable, Equatable, Identifiable, OCKAnyContact {
+public struct OCKContact: Codable, Hashable, Identifiable, OCKAnyContact {
 
     /// The version id in the local database for the care plan associated with this contact.
     public var carePlanUUID: UUID?

--- a/CareKitStore/CareKitStore/Structs/OCKEntity.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKEntity.swift
@@ -31,7 +31,7 @@
 import Foundation
 
 /// Holds one of several possible modified entities.
-public enum OCKEntity: Equatable, Sendable, Codable {
+public enum OCKEntity: Hashable, Sendable, Codable {
 
     /// A patient entity.
     case patient(OCKPatient)

--- a/CareKitStore/CareKitStore/Structs/OCKHealthKitLinkage.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKHealthKitLinkage.swift
@@ -34,7 +34,7 @@ import HealthKit
 extension HKQuantityTypeIdentifier: Codable {}
 
 /// Describes how a task outcome values should be retrieved from HealthKit.
-public struct OCKHealthKitLinkage: Equatable, Codable, Sendable {
+public struct OCKHealthKitLinkage: Hashable, Codable, Sendable {
 
     public enum QuantityType: String, Codable, Sendable {
         /// Quantities that are defined over a period of time, such as step count or calories burned.

--- a/CareKitStore/CareKitStore/Structs/OCKLabeledValue.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKLabeledValue.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// An optional label paired with a value used to represent contact information.
 /// The label will typically indicate what kind of information the value carries.
-public struct OCKLabeledValue: Codable, Equatable, Sendable {
+public struct OCKLabeledValue: Codable, Hashable, Sendable {
     // Note: We cannot simply subclass `CNLabeledValue` the same we do with `CNMutablePostalAddress` because it is a generic class and not visible
     // to @objc. Instead, we use this struct and convert to and from `CNLabeledValue` when required. This is all to get `Codable`.
 

--- a/CareKitStore/CareKitStore/Structs/OCKNote.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKNote.swift
@@ -33,7 +33,7 @@ import Foundation
 /// `OCKNote` can be attached to all other CareKit objects and values. Use cases may include a physician leaving a note on a task when it is modified
 /// to explain why a medication dose was changed, or a note left from a patient to a care provider explaining why they weren't able to complete a
 /// task on a certain occasion.
-public struct OCKNote: Codable, Equatable, Sendable {
+public struct OCKNote: Codable, Hashable, Sendable {
 
     /// The person who created this note.
     public var author: String?

--- a/CareKitStore/CareKitStore/Structs/OCKOutcome.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKOutcome.swift
@@ -34,7 +34,7 @@ import Foundation
 /// An `OCKOutcome` represents the outcome of an event corresponding to a task. An outcome may have 0 or more values associated with it.
 /// For example, a task that asks a patient to measure their temperature will have events whose outcome will contain a single value representing
 /// the patient's temperature.
-public struct OCKOutcome: Codable, Equatable, Identifiable, OCKAnyOutcome {
+public struct OCKOutcome: Codable, Hashable, Identifiable, OCKAnyOutcome {
 
     /// The version ID of the task to which this outcomes belongs.
     public var taskUUID: UUID

--- a/CareKitStore/CareKitStore/Structs/OCKOutcomeValue.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKOutcomeValue.swift
@@ -52,7 +52,7 @@ public enum OCKOutcomeValueType: String, Codable {
 
 /// An `OCKOutcomeValue` is a representation of any response of measurement that a user gives in response to a task. The underlying type could be
 /// any of a number of types including integers, booleans, dates, text, and binary data, among others.
-public struct OCKOutcomeValue: Codable, Equatable, Sendable, CustomStringConvertible {
+public struct OCKOutcomeValue: Codable, Hashable, Sendable, CustomStringConvertible {
 
     public static func == (lhs: OCKOutcomeValue, rhs: OCKOutcomeValue) -> Bool {
         lhs.hasSameValueAs(rhs) &&
@@ -60,6 +60,21 @@ public struct OCKOutcomeValue: Codable, Equatable, Sendable, CustomStringConvert
         lhs.kind == rhs.kind &&
         lhs.units == rhs.units &&
         lhs.createdDate == rhs.createdDate
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        switch type {
+        case .binary: hasher.combine(dataValue)
+        case .boolean: hasher.combine(booleanValue)
+        case .date: hasher.combine(dateValue)
+        case .double: hasher.combine(doubleValue)
+        case .integer: hasher.combine(integerValue)
+        case .text: hasher.combine(stringValue)
+        }
+        hasher.combine(type)
+        hasher.combine(kind)
+        hasher.combine(units)
+        hasher.combine(createdDate)
     }
 
     /// An optional property that can be used to specify what kind of value this is (e.g. blood pressure, qualitative stress, weight)

--- a/CareKitStore/CareKitStore/Structs/OCKPatient.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKPatient.swift
@@ -32,7 +32,7 @@ import CoreData
 import Foundation
 
 /// Represents a patient
-public struct OCKPatient: Codable, Equatable, Identifiable, OCKAnyPatient {
+public struct OCKPatient: Codable, Hashable, Identifiable, OCKAnyPatient {
 
     // MARK: OCKAnyPatient
     public var id: String

--- a/CareKitStore/CareKitStore/Structs/OCKSchedule.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKSchedule.swift
@@ -37,7 +37,7 @@ import Foundation
 /// - Note: A variety of initializers are provided to quickly create commonly used schedules. Used in
 ///         combination with the offset method, building up complex schedules can be performed quite
 ///         efficiently.
-public struct OCKSchedule: Codable, Equatable, Sendable {
+public struct OCKSchedule: Codable, Hashable, Sendable {
 
     /// The constituent components this schedule was built from.
     public let elements: [OCKScheduleElement]

--- a/CareKitStore/CareKitStore/Structs/OCKScheduleElement.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKScheduleElement.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// The simplest possible `OCKSchedulable`, representing a single event that repeats at
 /// fixed intervals. It may have fixed duration or repeat indefinitely.
-public struct OCKScheduleElement: Codable, Equatable, Sendable {
+public struct OCKScheduleElement: Codable, Hashable, Sendable {
 
     // Disabled because nested types are an internal implementation detail.
 

--- a/CareKitStore/CareKitStore/Structs/OCKScheduleEvent.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKScheduleEvent.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct OCKScheduleEvent: Equatable, Sendable {
+public struct OCKScheduleEvent: Hashable, Sendable {
     public var start: Date
     public var end: Date
     public var element: OCKScheduleElement

--- a/CareKitStore/CareKitStore/Structs/OCKSemanticVersion.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKSemanticVersion.swift
@@ -31,7 +31,7 @@
 import Foundation
 
 /// A semantic version with major, minor, and patch version numbers. Semantic versions parsed from strings and compared.
-public struct OCKSemanticVersion: Codable, Equatable, Sendable, Comparable, LosslessStringConvertible {
+public struct OCKSemanticVersion: Codable, Hashable, Sendable, Comparable, LosslessStringConvertible {
 
     /// The major version number, i.e. the *3* in 3.11.2.
     public let majorVersion: Int

--- a/CareKitStore/CareKitStore/Structs/OCKTask.swift
+++ b/CareKitStore/CareKitStore/Structs/OCKTask.swift
@@ -34,7 +34,7 @@ import Foundation
 /// An `OCKTask` represents some task or action that a patient is supposed to perform. Tasks are optionally associable with an `OCKCarePlan`
 /// and must have a unique id and schedule. The schedule determines when and how often the task should be performed, and the
 /// `impactsAdherence` flag may be used to specify whether or not the patients adherence to this task will affect their daily completion rings.
-public struct OCKTask: Codable, Equatable, OCKAnyVersionableTask, OCKAnyMutableTask {
+public struct OCKTask: Codable, Hashable, OCKAnyVersionableTask, OCKAnyMutableTask {
 
     /// The UUID of the care plan to which this task belongs.
     public var carePlanUUID: UUID?

--- a/CareKitStore/CareKitStoreTests/Structs/TestOutcomeValue.swift
+++ b/CareKitStore/CareKitStoreTests/Structs/TestOutcomeValue.swift
@@ -158,6 +158,62 @@ class TestOutcomeValue: XCTestCase {
         value2.createdDate = value1.createdDate
         XCTAssertEqual(value1, value2)
     }
+    
+    func testValuesHashesAreEqual() {
+        var value1 = OCKOutcomeValue(1.012, units: "m")
+        value1.kind = "length"
+
+        var value2 = OCKOutcomeValue(1.012, units: "m")
+        value2.kind = "length"
+        value2.createdDate = value1.createdDate
+
+        XCTAssertEqual(value1.hashValue, value2.hashValue)
+    }
+    
+    func testValuesHashesAreUnique() {
+        let referenceValue = OCKOutcomeValue(1, units: "m")
+        var set: Set<OCKOutcomeValue> = []
+        var uniqueElements: Int = 0
+        
+        var mutableValue = referenceValue
+        set.insert(mutableValue)
+        uniqueElements += 1
+        
+        mutableValue.kind = "length"
+        set.insert(mutableValue)
+        uniqueElements += 1
+        
+        mutableValue.createdDate = Date(timeIntervalSinceReferenceDate: 0)
+        set.insert(mutableValue)
+        uniqueElements += 1
+     
+        mutableValue.value = 2.03
+        set.insert(mutableValue)
+        uniqueElements += 1
+        
+        mutableValue.units = "in"
+        set.insert(mutableValue)
+        uniqueElements += 1
+        
+        mutableValue.value = Date(timeIntervalSinceReferenceDate: 1)
+        set.insert(mutableValue)
+        uniqueElements += 1
+        
+        mutableValue.units = nil
+        mutableValue.value = true
+        set.insert(mutableValue)
+        uniqueElements += 1
+        
+        mutableValue.value = "some"
+        set.insert(mutableValue)
+        uniqueElements += 1
+        
+        mutableValue.value = "some".data(using: .utf8) ?? .init()
+        set.insert(mutableValue)
+        uniqueElements += 1
+        
+        XCTAssertEqual(uniqueElements, set.count)
+    }
 
     func testProperDecodingWhenMissingValues() throws {
         let valueToDecode = "{\"value\": 10,\"type\": \"\(OCKOutcomeValueType.integer.rawValue)\",\"createdDate\": 0}"


### PR DESCRIPTION
Add Hashable conformance for:

- CareStoreFetchedResult
- OCKHealthKitTask
- OCKAdherence
- OCKBiologicalSex
- OCKCarePlan
- OCKContact
- OCKEntity
- OCKHealthKitLinkage
- OCKLabeledValue
- OCKNote
- OCKOutcome
- OCKOutcomeValue
- OCKSchedule
- OCKScheduleElement
- OCKScheduleEvent
- OCKPatient
- OCKSemanticVersion
- OCKTask

For more please refer to:
https://github.com/carekit-apple/CareKit/issues/726


# Test results

<img width="1504" height="508" alt="Screenshot 2025-11-19 at 3 42 27 PM" src="https://github.com/user-attachments/assets/6c0ae4ee-33a4-4201-9d48-8296760ab786" />

